### PR TITLE
Add Claude Code on the web support

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,8 +2,13 @@
   "hooks": {
     "SessionStart": [
       {
-        "type": "command",
-        "command": "bash .claude/scripts/setup-dotnet-proxy.sh"
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/scripts/setup-dotnet-proxy.sh"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary
- Add SessionStart hook to setup .NET proxy for Claude Code web sessions
- Update hook configuration to use proper nested format with matcher and hooks array
- Enables seamless development in browser-based Claude Code environment

## Test plan
- [ ] Verify hook runs correctly on session start in Claude Code web
- [ ] Confirm .NET proxy setup works when CODESPACE_NAME is detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)