### PR TITLE
fix(ci): Allow Claude bot to trigger code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Allow Claude bot to trigger code reviews (e.g., when Claude workflow pushes to a PR)
+          allowed_bots: "claude"
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
Add allowed_bots parameter to permit the Claude workflow to trigger
code reviews when it pushes changes to pull requests.

https://claude.ai/code/session_01UzhWMEWL8RLhFuREC2BSzM