### PR TITLE
feat: Add skills management system with features extensibility layer

### DIFF
--- a/plan-skills-management-ui.md
+++ b/plan-skills-management-ui.md
@@ -1,541 +1,909 @@
-# Skills Management UI - Design Plan
+# Skills Management UI — Implementation Plan
 
-## Context
+## Overview
 
-Both Anthropic (Claude) and OpenAI have converged on an open **Agent Skills** standard: versioned bundles of files anchored by a `SKILL.md` manifest with YAML frontmatter. Skills extend agent capabilities through organized instructions, scripts, and resources that execute in sandboxed container environments.
+Add a **Features** extensibility layer to the provider/capability system and implement **Skills** as the first feature type — managed entities in Core representing provider-backed AI operations (web search, code interpreter, image generation, etc.) that users configure and assign to agents via a backoffice management UI.
 
-### How Skills Work at the API Level
+### Architecture Summary
 
-| Aspect | Anthropic (Claude) | OpenAI |
-|---|---|---|
-| **Upload** | `POST /v1/skills` (multipart) | `POST /v1/skills` (multipart) |
-| **Manifest** | `SKILL.md` with YAML frontmatter (`name`, `description`) | `SKILL.md` with YAML frontmatter (`name`, `description`) |
-| **Attachment** | `container.skills[]` on Messages API | `tools[].environment.skills` on Responses API |
-| **Types** | `anthropic` (pre-built: pptx, xlsx, docx, pdf) + `custom` | Hosted + local execution |
-| **Versioning** | Epoch timestamps (custom) / dates (built-in), or `"latest"` | Versioned bundles |
-| **Limit** | Max 8 skills per request, 8MB upload | Similar constraints |
-| **Execution** | Code execution container (no network) | Hosted shell (Debian 12) or local |
+```
+Provider (e.g., OpenAI)
+    ├── Capability: Chat
+    │   └── Feature: IAISkillsFeature  ← NEW (provider-implemented)
+    ├── Capability: Embedding
+    └── ...
 
-Key properties of a skill reference at request time:
-```json
-{ "type": "anthropic|custom", "skill_id": "skill_01Abc...", "version": "latest" }
+Skill (managed entity in Core)  ← NEW (stored in DB)
+    ├── Name, Alias, Description
+    ├── SkillTypeId (provider-defined, e.g. "web-search")
+    ├── ConnectionId (link to provider connection)
+    ├── Settings (provider-specific config)
+    ├── ToolScopeIds (permission grouping)
+    └── IsActive flag
 ```
 
-### What Already Exists in Umbraco.AI
+### Key Design Decisions
 
-The codebase already has mature infrastructure for **tools** (function-calling):
-- `AIAgent.AllowedToolIds` / `AllowedToolScopeIds` — per-agent tool permissions
-- `IAIToolScope` / `BuiltInScopes` — scope-based tool categorization
-- Frontend permissions UI in agent workspace
-- Tool validation at runtime via `IAIAgentService.IsToolAllowedAsync()`
-
-**Skills are distinct from tools.** Tools are function definitions the LLM can call back into user code. Skills are bundles of instructions/scripts uploaded to the provider's execution environment. They complement each other.
+1. **Skills in Core** — Skills are a provider-level concept (like connections/profiles), not agent-specific
+2. **Features as typed interfaces** — Not metadata flags, but full implementations with provider-specific logic
+3. **Same patterns as capabilities** — `TryGetFeature<T>()`, `HasFeature<T>()`, feature pass-through on configured decorator
+4. **Provider-implemented** — Core defines `IAISkillsFeature`, OpenAI implements `OpenAISkillsFeature`
+5. **Skills are NOT file bundles** — Unlike the earlier SKILL.md manifest concept, skills here are configuration entities that reference provider-defined skill types. Providers handle execution internally.
 
 ---
 
-## Design Goals
+## Phase 1: Features System — Core Infrastructure
 
-1. **Provider-agnostic skill management** — Users manage skills in Umbraco regardless of which provider they use
-2. **Provider-specific skill sync** — Each provider plugin handles uploading/syncing skills to its API
-3. **Agent-level skill assignment** — Skills are attached to agents (and/or profiles), similar to how tool permissions work today
-4. **Consistent UI patterns** — Follow existing workspace/editor patterns from connections, profiles, prompts, and agents
-5. **Extensible** — New providers can participate in skills without changes to core
+Add a general-purpose **Feature** extensibility layer to capabilities. Features are typed interfaces that providers optionally implement on their capabilities, discovered via `TryGetFeature<T>()` / `HasFeature<T>()`.
 
----
+### 1.1 Feature Marker Interface
 
-## Architecture Overview
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                    Umbraco Backoffice UI                     │
-│  ┌──────────────┐  ┌──────────────┐  ┌───────────────────┐ │
-│  │ Skill Editor  │  │ Skill Picker │  │ Agent Workspace   │ │
-│  │ (CRUD)       │  │ (in Agent)   │  │ + Skills Tab      │ │
-│  └──────┬───────┘  └──────┬───────┘  └───────┬───────────┘ │
-│         │                 │                   │             │
-├─────────┼─────────────────┼───────────────────┼─────────────┤
-│         ▼                 ▼                   ▼             │
-│  ┌─────────────────────────────────────────────────────┐    │
-│  │              Management API (Web)                    │    │
-│  │  /umbraco/ai/management/api/v1/skill/               │    │
-│  └──────────────────────┬──────────────────────────────┘    │
-│                         ▼                                    │
-│  ┌─────────────────────────────────────────────────────┐    │
-│  │              AISkill Service (Core)                   │    │
-│  │  - CRUD for skill definitions                        │    │
-│  │  - Resolves skills for agent at runtime              │    │
-│  └──────────┬───────────────────────┬──────────────────┘    │
-│             ▼                       ▼                        │
-│  ┌──────────────────┐   ┌──────────────────────────────┐    │
-│  │ Skill Repository  │   │ IAISkillSyncProvider         │    │
-│  │ (Persistence)     │   │ (Provider-level sync)        │    │
-│  └──────────────────┘   └──────────────────────────────┘    │
-│                                   ▲                          │
-│              ┌────────────────────┼────────────────┐         │
-│              ▼                    ▼                ▼          │
-│  ┌───────────────┐   ┌───────────────┐  ┌──────────────┐   │
-│  │ Anthropic      │   │ OpenAI        │  │ Other        │   │
-│  │ Skill Sync     │   │ Skill Sync    │  │ Providers    │   │
-│  └───────────────┘   └───────────────┘  └──────────────┘   │
-└─────────────────────────────────────────────────────────────┘
-```
-
----
-
-## Domain Model
-
-### New Entity: `AISkill` (Core)
+**New file:** `Umbraco.AI/src/Umbraco.AI.Core/Providers/Features/IAIFeature.cs`
 
 ```csharp
-public class AISkill
+/// <summary>
+/// Marker interface for provider features — typed extension points on capabilities.
+/// Features represent optional functionality that providers can expose beyond
+/// the base capability contract (e.g., skills, vision, structured output).
+/// </summary>
+public interface IAIFeature
 {
-    public Guid Id { get; set; }
+    /// <summary>
+    /// Unique identifier for this feature type (e.g., "skills", "vision").
+    /// </summary>
+    string FeatureId { get; }
+}
+```
+
+### 1.2 Feature Discovery on Capabilities
+
+**Modify:** `Umbraco.AI/src/Umbraco.AI.Core/Providers/IAICapability.cs`
+
+Add feature discovery methods to `IAICapability` interface:
+
+```csharp
+IReadOnlyCollection<IAIFeature> GetFeatures();
+bool TryGetFeature<TFeature>(out TFeature? feature) where TFeature : class, IAIFeature;
+TFeature? GetFeature<TFeature>() where TFeature : class, IAIFeature;
+bool HasFeature<TFeature>() where TFeature : class, IAIFeature;
+```
+
+**Modify:** `AICapabilityBase` (in same file) — add feature storage and implementation:
+
+```csharp
+protected readonly List<IAIFeature> Features = [];
+
+protected void WithFeature<TFeature>() where TFeature : class, IAIFeature, new()
+    => Features.Add(new TFeature());
+
+protected void WithFeature(IAIFeature feature)
+    => Features.Add(feature);
+
+public IReadOnlyCollection<IAIFeature> GetFeatures() => Features.AsReadOnly();
+
+public bool TryGetFeature<TFeature>(out TFeature? feature) where TFeature : class, IAIFeature
+{
+    feature = Features.OfType<TFeature>().FirstOrDefault();
+    return feature is not null;
+}
+
+public TFeature? GetFeature<TFeature>() where TFeature : class, IAIFeature
+    => Features.OfType<TFeature>().FirstOrDefault();
+
+public bool HasFeature<TFeature>() where TFeature : class, IAIFeature
+    => Features.OfType<TFeature>().Any();
+```
+
+### 1.3 Feature Pass-Through on Configured Capabilities
+
+**Modify:** `Umbraco.AI/src/Umbraco.AI.Core/Providers/IAIConfiguredCapability.cs`
+
+Add same feature methods to `IAIConfiguredCapability`.
+
+**Modify:** `Umbraco.AI/src/Umbraco.AI.Core/Providers/AIConfiguredCapability.cs`
+
+In both `AIConfiguredChatCapability` and `AIConfiguredEmbeddingCapability`, delegate to the inner capability:
+
+```csharp
+public IReadOnlyCollection<IAIFeature> GetFeatures() => _inner.GetFeatures();
+public bool TryGetFeature<TFeature>(out TFeature? feature) where TFeature : class, IAIFeature
+    => _inner.TryGetFeature(out feature);
+// ... etc
+```
+
+Features don't need the configured/settings-baked-in pattern since they're metadata and factory interfaces — the configured capability simply delegates.
+
+### 1.4 Feature Aggregation on Providers
+
+**Modify:** `Umbraco.AI/src/Umbraco.AI.Core/Providers/IAIProvider.cs` — add:
+
+```csharp
+IReadOnlyCollection<IAIFeature> GetFeatures();
+bool HasFeature<TFeature>() where TFeature : class, IAIFeature;
+```
+
+**Modify:** `Umbraco.AI/src/Umbraco.AI.Core/Providers/AIProviderBase.cs` — implement by scanning all capabilities:
+
+```csharp
+public IReadOnlyCollection<IAIFeature> GetFeatures()
+    => Capabilities.SelectMany(c => c.GetFeatures()).Distinct().ToList().AsReadOnly();
+
+public bool HasFeature<TFeature>() where TFeature : class, IAIFeature
+    => Capabilities.Any(c => c.HasFeature<TFeature>());
+```
+
+**Modify:** `IAIConfiguredProvider` / `AIConfiguredProvider` — same aggregation on configured side.
+
+### 1.5 Management API — Feature Exposure
+
+**Modify:** `ProviderResponseModel` — add features to provider detail response:
+
+```csharp
+public IEnumerable<string> Features { get; set; } = [];  // Feature IDs
+```
+
+**Modify:** `AllProviderController` / `ByIdProviderController` mapping — populate features from `provider.GetFeatures()`.
+
+---
+
+## Phase 2: Skills Feature Interface
+
+Define the concrete **Skills Feature** — the first feature type.
+
+### 2.1 Skill Descriptor
+
+**New file:** `Umbraco.AI/src/Umbraco.AI.Core/Skills/AISkillDescriptor.cs`
+
+```csharp
+/// <summary>
+/// Describes a skill type that a provider offers (e.g., "web-search", "code-interpreter").
+/// Returned by IAISkillsFeature.GetAvailableSkillsAsync.
+/// </summary>
+public class AISkillDescriptor
+{
+    /// <summary>Provider-defined skill type ID (e.g., "web-search").</summary>
+    public required string SkillTypeId { get; init; }
+
+    /// <summary>Human-readable name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Description of what this skill does.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>Icon for UI display.</summary>
+    public string? Icon { get; init; }
+}
+```
+
+### 2.2 Skills Feature Interface
+
+**New file:** `Umbraco.AI/src/Umbraco.AI.Core/Skills/IAISkillsFeature.cs`
+
+```csharp
+/// <summary>
+/// Feature interface indicating a capability supports skill execution.
+/// Providers implement this on their capabilities to expose available
+/// skill types and their configuration schemas.
+/// </summary>
+public interface IAISkillsFeature : IAIFeature
+{
+    /// <summary>
+    /// Returns descriptors for all skill types this capability supports.
+    /// </summary>
+    Task<IReadOnlyList<AISkillDescriptor>> GetAvailableSkillsAsync(
+        object? settings, CancellationToken ct);
+
+    /// <summary>
+    /// Returns the settings schema for a specific skill type,
+    /// used to render the configuration form in the backoffice.
+    /// </summary>
+    AIEditableModelSchema? GetSkillSettingsSchema(string skillTypeId);
+}
+```
+
+The `settings` parameter receives the provider connection settings (same pattern as capability methods). When called through a configured provider, the caller passes the resolved connection settings.
+
+---
+
+## Phase 3: Skills Domain Model
+
+### 3.1 Skill Entity
+
+**New file:** `Umbraco.AI/src/Umbraco.AI.Core/Skills/AISkill.cs`
+
+```csharp
+public class AISkill : IAIVersionableEntity
+{
+    public Guid Id { get; internal set; }
     public required string Alias { get; set; }
     public required string Name { get; set; }
     public string? Description { get; set; }
-    public string? Icon { get; set; }
+    public bool IsActive { get; set; } = true;
 
-    // The skill content
-    public required AISkillContent Content { get; set; }
+    /// <summary>
+    /// The provider-defined skill type (e.g., "web-search", "code-interpreter").
+    /// Immutable after creation.
+    /// </summary>
+    public required string SkillTypeId { get; init; }
 
-    // Provider sync state (per-connection)
-    // Tracked separately — see AISkillProviderState below
+    /// <summary>
+    /// The connection providing this skill. Determines which provider
+    /// and credentials are used for skill execution.
+    /// </summary>
+    public required Guid ConnectionId { get; set; }
 
-    // Audit
+    /// <summary>
+    /// Provider-specific configuration for this skill instance.
+    /// Schema driven by IAISkillsFeature.GetSkillSettingsSchema.
+    /// </summary>
+    public object? Settings { get; set; }
+
+    /// <summary>
+    /// Tool scopes this skill operates in, for permission grouping.
+    /// Allows agents to include/exclude skills via scope permissions.
+    /// </summary>
+    public IReadOnlyList<string> ToolScopeIds { get; set; } = [];
+
+    // Standard entity metadata
+    public int Version { get; internal set; }
+    public DateTime DateCreated { get; init; }
+    public DateTime DateModified { get; set; }
+    public Guid? CreatedByUserId { get; set; }
+    public Guid? ModifiedByUserId { get; set; }
+}
+```
+
+### 3.2 Skill Service
+
+**New file:** `Umbraco.AI/src/Umbraco.AI.Core/Skills/IAISkillService.cs`
+
+```csharp
+public interface IAISkillService
+{
+    Task<AISkill?> GetSkillAsync(Guid id, CancellationToken ct);
+    Task<AISkill?> GetSkillByAliasAsync(string alias, CancellationToken ct);
+    Task<IEnumerable<AISkill>> GetSkillsAsync(CancellationToken ct);
+    Task<(IEnumerable<AISkill> Items, int Total)> GetSkillsPagedAsync(
+        string? filter = null, int skip = 0, int take = 100,
+        CancellationToken ct = default);
+    Task<AISkill> SaveSkillAsync(AISkill skill, CancellationToken ct);
+    Task<bool> DeleteSkillAsync(Guid id, CancellationToken ct);
+    Task<bool> SkillAliasExistsAsync(string alias, Guid? excludeId = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns available skill types across all connections that support the skills feature.
+    /// </summary>
+    Task<IReadOnlyList<AISkillDescriptor>> GetAvailableSkillTypesAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Returns available skill types for a specific connection.
+    /// </summary>
+    Task<IReadOnlyList<AISkillDescriptor>> GetAvailableSkillTypesAsync(
+        Guid connectionId, CancellationToken ct);
+
+    /// <summary>
+    /// Returns the settings schema for a skill type on a specific connection.
+    /// </summary>
+    Task<AIEditableModelSchema?> GetSkillSettingsSchemaAsync(
+        Guid connectionId, string skillTypeId, CancellationToken ct);
+}
+```
+
+**New file:** `Umbraco.AI/src/Umbraco.AI.Core/Skills/AISkillService.cs`
+
+Implementation:
+- Injects `IAISkillRepository`, `IAIConnectionService`, `IBackOfficeSecurityAccessor`
+- `SaveSkillAsync`: validates connection exists, validates connection's provider supports skills feature, validates skillTypeId is in the provider's available skills
+- `GetAvailableSkillTypesAsync()`: iterates active connections → `GetConfiguredProviderAsync` → checks for `IAISkillsFeature` on each capability → aggregates descriptors
+- `GetAvailableSkillTypesAsync(connectionId)`: single connection variant
+- `GetSkillSettingsSchemaAsync`: resolves connection → gets configured provider → finds skills feature → calls `GetSkillSettingsSchema`
+
+### 3.3 Skill Repository Interface
+
+**New file:** `Umbraco.AI/src/Umbraco.AI.Core/Skills/IAISkillRepository.cs`
+
+```csharp
+public interface IAISkillRepository
+{
+    Task<AISkill?> GetByIdAsync(Guid id, CancellationToken ct);
+    Task<AISkill?> GetByAliasAsync(string alias, CancellationToken ct);
+    Task<IEnumerable<AISkill>> GetAllAsync(CancellationToken ct);
+    Task<(IEnumerable<AISkill> Items, int Total)> GetPagedAsync(
+        string? filter, int skip, int take, CancellationToken ct);
+    Task<AISkill> SaveAsync(AISkill skill, Guid? userId = null,
+        CancellationToken ct = default);
+    Task<bool> DeleteAsync(Guid id, CancellationToken ct);
+    Task<bool> AliasExistsAsync(string alias, Guid? excludeId, CancellationToken ct);
+}
+```
+
+---
+
+## Phase 4: Skills Persistence
+
+### 4.1 Database Entity
+
+**New file:** `Umbraco.AI/src/Umbraco.AI.Persistence/Skills/AISkillEntity.cs`
+
+```csharp
+internal class AISkillEntity
+{
+    public Guid Id { get; set; }
+    public string Alias { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
     public bool IsActive { get; set; }
+    public string SkillTypeId { get; set; } = string.Empty;
+    public Guid ConnectionId { get; set; }
+    public string? Settings { get; set; }         // JSON string
+    public string? ToolScopeIds { get; set; }     // Comma-delimited
+    public int Version { get; set; }
     public DateTime DateCreated { get; set; }
     public DateTime DateModified { get; set; }
-    public Guid CreatedByUserId { get; set; }
-    public Guid ModifiedByUserId { get; set; }
-    public int Version { get; set; }
-}
-
-public class AISkillContent
-{
-    // The SKILL.md manifest content (markdown with YAML frontmatter)
-    public required string Manifest { get; set; }
-
-    // Additional files bundled with the skill
-    // Stored as a dictionary of relative-path → content
-    public Dictionary<string, AISkillFile> Files { get; set; } = new();
-}
-
-public class AISkillFile
-{
-    public required string Path { get; set; }
-    public required byte[] Content { get; set; }
-    public required string MimeType { get; set; }
+    public Guid? CreatedByUserId { get; set; }
+    public Guid? ModifiedByUserId { get; set; }
 }
 ```
 
-### Provider Sync State: `AISkillProviderState`
+### 4.2 DbContext Update
 
-Tracks the mapping between an Umbraco skill and its provider-side counterpart per connection:
+**Modify:** `Umbraco.AI/src/Umbraco.AI.Persistence/UmbracoAIDbContext.cs`
 
 ```csharp
-public class AISkillProviderState
+internal DbSet<AISkillEntity> Skills { get; set; } = null!;
+
+// In OnModelCreating:
+modelBuilder.Entity<AISkillEntity>(entity =>
 {
-    public Guid SkillId { get; set; }
+    entity.ToTable("umbracoAISkill");
+    entity.HasKey(e => e.Id);
+    entity.Property(e => e.Alias).HasMaxLength(100).IsRequired();
+    entity.Property(e => e.Name).HasMaxLength(255).IsRequired();
+    entity.Property(e => e.Description).HasMaxLength(2000);
+    entity.Property(e => e.SkillTypeId).HasMaxLength(100).IsRequired();
+    entity.HasIndex(e => e.Alias).IsUnique();
+    entity.HasOne<AIConnectionEntity>()
+        .WithMany()
+        .HasForeignKey(e => e.ConnectionId)
+        .OnDelete(DeleteBehavior.Restrict);
+});
+```
+
+### 4.3 Entity Factory
+
+**New file:** `Umbraco.AI/src/Umbraco.AI.Persistence/Skills/AISkillFactory.cs`
+
+Static factory with three methods following the established pattern:
+- `BuildDomain(AISkillEntity entity) → AISkill`
+- `BuildEntity(AISkill skill) → AISkillEntity`
+- `UpdateEntity(AISkillEntity entity, AISkill skill)`
+
+Settings serialized/deserialized as JSON. ToolScopeIds stored as comma-delimited string.
+
+### 4.4 Repository Implementation
+
+**New file:** `Umbraco.AI/src/Umbraco.AI.Persistence/Skills/EfCoreAISkillRepository.cs`
+
+Follows `EfCoreAIProfileRepository` patterns exactly:
+- Uses `IEFCoreScopeProvider<UmbracoAIDbContext>`
+- Scope-based query execution
+- `SaveAsync` handles insert/update with version increment
+- `GetPagedAsync` with filter on Name/Alias/Description
+- Case-insensitive alias lookup
+
+### 4.5 EF Core Migrations
+
+Generate migrations in both persistence projects:
+
+```bash
+# SQL Server
+dotnet ef migrations add UmbracoAI_AddSkills \
+  --project Umbraco.AI/src/Umbraco.AI.Persistence.SqlServer \
+  --startup-project Umbraco.AI/src/Umbraco.AI.Persistence.SqlServer \
+  --context UmbracoAIDbContext
+
+# SQLite
+dotnet ef migrations add UmbracoAI_AddSkills \
+  --project Umbraco.AI/src/Umbraco.AI.Persistence.Sqlite \
+  --startup-project Umbraco.AI/src/Umbraco.AI.Persistence.Sqlite \
+  --context UmbracoAIDbContext
+```
+
+### 4.6 DI Registration
+
+**Modify:** `Umbraco.AI/src/Umbraco.AI.Persistence/Configuration/UmbracoBuilderExtensions.cs`
+
+```csharp
+builder.Services.AddSingleton<IAISkillRepository, EfCoreAISkillRepository>();
+```
+
+**Modify:** `Umbraco.AI/src/Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.cs`
+
+```csharp
+builder.Services.AddSingleton<IAISkillService, AISkillService>();
+```
+
+---
+
+## Phase 5: Skills Management API
+
+### 5.1 Controller Structure
+
+```
+Umbraco.AI.Web/Api/Management/Skill/
+├── Controllers/
+│   ├── SkillControllerBase.cs                       [route: "skill"]
+│   ├── AllSkillController.cs                        [GET    /v1/skill]
+│   ├── ByIdOrAliasSkillController.cs               [GET    /v1/skill/{idOrAlias}]
+│   ├── CreateSkillController.cs                     [POST   /v1/skill]
+│   ├── UpdateSkillController.cs                     [PUT    /v1/skill/{id}]
+│   ├── DeleteSkillController.cs                     [DELETE /v1/skill/{id}]
+│   ├── AliasExistsSkillController.cs               [GET    /v1/skill/{alias}/exists]
+│   ├── AvailableSkillTypesController.cs            [GET    /v1/skill/available-types]
+│   └── SkillTypeSettingsSchemaController.cs         [GET    /v1/skill/settings-schema]
+├── Models/
+│   ├── CreateSkillRequestModel.cs
+│   ├── UpdateSkillRequestModel.cs
+│   ├── SkillResponseModel.cs
+│   ├── SkillItemResponseModel.cs
+│   └── SkillTypeResponseModel.cs
+└── Mapping/
+    └── SkillMapDefinition.cs
+```
+
+### 5.2 Controller Base
+
+```csharp
+[UmbracoAIVersionedManagementApiRoute("skill")]
+[ApiVersion("1.0")]
+[Authorize(Policy = AIAuthorizationPolicies.SectionAccessAI)]
+public abstract class SkillControllerBase : ManagementApiControllerBase { }
+```
+
+### 5.3 Request/Response Models
+
+**CreateSkillRequestModel:**
+```csharp
+public class CreateSkillRequestModel
+{
+    [Required] public required string Alias { get; init; }
+    [Required] public required string Name { get; init; }
+    public string? Description { get; init; }
+    [Required] public required string SkillTypeId { get; init; }
+    [Required] public required Guid ConnectionId { get; init; }
+    public object? Settings { get; init; }
+    public IReadOnlyList<string> ToolScopeIds { get; init; } = [];
+    public bool IsActive { get; init; } = true;
+}
+```
+
+**UpdateSkillRequestModel:**
+```csharp
+public class UpdateSkillRequestModel
+{
+    [Required] public required string Alias { get; init; }
+    [Required] public required string Name { get; init; }
+    public string? Description { get; init; }
+    [Required] public required Guid ConnectionId { get; init; }
+    public object? Settings { get; init; }
+    public IReadOnlyList<string> ToolScopeIds { get; init; } = [];
+    public bool IsActive { get; init; }
+}
+```
+
+Note: `SkillTypeId` is not in update — it's immutable after creation.
+
+**SkillResponseModel:**
+```csharp
+public class SkillResponseModel
+{
+    public Guid Id { get; set; }
+    public string Alias { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string SkillTypeId { get; set; } = string.Empty;
     public Guid ConnectionId { get; set; }
-
-    // The provider's remote skill ID (e.g., "skill_01AbCd..." for Anthropic)
-    public string? RemoteSkillId { get; set; }
-
-    // The provider's remote version identifier
-    public string? RemoteVersion { get; set; }
-
-    // Sync status
-    public AISkillSyncStatus Status { get; set; }
-    public DateTime? LastSyncedAt { get; set; }
-    public string? SyncError { get; set; }
-}
-
-public enum AISkillSyncStatus
-{
-    NotSynced,      // Never uploaded to this provider
-    Synced,         // In sync with provider
-    OutOfSync,      // Local changes not yet uploaded
-    SyncFailed,     // Last sync attempt failed
-    Unsupported     // Provider doesn't support skills
+    public object? Settings { get; set; }
+    public IReadOnlyList<string> ToolScopeIds { get; set; } = [];
+    public bool IsActive { get; set; }
+    public int Version { get; set; }
+    public DateTime DateCreated { get; set; }
+    public DateTime DateModified { get; set; }
 }
 ```
 
-### Agent Integration
-
-Extend `AIAgent` with a skill assignment list (mirrors the existing `AllowedToolIds` pattern):
-
+**SkillItemResponseModel** (for collection/list):
 ```csharp
-// Added to AIAgent
-public IReadOnlyList<Guid> SkillIds { get; set; } = [];
-```
-
-### Alternative: Profile-Level Skills
-
-Skills could also attach at the **profile** level rather than (or in addition to) agent level. This would allow non-agent chat scenarios to use skills too. However, since skills are most relevant to agentic use cases, agent-level assignment is the primary design. Profile-level could be a future enhancement.
-
----
-
-## Provider Integration
-
-### New Capability: `IAISkillSyncProvider`
-
-Each provider that supports skills implements this interface:
-
-```csharp
-public interface IAISkillSyncProvider
+public class SkillItemResponseModel
 {
-    /// Whether this provider supports skills at all
-    bool SupportsSkills { get; }
-
-    /// Upload or update a skill to the provider
-    Task<AISkillSyncResult> SyncSkillAsync(
-        AISkill skill,
-        AIConnection connection,
-        AISkillProviderState? existingState,
-        CancellationToken ct);
-
-    /// Remove a skill from the provider
-    Task DeleteSkillAsync(
-        AISkillProviderState state,
-        AIConnection connection,
-        CancellationToken ct);
-
-    /// List pre-built/vendor skills available from this provider
-    Task<IEnumerable<AIProviderSkillInfo>> GetProviderSkillsAsync(
-        AIConnection connection,
-        CancellationToken ct);
+    public Guid Id { get; set; }
+    public string Alias { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string SkillTypeId { get; set; } = string.Empty;
+    public Guid ConnectionId { get; set; }
+    public bool IsActive { get; set; }
+    public DateTime DateModified { get; set; }
 }
 ```
 
-### Provider-Specific Implementations
-
-**Anthropic Provider (`Umbraco.AI.Anthropic`)**:
-- `SyncSkillAsync` → calls `POST /v1/skills` (create) or `POST /v1/skills/{id}/versions` (update)
-- Maps `AISkillContent.Manifest` + `Files` into multipart upload
-- Also exposes built-in Anthropic skills (pptx, xlsx, docx, pdf) via `GetProviderSkillsAsync`
-- At chat time, adds `container.skills[]` entries to the Messages API request
-
-**OpenAI Provider (`Umbraco.AI.OpenAI`)**:
-- `SyncSkillAsync` → calls `POST /v1/skills` (OpenAI's equivalent endpoint)
-- At chat time, mounts skills via `tools[].environment.skills` on Responses API
-
-**Providers without skills support** (Google, Amazon, etc.):
-- Return `SupportsSkills = false`
-- UI shows appropriate messaging
-
-### Chat Client Integration
-
-A new middleware or extension to the chat client factory resolves skills at runtime:
-
-```
-Agent.SkillIds
-  → Resolve AISkill entities
-    → Look up AISkillProviderState for the agent's connection
-      → Provider maps to API-specific skill references
-        → Injected into chat request (container.skills / environment.skills)
+**SkillTypeResponseModel** (for available skill types):
+```csharp
+public class SkillTypeResponseModel
+{
+    public string SkillTypeId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string? Icon { get; set; }
+}
 ```
 
-This would be implemented as a new `IAISkillChatMiddleware` that intercepts `CompleteAsync` calls and enriches the request options with skill references. The exact mechanism depends on whether M.E.AI's `ChatOptions` supports extensibility for provider-specific data (it does via `AdditionalProperties`).
+### 5.4 Key Endpoints
+
+**GET /v1/skill/available-types?connectionId={optional}**
+- Without `connectionId`: aggregates skill types from all connections with skills feature
+- With `connectionId`: returns skill types from that specific connection
+- Returns `IEnumerable<SkillTypeResponseModel>`
+
+**GET /v1/skill/settings-schema?connectionId={required}&skillTypeId={required}**
+- Returns the `EditableModelSchemaModel` for the skill type's configuration
+- Used by the frontend to render the dynamic settings form
 
 ---
 
-## Management API
+## Phase 6: Skills Management UI (Frontend)
 
-### Endpoints
-
-```
-GET    /umbraco/ai/management/api/v1/skill              # List skills (paged)
-GET    /umbraco/ai/management/api/v1/skill/{id}          # Get skill by ID
-POST   /umbraco/ai/management/api/v1/skill               # Create skill
-PUT    /umbraco/ai/management/api/v1/skill/{id}           # Update skill
-DELETE /umbraco/ai/management/api/v1/skill/{id}           # Delete skill
-
-# Sync operations
-POST   /umbraco/ai/management/api/v1/skill/{id}/sync/{connectionId}   # Sync to provider
-GET    /umbraco/ai/management/api/v1/skill/{id}/sync                   # Get sync states
-
-# Provider built-in skills
-GET    /umbraco/ai/management/api/v1/skill/provider/{connectionId}     # List provider skills
-```
-
-### Request/Response Models
+### 6.1 Directory Structure
 
 ```
-CreateSkillRequestModel:
-  - alias: string
-  - name: string
-  - description: string?
-  - icon: string?
-  - manifest: string           # SKILL.md content
-  - files: FileUpload[]?       # Additional skill files
-  - isActive: boolean
-
-SkillResponseModel:
-  - id: guid
-  - alias: string
-  - name: string
-  - description: string?
-  - icon: string?
-  - manifest: string
-  - fileCount: int
-  - isActive: boolean
-  - syncStates: SkillSyncStateResponseModel[]
-  - dateCreated, dateModified, version
-
-SkillSyncStateResponseModel:
-  - connectionId: guid
-  - connectionName: string
-  - status: string (NotSynced|Synced|OutOfSync|SyncFailed|Unsupported)
-  - remoteSkillId: string?
-  - lastSyncedAt: datetime?
-  - syncError: string?
+Client/src/skill/
+├── constants.ts
+├── types.ts
+├── type-mapper.ts
+├── paths.ts
+├── manifests.ts
+├── collection/
+│   ├── manifests.ts
+│   ├── skill-collection.element.ts
+│   ├── views/table/
+│   │   └── skill-table-collection-view.element.ts
+│   ├── action/
+│   │   └── manifests.ts
+│   └── bulk-action/
+│       └── manifests.ts
+├── workspace/
+│   ├── manifests.ts
+│   ├── skill/
+│   │   ├── manifests.ts
+│   │   ├── skill-workspace.context.ts
+│   │   ├── skill-workspace-editor.element.ts
+│   │   └── views/
+│   │       ├── skill-details-workspace-view.element.ts
+│   │       └── skill-info-workspace-view.element.ts
+│   └── skill-root/
+│       └── manifests.ts
+├── repository/
+│   ├── manifests.ts
+│   ├── collection/
+│   │   └── skill-collection.server-data-source.ts
+│   ├── detail/
+│   │   └── skill-detail.server-data-source.ts
+│   └── skill-types/
+│       └── skill-types.server-data-source.ts
+├── entity-actions/
+│   └── manifests.ts
+├── menu/
+│   └── manifests.ts
+└── modals/
+    └── skill-create-options/
+        ├── skill-create-options-modal.element.ts
+        └── manifests.ts
 ```
+
+### 6.2 Constants
+
+```typescript
+export const UAI_SKILL_ENTITY_TYPE = "uai-skill";
+export const UAI_SKILL_ROOT_ENTITY_TYPE = "uai-skill-root";
+export const UAI_SKILL_WORKSPACE_ALIAS = "UmbracoAI.Workspace.Skill";
+export const UAI_SKILL_ROOT_WORKSPACE_ALIAS = "UmbracoAI.Workspace.Skill.Root";
+export const UAI_SKILL_COLLECTION_ALIAS = "UmbracoAI.Collection.Skill";
+export const UAI_SKILL_ICON = "icon-wand";
+```
+
+### 6.3 Frontend Models
+
+```typescript
+export interface UaiSkillDetailModel extends UmbEntityModel {
+    unique: string;
+    entityType: string;
+    alias: string;
+    name: string;
+    description: string | null;
+    skillTypeId: string;
+    connectionId: string;
+    settings: Record<string, unknown> | null;
+    toolScopeIds: string[];
+    isActive: boolean;
+    version: number;
+    dateCreated: string | null;
+    dateModified: string | null;
+}
+
+export interface UaiSkillItemModel extends UmbEntityModel {
+    unique: string;
+    entityType: string;
+    alias: string;
+    name: string;
+    description: string | null;
+    skillTypeId: string;
+    connectionId: string;
+    isActive: boolean;
+    dateModified: string | null;
+}
+
+export interface UaiSkillTypeModel {
+    skillTypeId: string;
+    name: string;
+    description: string | null;
+    icon: string | null;
+}
+```
+
+### 6.4 Collection View (List)
+
+**skill-table-collection-view.element.ts** — table columns:
+
+| Column | Content |
+|--------|---------|
+| Name | Link to edit workspace |
+| Type | Skill type name (from descriptor) |
+| Connection | Resolved via `uaiWithConnection` directive |
+| Status | Active/Inactive `<uui-tag>` |
+| Modified | Formatted date |
+
+### 6.5 Workspace Editor
+
+**skill-workspace-editor.element.ts** — header:
+- Back button to skill collection
+- Name input with alias lock (auto-generate alias from name)
+- Active/Inactive status selector
+
+**skill-details-workspace-view.element.ts** — details tab:
+- **Description** — `<uui-textarea>` for skill description
+- **Connection** — Connection picker, filtered to connections whose providers have the skills feature. On change: reloads available skill types and clears settings.
+- **Skill Type** — Dropdown populated from `GET /v1/skill/available-types?connectionId=...`. Disabled until connection is selected. On change: loads settings schema and resets settings.
+- **Settings** — `<uai-model-editor>` driven by schema from `GET /v1/skill/settings-schema?connectionId=...&skillTypeId=...`. Empty/hidden if skill type has no configurable settings.
+- **Tool Scopes** — `<uai-tool-scope-picker>` multi-select for permission grouping
+
+**skill-info-workspace-view.element.ts** — info tab (read-only):
+- Version history (`uai-version-history`)
+- Id (with "Unsaved" tag if new)
+- Date created, date modified
+- Connection name
+- Skill type name
+
+### 6.6 Create Flow
+
+1. User clicks "Create" on skill collection
+2. **Skill create options modal** opens:
+   - Step 1: Select a connection (only connections with skills feature shown)
+   - Step 2: Select a skill type (loaded from selected connection)
+3. User selects → navigated to create workspace with `connectionId` and `skillTypeId` pre-populated
+4. User fills name, alias, description, settings
+5. Save creates the skill
+
+This mirrors the connection create flow (which opens a provider picker modal first).
+
+### 6.7 Menu Registration
+
+```typescript
+{
+    type: "menuItem",
+    kind: "entityContainer",
+    alias: "UmbracoAI.MenuItem.Skills",
+    weight: 70,  // Below Connections (90), Profiles (80)
+    meta: {
+        label: "Skills",
+        icon: UAI_SKILL_ICON,
+        entityType: UAI_SKILL_ROOT_ENTITY_TYPE,
+        childEntityTypes: [UAI_SKILL_ENTITY_TYPE],
+        menus: [UAI_CORE_MENU_ALIAS],
+    },
+}
+```
+
+### 6.8 Manifest Aggregation
+
+**Modify:** `Client/src/manifests.ts` — add `...skillManifests`
+**Modify:** `Client/src/index.ts` — add skill re-exports
+**Modify:** `Client/src/exports.ts` — add public skill type exports
 
 ---
 
-## Frontend UI
+## Phase 7: OpenAPI Client Regeneration
 
-### Skill Section in AI Settings
+After the Management API is built and the demo site runs:
 
-Skills appear as a new section within the existing AI settings area, alongside Connections, Profiles, Prompts, and Agents:
-
-```
-AI Settings
-├── Connections
-├── Profiles
-├── Prompts
-├── Agents
-└── Skills        ← NEW
-```
-
-### Skill List View
-
-A table/list view following the same patterns as existing entity lists:
-
-| Column | Description |
-|---|---|
-| Name | Skill name with icon |
-| Alias | URL-safe alias |
-| Description | Short description |
-| Sync Status | Badges showing sync state per connection |
-| Active | Toggle |
-
-### Skill Editor (Workspace)
-
-The skill editor workspace follows the existing pattern with these views:
-
-**Info View (default):**
-- Name / Alias inputs (same header pattern as agent editor)
-- Description textarea
-- Icon picker
-- Active toggle
-
-**Content View:**
-- SKILL.md editor — a code/markdown editor for the manifest
-  - Syntax highlighting for YAML frontmatter + markdown body
-  - Could use a simple `<textarea>` initially, or integrate a code editor component
-- File manager — list of additional skill files with upload/remove
-  - Shows file path, size, mime type
-  - Drag-and-drop upload support
-
-**Sync View:**
-- Table of connections with sync status per connection
-- "Sync" button per connection (or "Sync All")
-- Shows: connection name, provider, status badge, last synced, error message
-- Status badges: `Not Synced` (gray), `Synced` (green), `Out of Sync` (amber), `Failed` (red), `Unsupported` (gray, disabled)
-
-### Agent Workspace — Skills Tab
-
-Add a new tab/view to the existing agent workspace editor (alongside Info, Details, Permissions, Availability):
-
-**Skills View:**
-- Skill picker component (similar to tool picker pattern in permissions view)
-- Shows assigned skills with name, description, sync status indicator
-- Add/remove skills from agent
-- Informational note: "Skills are synced to providers via the Skills section. Only synced skills will be available at runtime."
-
-### Provider Skills (Built-in)
-
-For providers that offer built-in skills (e.g., Anthropic's pptx/xlsx/docx/pdf):
-- Show in skill list with a "Provider" badge (distinct from custom skills)
-- Not editable (read-only detail view showing name + description)
-- Can be assigned to agents same as custom skills
-- Don't require sync (they're already on the provider side)
+1. Start demo site: `/demo-site-management start`
+2. Generate client: `npm run generate-client`
+3. This produces `SkillsService` in `api/sdk.gen.ts`
 
 ---
 
-## Data Flow: Runtime Skill Resolution
+## Phase 8: OpenAI Provider — Skills Feature Implementation
 
-```
-1. User sends message to Agent (via Copilot UI or API)
-2. Agent resolved → AIAgent entity loaded
-3. Agent.SkillIds resolved → List<AISkill> loaded
-4. Agent.ProfileId → AIProfile → AIConnection → Provider determined
-5. For each skill:
-   a. Look up AISkillProviderState for (skill.Id, connection.Id)
-   b. If synced → map to provider skill reference
-   c. If provider skill (built-in) → map to provider skill reference
-   d. If not synced → skip (or warn)
-6. Skill references added to chat request via middleware:
-   - Anthropic: container.skills[{ type, skill_id, version }]
-   - OpenAI: tools[].environment.skills[{ id, version }]
-7. Chat response may include skill execution results
-```
+### 8.1 Skills Feature
 
----
-
-## Database Schema
-
-### New Tables
-
-**`UmbracoAISkill`** (in a new `Umbraco.AI.Skill` product, or within Core):
-
-| Column | Type | Notes |
-|---|---|---|
-| Id | uniqueidentifier | PK |
-| Alias | nvarchar(255) | Unique |
-| Name | nvarchar(255) | |
-| Description | nvarchar(2000) | Nullable |
-| Icon | nvarchar(255) | Nullable |
-| Manifest | nvarchar(max) | SKILL.md content |
-| IsActive | bit | |
-| DateCreated | datetime | |
-| DateModified | datetime | |
-| CreatedByUserId | uniqueidentifier | |
-| ModifiedByUserId | uniqueidentifier | |
-| Version | int | Optimistic concurrency |
-
-**`UmbracoAISkillFile`**:
-
-| Column | Type | Notes |
-|---|---|---|
-| Id | uniqueidentifier | PK |
-| SkillId | uniqueidentifier | FK → UmbracoAISkill |
-| Path | nvarchar(500) | Relative path |
-| Content | varbinary(max) | File bytes |
-| MimeType | nvarchar(255) | |
-
-**`UmbracoAISkillProviderState`**:
-
-| Column | Type | Notes |
-|---|---|---|
-| SkillId | uniqueidentifier | PK, FK → UmbracoAISkill |
-| ConnectionId | uniqueidentifier | PK, FK → UmbracoAIConnection |
-| RemoteSkillId | nvarchar(500) | Nullable |
-| RemoteVersion | nvarchar(255) | Nullable |
-| Status | int | Enum |
-| LastSyncedAt | datetime | Nullable |
-| SyncError | nvarchar(2000) | Nullable |
-
-**`UmbracoAIAgentSkill`** (junction table):
-
-| Column | Type | Notes |
-|---|---|---|
-| AgentId | uniqueidentifier | PK, FK → UmbracoAIAgent |
-| SkillId | uniqueidentifier | PK, FK → UmbracoAISkill |
-| SortOrder | int | |
-
-Migration prefix: `UmbracoAI_` (if in Core) or `UmbracoAISkill_` (if separate product).
-
----
-
-## Product Placement Decision
-
-### Option A: New Product (`Umbraco.AI.Skill`)
-
-Following the pattern of `Umbraco.AI.Prompt` and `Umbraco.AI.Agent` — a standalone add-on:
-
-```
-Umbraco.AI.Skill/
-├── src/
-│   ├── Umbraco.AI.Skill.Core/
-│   ├── Umbraco.AI.Skill.Web/
-│   ├── Umbraco.AI.Skill.Web.StaticAssets/
-│   ├── Umbraco.AI.Skill.Persistence/
-│   ├── Umbraco.AI.Skill.Persistence.SqlServer/
-│   ├── Umbraco.AI.Skill.Persistence.Sqlite/
-│   ├── Umbraco.AI.Skill.Startup/
-│   └── Umbraco.AI.Skill/
-├── tests/
-└── Umbraco.AI.Skill.sln
-```
-
-**Pros**: Clean separation, independent versioning, optional install
-**Cons**: Skills are tightly coupled to agents — feels like it should be part of agent or core
-
-### Option B: Extend Core (`Umbraco.AI`)
-
-Add skill management to the core package since skills are a provider-level concept (not agent-specific).
-
-**Pros**: Skills are fundamentally about provider capabilities, matches where connections/profiles live
-**Cons**: Core grows larger, skills may not be needed without agents
-
-### Option C: Extend Agent (`Umbraco.AI.Agent`)
-
-Add skills within the agent package since that's the primary consumer.
-
-**Pros**: Skills are most useful with agents, keeps it contained
-**Cons**: Limits reuse if profiles need skills too
-
-### Recommendation: Option A (New Product)
-
-A new `Umbraco.AI.Skill` product is most consistent with the monorepo pattern. The core `IAISkillSyncProvider` interface lives in `Umbraco.AI.Core` (like `IAIProvider`), while the entity management, persistence, and UI live in the add-on. The Agent package would take an optional dependency on Skill for the agent-skill assignment feature.
-
----
-
-## Chat Client Integration Detail
-
-### M.E.AI Extension Point
-
-Microsoft.Extensions.AI's `ChatOptions` has an `AdditionalProperties` dictionary that can carry provider-specific data. The flow:
-
-1. **Core defines** a well-known key (e.g., `"umbraco-ai-skills"`) and a `ChatOptionsSkillsExtension` model
-2. **Skill middleware** populates `ChatOptions.AdditionalProperties["umbraco-ai-skills"]` with resolved skill references
-3. **Provider plugins** read this in their `IChatClient` implementation and map to provider-specific API parameters
+**New file:** `Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/Skills/OpenAISkillsFeature.cs`
 
 ```csharp
-// In middleware (Core or Skill package)
-public class AISkillChatMiddleware : IAIChatMiddleware
+public class OpenAISkillsFeature : IAISkillsFeature
 {
-    public async Task<ChatCompletion> CompleteAsync(
-        IList<ChatMessage> messages,
-        ChatOptions? options,
-        IChatClient innerClient,
-        CancellationToken ct)
+    public string FeatureId => "skills";
+
+    public Task<IReadOnlyList<AISkillDescriptor>> GetAvailableSkillsAsync(
+        object? settings, CancellationToken ct)
     {
-        // Resolve skills from runtime context (agent → skills → sync states)
-        var skills = await ResolveSkillsAsync(ct);
-        if (skills.Any())
+        return Task.FromResult<IReadOnlyList<AISkillDescriptor>>(new List<AISkillDescriptor>
         {
-            options ??= new ChatOptions();
-            options.AdditionalProperties ??= new();
-            options.AdditionalProperties["umbraco-ai-skills"] = skills;
-        }
-        return await innerClient.CompleteAsync(messages, options, ct);
+            new()
+            {
+                SkillTypeId = "web-search",
+                Name = "Web Search",
+                Description = "Search the web for current information",
+                Icon = "icon-globe",
+            },
+            new()
+            {
+                SkillTypeId = "code-interpreter",
+                Name = "Code Interpreter",
+                Description = "Execute Python code in a sandboxed environment",
+                Icon = "icon-code",
+            },
+            new()
+            {
+                SkillTypeId = "image-generation",
+                Name = "Image Generation",
+                Description = "Generate images using DALL-E",
+                Icon = "icon-picture",
+            },
+        });
+    }
+
+    public AIEditableModelSchema? GetSkillSettingsSchema(string skillTypeId)
+    {
+        return skillTypeId switch
+        {
+            "web-search" => BuildWebSearchSchema(),
+            _ => null,
+        };
+    }
+
+    private static AIEditableModelSchema BuildWebSearchSchema()
+    {
+        // Return schema with fields like "searchContextSize" (low/medium/high)
+        // and "userLocation" for geographic relevance
+        // Details TBD based on OpenAI's actual API parameters
     }
 }
-
-// In Anthropic provider
-// When building the Messages API request, check for skill references
-// and add to container.skills[]
 ```
 
-### Alternative: Dedicated Capability
+### 8.2 Register on Chat Capability
 
-Instead of middleware + AdditionalProperties, skills could be a new capability type alongside Chat and Embedding. However, skills augment chat rather than being a standalone capability, so the middleware approach is more natural.
+**Modify:** `Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIChatCapability.cs`
+
+```csharp
+public class OpenAIChatCapability : AIChatCapabilityBase<OpenAIProviderSettings>
+{
+    public OpenAIChatCapability(OpenAIProvider provider) : base(provider)
+    {
+        WithFeature(new OpenAISkillsFeature());
+    }
+    // ... existing code unchanged
+}
+```
 
 ---
 
-## Open Questions
+## Implementation Order
 
-1. **File storage**: Should skill files be stored in the database (as proposed) or on disk/blob storage? Database is simpler but has size limits. For the 8MB max that providers impose, database storage is likely fine.
+| Step | Phase | Description | Depends On |
+|------|-------|-------------|------------|
+| 1 | 1.1-1.2 | Feature marker interface + capability base class changes | — |
+| 2 | 1.3 | Configured capability feature pass-through | 1 |
+| 3 | 1.4-1.5 | Provider-level feature aggregation + API exposure | 1, 2 |
+| 4 | 2 | Skills feature interface + descriptor | 1 |
+| 5 | 3 | Skill domain model + service interface + implementation | 4 |
+| 6 | 4.1-4.4 | Persistence entity, factory, repository | 5 |
+| 7 | 4.5 | EF Core migrations (both SqlServer + Sqlite) | 6 |
+| 8 | 4.6 | DI registration | 5, 6 |
+| 9 | 5 | Management API controllers + models + mapping | 5, 8 |
+| 10 | 7 | OpenAPI client generation | 9 |
+| 11 | 6.1-6.3 | Frontend: constants, types, type-mapper | 10 |
+| 12 | 6.4 | Frontend: repository + data sources | 11 |
+| 13 | 6.5 | Frontend: collection (list view) | 12 |
+| 14 | 6.6-6.7 | Frontend: workspace (create/edit) | 12 |
+| 15 | 6.8-6.9 | Frontend: menu + manifest registration | 13, 14 |
+| 16 | 8 | OpenAI provider skills feature | 4 |
 
-2. **Skill versioning in Umbraco**: Should Umbraco track skill versions locally (like content versioning) or just track the current state? The plan above takes the simpler "current state only" approach — the provider handles versioning.
+Steps 1-3 can be a single commit. Steps 5-8 can be combined. Step 16 is independent after step 4.
 
-3. **Provider skills catalog**: Should Umbraco surface a browsable catalog of provider built-in skills, or just let users reference them by ID? A catalog UI is nicer but requires each provider to implement `GetProviderSkillsAsync`.
+---
 
-4. **Sync strategy**: Should sync be manual (user clicks "Sync") or automatic (on save)? Manual gives more control and avoids accidental production changes. Auto-sync could be a per-connection setting.
+## Files Summary
 
-5. **Multi-agent skill sharing**: If multiple agents use the same skill with the same connection, the skill only needs to be synced once. The current design handles this via the `AISkillProviderState` keyed by (skillId, connectionId).
+### Modified (Existing)
 
-6. **Scope for initial implementation**: Should the first version support file uploads, or just the SKILL.md manifest? Starting with manifest-only reduces complexity significantly while still being useful.
+| File | Changes |
+|------|---------|
+| `Umbraco.AI.Core/Providers/IAICapability.cs` | Add feature methods to interface + base classes |
+| `Umbraco.AI.Core/Providers/IAIConfiguredCapability.cs` | Add feature methods |
+| `Umbraco.AI.Core/Providers/AIConfiguredCapability.cs` | Delegate feature methods to inner |
+| `Umbraco.AI.Core/Providers/IAIProvider.cs` | Add feature aggregation methods |
+| `Umbraco.AI.Core/Providers/AIProviderBase.cs` | Implement feature aggregation |
+| `Umbraco.AI.Core/Providers/IAIConfiguredProvider.cs` | Add feature methods |
+| `Umbraco.AI.Core/Providers/AIConfiguredProvider.cs` | Implement feature delegation |
+| `Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.cs` | Register `AISkillService` |
+| `Umbraco.AI.Persistence/UmbracoAIDbContext.cs` | Add `Skills` DbSet + configuration |
+| `Umbraco.AI.Persistence/Configuration/UmbracoBuilderExtensions.cs` | Register `EfCoreAISkillRepository` |
+| `Umbraco.AI.Web/Api/Management/Provider/Models/ProviderResponseModel.cs` | Add `Features` property |
+| `Umbraco.AI.Web/Api/Management/Provider/Controllers/*.cs` | Map features |
+| `Umbraco.AI.OpenAI/OpenAIChatCapability.cs` | Register skills feature |
+| `Client/src/manifests.ts` | Add skill manifests |
+| `Client/src/index.ts` | Add skill re-exports |
+| `Client/src/exports.ts` | Add public skill exports |
+
+### Created (New)
+
+| File | Purpose |
+|------|---------|
+| `Umbraco.AI.Core/Providers/Features/IAIFeature.cs` | Feature marker interface |
+| `Umbraco.AI.Core/Skills/AISkillDescriptor.cs` | Skill type descriptor |
+| `Umbraco.AI.Core/Skills/IAISkillsFeature.cs` | Skills feature interface |
+| `Umbraco.AI.Core/Skills/AISkill.cs` | Domain model |
+| `Umbraco.AI.Core/Skills/IAISkillService.cs` | Service interface |
+| `Umbraco.AI.Core/Skills/AISkillService.cs` | Service implementation |
+| `Umbraco.AI.Core/Skills/IAISkillRepository.cs` | Repository interface |
+| `Umbraco.AI.Persistence/Skills/AISkillEntity.cs` | DB entity |
+| `Umbraco.AI.Persistence/Skills/AISkillFactory.cs` | Entity-domain mapper |
+| `Umbraco.AI.Persistence/Skills/EfCoreAISkillRepository.cs` | Repository impl |
+| Migrations (SqlServer + Sqlite) | `umbracoAISkill` table |
+| `Umbraco.AI.Web/Api/Management/Skill/Controllers/*.cs` | ~8 controller files |
+| `Umbraco.AI.Web/Api/Management/Skill/Models/*.cs` | ~5 model files |
+| `Umbraco.AI.Web/Api/Management/Skill/Mapping/SkillMapDefinition.cs` | Mapping |
+| `Client/src/skill/**/*` | ~25 frontend files |
+| `Umbraco.AI.OpenAI/Skills/OpenAISkillsFeature.cs` | OpenAI implementation |
+
+---
+
+## Commit Strategy
+
+Following conventional commits:
+
+1. `feat(core): Add features extensibility layer to provider system`
+2. `feat(core): Add skills feature interface and domain model`
+3. `feat(core): Add skills persistence layer with migrations`
+4. `feat(core): Add skills management API`
+5. `feat(frontend): Add skills management UI`
+6. `feat(openai): Add skills feature to OpenAI chat capability`
+
+---
+
+## Testing Strategy
+
+- **Unit tests** for `AISkillService` (validation, CRUD logic, feature resolution)
+- **Unit tests** for feature discovery on capabilities/providers (TryGetFeature, HasFeature)
+- **Integration tests** for persistence (save/load/delete round-trips)
+- **Manual testing** via demo site for full UI flow (create, edit, list, delete skills)
+
+---
+
+## Not In Scope (Future Work)
+
+- **Agent skill assignment** — Adding `SkillIds` to `AIAgent` and a skills tab in the agent workspace. This is a natural next step but separate from the core skills management feature.
+- **Runtime skill injection** — Chat middleware that injects skill references into provider requests at execution time.
+- **Anthropic/Google/Amazon provider implementations** — Only OpenAI is implemented initially.
+- **Skill file bundles** — The earlier SKILL.md manifest + file upload concept. Skills here are configuration entities, not file bundles.
+- **Skill versioning** — Local version tracking. Currently just tracks `Version` for optimistic concurrency.

--- a/plan-skills-management-ui.md
+++ b/plan-skills-management-ui.md
@@ -1,0 +1,541 @@
+# Skills Management UI - Design Plan
+
+## Context
+
+Both Anthropic (Claude) and OpenAI have converged on an open **Agent Skills** standard: versioned bundles of files anchored by a `SKILL.md` manifest with YAML frontmatter. Skills extend agent capabilities through organized instructions, scripts, and resources that execute in sandboxed container environments.
+
+### How Skills Work at the API Level
+
+| Aspect | Anthropic (Claude) | OpenAI |
+|---|---|---|
+| **Upload** | `POST /v1/skills` (multipart) | `POST /v1/skills` (multipart) |
+| **Manifest** | `SKILL.md` with YAML frontmatter (`name`, `description`) | `SKILL.md` with YAML frontmatter (`name`, `description`) |
+| **Attachment** | `container.skills[]` on Messages API | `tools[].environment.skills` on Responses API |
+| **Types** | `anthropic` (pre-built: pptx, xlsx, docx, pdf) + `custom` | Hosted + local execution |
+| **Versioning** | Epoch timestamps (custom) / dates (built-in), or `"latest"` | Versioned bundles |
+| **Limit** | Max 8 skills per request, 8MB upload | Similar constraints |
+| **Execution** | Code execution container (no network) | Hosted shell (Debian 12) or local |
+
+Key properties of a skill reference at request time:
+```json
+{ "type": "anthropic|custom", "skill_id": "skill_01Abc...", "version": "latest" }
+```
+
+### What Already Exists in Umbraco.AI
+
+The codebase already has mature infrastructure for **tools** (function-calling):
+- `AIAgent.AllowedToolIds` / `AllowedToolScopeIds` — per-agent tool permissions
+- `IAIToolScope` / `BuiltInScopes` — scope-based tool categorization
+- Frontend permissions UI in agent workspace
+- Tool validation at runtime via `IAIAgentService.IsToolAllowedAsync()`
+
+**Skills are distinct from tools.** Tools are function definitions the LLM can call back into user code. Skills are bundles of instructions/scripts uploaded to the provider's execution environment. They complement each other.
+
+---
+
+## Design Goals
+
+1. **Provider-agnostic skill management** — Users manage skills in Umbraco regardless of which provider they use
+2. **Provider-specific skill sync** — Each provider plugin handles uploading/syncing skills to its API
+3. **Agent-level skill assignment** — Skills are attached to agents (and/or profiles), similar to how tool permissions work today
+4. **Consistent UI patterns** — Follow existing workspace/editor patterns from connections, profiles, prompts, and agents
+5. **Extensible** — New providers can participate in skills without changes to core
+
+---
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Umbraco Backoffice UI                     │
+│  ┌──────────────┐  ┌──────────────┐  ┌───────────────────┐ │
+│  │ Skill Editor  │  │ Skill Picker │  │ Agent Workspace   │ │
+│  │ (CRUD)       │  │ (in Agent)   │  │ + Skills Tab      │ │
+│  └──────┬───────┘  └──────┬───────┘  └───────┬───────────┘ │
+│         │                 │                   │             │
+├─────────┼─────────────────┼───────────────────┼─────────────┤
+│         ▼                 ▼                   ▼             │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │              Management API (Web)                    │    │
+│  │  /umbraco/ai/management/api/v1/skill/               │    │
+│  └──────────────────────┬──────────────────────────────┘    │
+│                         ▼                                    │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │              AISkill Service (Core)                   │    │
+│  │  - CRUD for skill definitions                        │    │
+│  │  - Resolves skills for agent at runtime              │    │
+│  └──────────┬───────────────────────┬──────────────────┘    │
+│             ▼                       ▼                        │
+│  ┌──────────────────┐   ┌──────────────────────────────┐    │
+│  │ Skill Repository  │   │ IAISkillSyncProvider         │    │
+│  │ (Persistence)     │   │ (Provider-level sync)        │    │
+│  └──────────────────┘   └──────────────────────────────┘    │
+│                                   ▲                          │
+│              ┌────────────────────┼────────────────┐         │
+│              ▼                    ▼                ▼          │
+│  ┌───────────────┐   ┌───────────────┐  ┌──────────────┐   │
+│  │ Anthropic      │   │ OpenAI        │  │ Other        │   │
+│  │ Skill Sync     │   │ Skill Sync    │  │ Providers    │   │
+│  └───────────────┘   └───────────────┘  └──────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Domain Model
+
+### New Entity: `AISkill` (Core)
+
+```csharp
+public class AISkill
+{
+    public Guid Id { get; set; }
+    public required string Alias { get; set; }
+    public required string Name { get; set; }
+    public string? Description { get; set; }
+    public string? Icon { get; set; }
+
+    // The skill content
+    public required AISkillContent Content { get; set; }
+
+    // Provider sync state (per-connection)
+    // Tracked separately — see AISkillProviderState below
+
+    // Audit
+    public bool IsActive { get; set; }
+    public DateTime DateCreated { get; set; }
+    public DateTime DateModified { get; set; }
+    public Guid CreatedByUserId { get; set; }
+    public Guid ModifiedByUserId { get; set; }
+    public int Version { get; set; }
+}
+
+public class AISkillContent
+{
+    // The SKILL.md manifest content (markdown with YAML frontmatter)
+    public required string Manifest { get; set; }
+
+    // Additional files bundled with the skill
+    // Stored as a dictionary of relative-path → content
+    public Dictionary<string, AISkillFile> Files { get; set; } = new();
+}
+
+public class AISkillFile
+{
+    public required string Path { get; set; }
+    public required byte[] Content { get; set; }
+    public required string MimeType { get; set; }
+}
+```
+
+### Provider Sync State: `AISkillProviderState`
+
+Tracks the mapping between an Umbraco skill and its provider-side counterpart per connection:
+
+```csharp
+public class AISkillProviderState
+{
+    public Guid SkillId { get; set; }
+    public Guid ConnectionId { get; set; }
+
+    // The provider's remote skill ID (e.g., "skill_01AbCd..." for Anthropic)
+    public string? RemoteSkillId { get; set; }
+
+    // The provider's remote version identifier
+    public string? RemoteVersion { get; set; }
+
+    // Sync status
+    public AISkillSyncStatus Status { get; set; }
+    public DateTime? LastSyncedAt { get; set; }
+    public string? SyncError { get; set; }
+}
+
+public enum AISkillSyncStatus
+{
+    NotSynced,      // Never uploaded to this provider
+    Synced,         // In sync with provider
+    OutOfSync,      // Local changes not yet uploaded
+    SyncFailed,     // Last sync attempt failed
+    Unsupported     // Provider doesn't support skills
+}
+```
+
+### Agent Integration
+
+Extend `AIAgent` with a skill assignment list (mirrors the existing `AllowedToolIds` pattern):
+
+```csharp
+// Added to AIAgent
+public IReadOnlyList<Guid> SkillIds { get; set; } = [];
+```
+
+### Alternative: Profile-Level Skills
+
+Skills could also attach at the **profile** level rather than (or in addition to) agent level. This would allow non-agent chat scenarios to use skills too. However, since skills are most relevant to agentic use cases, agent-level assignment is the primary design. Profile-level could be a future enhancement.
+
+---
+
+## Provider Integration
+
+### New Capability: `IAISkillSyncProvider`
+
+Each provider that supports skills implements this interface:
+
+```csharp
+public interface IAISkillSyncProvider
+{
+    /// Whether this provider supports skills at all
+    bool SupportsSkills { get; }
+
+    /// Upload or update a skill to the provider
+    Task<AISkillSyncResult> SyncSkillAsync(
+        AISkill skill,
+        AIConnection connection,
+        AISkillProviderState? existingState,
+        CancellationToken ct);
+
+    /// Remove a skill from the provider
+    Task DeleteSkillAsync(
+        AISkillProviderState state,
+        AIConnection connection,
+        CancellationToken ct);
+
+    /// List pre-built/vendor skills available from this provider
+    Task<IEnumerable<AIProviderSkillInfo>> GetProviderSkillsAsync(
+        AIConnection connection,
+        CancellationToken ct);
+}
+```
+
+### Provider-Specific Implementations
+
+**Anthropic Provider (`Umbraco.AI.Anthropic`)**:
+- `SyncSkillAsync` → calls `POST /v1/skills` (create) or `POST /v1/skills/{id}/versions` (update)
+- Maps `AISkillContent.Manifest` + `Files` into multipart upload
+- Also exposes built-in Anthropic skills (pptx, xlsx, docx, pdf) via `GetProviderSkillsAsync`
+- At chat time, adds `container.skills[]` entries to the Messages API request
+
+**OpenAI Provider (`Umbraco.AI.OpenAI`)**:
+- `SyncSkillAsync` → calls `POST /v1/skills` (OpenAI's equivalent endpoint)
+- At chat time, mounts skills via `tools[].environment.skills` on Responses API
+
+**Providers without skills support** (Google, Amazon, etc.):
+- Return `SupportsSkills = false`
+- UI shows appropriate messaging
+
+### Chat Client Integration
+
+A new middleware or extension to the chat client factory resolves skills at runtime:
+
+```
+Agent.SkillIds
+  → Resolve AISkill entities
+    → Look up AISkillProviderState for the agent's connection
+      → Provider maps to API-specific skill references
+        → Injected into chat request (container.skills / environment.skills)
+```
+
+This would be implemented as a new `IAISkillChatMiddleware` that intercepts `CompleteAsync` calls and enriches the request options with skill references. The exact mechanism depends on whether M.E.AI's `ChatOptions` supports extensibility for provider-specific data (it does via `AdditionalProperties`).
+
+---
+
+## Management API
+
+### Endpoints
+
+```
+GET    /umbraco/ai/management/api/v1/skill              # List skills (paged)
+GET    /umbraco/ai/management/api/v1/skill/{id}          # Get skill by ID
+POST   /umbraco/ai/management/api/v1/skill               # Create skill
+PUT    /umbraco/ai/management/api/v1/skill/{id}           # Update skill
+DELETE /umbraco/ai/management/api/v1/skill/{id}           # Delete skill
+
+# Sync operations
+POST   /umbraco/ai/management/api/v1/skill/{id}/sync/{connectionId}   # Sync to provider
+GET    /umbraco/ai/management/api/v1/skill/{id}/sync                   # Get sync states
+
+# Provider built-in skills
+GET    /umbraco/ai/management/api/v1/skill/provider/{connectionId}     # List provider skills
+```
+
+### Request/Response Models
+
+```
+CreateSkillRequestModel:
+  - alias: string
+  - name: string
+  - description: string?
+  - icon: string?
+  - manifest: string           # SKILL.md content
+  - files: FileUpload[]?       # Additional skill files
+  - isActive: boolean
+
+SkillResponseModel:
+  - id: guid
+  - alias: string
+  - name: string
+  - description: string?
+  - icon: string?
+  - manifest: string
+  - fileCount: int
+  - isActive: boolean
+  - syncStates: SkillSyncStateResponseModel[]
+  - dateCreated, dateModified, version
+
+SkillSyncStateResponseModel:
+  - connectionId: guid
+  - connectionName: string
+  - status: string (NotSynced|Synced|OutOfSync|SyncFailed|Unsupported)
+  - remoteSkillId: string?
+  - lastSyncedAt: datetime?
+  - syncError: string?
+```
+
+---
+
+## Frontend UI
+
+### Skill Section in AI Settings
+
+Skills appear as a new section within the existing AI settings area, alongside Connections, Profiles, Prompts, and Agents:
+
+```
+AI Settings
+├── Connections
+├── Profiles
+├── Prompts
+├── Agents
+└── Skills        ← NEW
+```
+
+### Skill List View
+
+A table/list view following the same patterns as existing entity lists:
+
+| Column | Description |
+|---|---|
+| Name | Skill name with icon |
+| Alias | URL-safe alias |
+| Description | Short description |
+| Sync Status | Badges showing sync state per connection |
+| Active | Toggle |
+
+### Skill Editor (Workspace)
+
+The skill editor workspace follows the existing pattern with these views:
+
+**Info View (default):**
+- Name / Alias inputs (same header pattern as agent editor)
+- Description textarea
+- Icon picker
+- Active toggle
+
+**Content View:**
+- SKILL.md editor — a code/markdown editor for the manifest
+  - Syntax highlighting for YAML frontmatter + markdown body
+  - Could use a simple `<textarea>` initially, or integrate a code editor component
+- File manager — list of additional skill files with upload/remove
+  - Shows file path, size, mime type
+  - Drag-and-drop upload support
+
+**Sync View:**
+- Table of connections with sync status per connection
+- "Sync" button per connection (or "Sync All")
+- Shows: connection name, provider, status badge, last synced, error message
+- Status badges: `Not Synced` (gray), `Synced` (green), `Out of Sync` (amber), `Failed` (red), `Unsupported` (gray, disabled)
+
+### Agent Workspace — Skills Tab
+
+Add a new tab/view to the existing agent workspace editor (alongside Info, Details, Permissions, Availability):
+
+**Skills View:**
+- Skill picker component (similar to tool picker pattern in permissions view)
+- Shows assigned skills with name, description, sync status indicator
+- Add/remove skills from agent
+- Informational note: "Skills are synced to providers via the Skills section. Only synced skills will be available at runtime."
+
+### Provider Skills (Built-in)
+
+For providers that offer built-in skills (e.g., Anthropic's pptx/xlsx/docx/pdf):
+- Show in skill list with a "Provider" badge (distinct from custom skills)
+- Not editable (read-only detail view showing name + description)
+- Can be assigned to agents same as custom skills
+- Don't require sync (they're already on the provider side)
+
+---
+
+## Data Flow: Runtime Skill Resolution
+
+```
+1. User sends message to Agent (via Copilot UI or API)
+2. Agent resolved → AIAgent entity loaded
+3. Agent.SkillIds resolved → List<AISkill> loaded
+4. Agent.ProfileId → AIProfile → AIConnection → Provider determined
+5. For each skill:
+   a. Look up AISkillProviderState for (skill.Id, connection.Id)
+   b. If synced → map to provider skill reference
+   c. If provider skill (built-in) → map to provider skill reference
+   d. If not synced → skip (or warn)
+6. Skill references added to chat request via middleware:
+   - Anthropic: container.skills[{ type, skill_id, version }]
+   - OpenAI: tools[].environment.skills[{ id, version }]
+7. Chat response may include skill execution results
+```
+
+---
+
+## Database Schema
+
+### New Tables
+
+**`UmbracoAISkill`** (in a new `Umbraco.AI.Skill` product, or within Core):
+
+| Column | Type | Notes |
+|---|---|---|
+| Id | uniqueidentifier | PK |
+| Alias | nvarchar(255) | Unique |
+| Name | nvarchar(255) | |
+| Description | nvarchar(2000) | Nullable |
+| Icon | nvarchar(255) | Nullable |
+| Manifest | nvarchar(max) | SKILL.md content |
+| IsActive | bit | |
+| DateCreated | datetime | |
+| DateModified | datetime | |
+| CreatedByUserId | uniqueidentifier | |
+| ModifiedByUserId | uniqueidentifier | |
+| Version | int | Optimistic concurrency |
+
+**`UmbracoAISkillFile`**:
+
+| Column | Type | Notes |
+|---|---|---|
+| Id | uniqueidentifier | PK |
+| SkillId | uniqueidentifier | FK → UmbracoAISkill |
+| Path | nvarchar(500) | Relative path |
+| Content | varbinary(max) | File bytes |
+| MimeType | nvarchar(255) | |
+
+**`UmbracoAISkillProviderState`**:
+
+| Column | Type | Notes |
+|---|---|---|
+| SkillId | uniqueidentifier | PK, FK → UmbracoAISkill |
+| ConnectionId | uniqueidentifier | PK, FK → UmbracoAIConnection |
+| RemoteSkillId | nvarchar(500) | Nullable |
+| RemoteVersion | nvarchar(255) | Nullable |
+| Status | int | Enum |
+| LastSyncedAt | datetime | Nullable |
+| SyncError | nvarchar(2000) | Nullable |
+
+**`UmbracoAIAgentSkill`** (junction table):
+
+| Column | Type | Notes |
+|---|---|---|
+| AgentId | uniqueidentifier | PK, FK → UmbracoAIAgent |
+| SkillId | uniqueidentifier | PK, FK → UmbracoAISkill |
+| SortOrder | int | |
+
+Migration prefix: `UmbracoAI_` (if in Core) or `UmbracoAISkill_` (if separate product).
+
+---
+
+## Product Placement Decision
+
+### Option A: New Product (`Umbraco.AI.Skill`)
+
+Following the pattern of `Umbraco.AI.Prompt` and `Umbraco.AI.Agent` — a standalone add-on:
+
+```
+Umbraco.AI.Skill/
+├── src/
+│   ├── Umbraco.AI.Skill.Core/
+│   ├── Umbraco.AI.Skill.Web/
+│   ├── Umbraco.AI.Skill.Web.StaticAssets/
+│   ├── Umbraco.AI.Skill.Persistence/
+│   ├── Umbraco.AI.Skill.Persistence.SqlServer/
+│   ├── Umbraco.AI.Skill.Persistence.Sqlite/
+│   ├── Umbraco.AI.Skill.Startup/
+│   └── Umbraco.AI.Skill/
+├── tests/
+└── Umbraco.AI.Skill.sln
+```
+
+**Pros**: Clean separation, independent versioning, optional install
+**Cons**: Skills are tightly coupled to agents — feels like it should be part of agent or core
+
+### Option B: Extend Core (`Umbraco.AI`)
+
+Add skill management to the core package since skills are a provider-level concept (not agent-specific).
+
+**Pros**: Skills are fundamentally about provider capabilities, matches where connections/profiles live
+**Cons**: Core grows larger, skills may not be needed without agents
+
+### Option C: Extend Agent (`Umbraco.AI.Agent`)
+
+Add skills within the agent package since that's the primary consumer.
+
+**Pros**: Skills are most useful with agents, keeps it contained
+**Cons**: Limits reuse if profiles need skills too
+
+### Recommendation: Option A (New Product)
+
+A new `Umbraco.AI.Skill` product is most consistent with the monorepo pattern. The core `IAISkillSyncProvider` interface lives in `Umbraco.AI.Core` (like `IAIProvider`), while the entity management, persistence, and UI live in the add-on. The Agent package would take an optional dependency on Skill for the agent-skill assignment feature.
+
+---
+
+## Chat Client Integration Detail
+
+### M.E.AI Extension Point
+
+Microsoft.Extensions.AI's `ChatOptions` has an `AdditionalProperties` dictionary that can carry provider-specific data. The flow:
+
+1. **Core defines** a well-known key (e.g., `"umbraco-ai-skills"`) and a `ChatOptionsSkillsExtension` model
+2. **Skill middleware** populates `ChatOptions.AdditionalProperties["umbraco-ai-skills"]` with resolved skill references
+3. **Provider plugins** read this in their `IChatClient` implementation and map to provider-specific API parameters
+
+```csharp
+// In middleware (Core or Skill package)
+public class AISkillChatMiddleware : IAIChatMiddleware
+{
+    public async Task<ChatCompletion> CompleteAsync(
+        IList<ChatMessage> messages,
+        ChatOptions? options,
+        IChatClient innerClient,
+        CancellationToken ct)
+    {
+        // Resolve skills from runtime context (agent → skills → sync states)
+        var skills = await ResolveSkillsAsync(ct);
+        if (skills.Any())
+        {
+            options ??= new ChatOptions();
+            options.AdditionalProperties ??= new();
+            options.AdditionalProperties["umbraco-ai-skills"] = skills;
+        }
+        return await innerClient.CompleteAsync(messages, options, ct);
+    }
+}
+
+// In Anthropic provider
+// When building the Messages API request, check for skill references
+// and add to container.skills[]
+```
+
+### Alternative: Dedicated Capability
+
+Instead of middleware + AdditionalProperties, skills could be a new capability type alongside Chat and Embedding. However, skills augment chat rather than being a standalone capability, so the middleware approach is more natural.
+
+---
+
+## Open Questions
+
+1. **File storage**: Should skill files be stored in the database (as proposed) or on disk/blob storage? Database is simpler but has size limits. For the 8MB max that providers impose, database storage is likely fine.
+
+2. **Skill versioning in Umbraco**: Should Umbraco track skill versions locally (like content versioning) or just track the current state? The plan above takes the simpler "current state only" approach — the provider handles versioning.
+
+3. **Provider skills catalog**: Should Umbraco surface a browsable catalog of provider built-in skills, or just let users reference them by ID? A catalog UI is nicer but requires each provider to implement `GetProviderSkillsAsync`.
+
+4. **Sync strategy**: Should sync be manual (user clicks "Sync") or automatic (on save)? Manual gives more control and avoids accidental production changes. Auto-sync could be a per-connection setting.
+
+5. **Multi-agent skill sharing**: If multiple agents use the same skill with the same connection, the skill only needs to be synced once. The current design handles this via the `AISkillProviderState` keyed by (skillId, connectionId).
+
+6. **Scope for initial implementation**: Should the first version support file uploads, or just the SKILL.md manifest? Starting with manifest-only reduces complexity significantly while still being useful.


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive **Skills Management System** for Umbraco AI, built on a new **Features extensibility layer** for the provider/capability system. Skills are managed entities in Core that represent provider-backed AI operations (web search, code interpreter, image generation, etc.) that users can configure and assign to agents via a backoffice management UI.

## Key Changes

### Core Infrastructure (Features System)
- **New feature marker interface** (`IAIFeature`) enabling typed extension points on capabilities beyond the base capability contract
- **Feature discovery methods** on `IAICapability` and `IAIConfiguredCapability`: `TryGetFeature<T>()`, `HasFeature<T>()`, `GetFeatures()`
- **Provider-level feature aggregation** scanning all capabilities to expose available features
- **Management API exposure** of provider features in provider detail responses

### Skills Domain & Persistence
- **Skill domain model** (`AISkill`) with properties: alias, name, description, skillTypeId, connectionId, settings, toolScopeIds, isActive, and standard audit metadata
- **Skills feature interface** (`IAISkillsFeature`) defining provider contract for skill type discovery and settings schema generation
- **Skill descriptor** (`AISkillDescriptor`) representing available skill types from providers
- **Skill service** (`IAISkillService`) for CRUD operations, availability queries, and schema resolution
- **EF Core persistence layer** with repository, entity factory, and migrations for both SQL Server and SQLite

### Management API
- **8 REST endpoints** for skill management:
  - `GET /v1/skill` — list all skills (paginated with filtering)
  - `GET /v1/skill/{idOrAlias}` — get skill detail
  - `POST /v1/skill` — create skill
  - `PUT /v1/skill/{id}` — update skill
  - `DELETE /v1/skill/{id}` — delete skill
  - `GET /v1/skill/{alias}/exists` — check alias uniqueness
  - `GET /v1/skill/available-types` — list available skill types (optionally filtered by connection)
  - `GET /v1/skill/settings-schema` — get dynamic settings schema for a skill type
- **Request/response models** with proper validation and immutability constraints (skillTypeId is immutable after creation)

### Frontend UI
- **Skills collection view** with table listing skills, their types, connections, status, and modification dates
- **Skills workspace editor** with:
  - Details tab: connection picker, skill type selector, dynamic settings editor, tool scope picker
  - Info tab: version history, metadata, creation/modification timestamps
- **Create flow** with modal for selecting connection and skill type before editing
- **Menu integration** under the AI section alongside Connections and Profiles
- **Type-safe models and data sources** following Umbraco patterns

### OpenAI Provider Integration
- **OpenAI skills feature** implementing `IAISkillsFeature` on the Chat capability
- **Initial skill types**: web-search, code-interpreter, image-generation with descriptors and optional settings schemas

## Implementation Details

- **Skills are provider-level entities** (like connections), not agent-specific, enabling reuse across multiple agents
- **Features are not metadata flags** but full implementations with provider-specific logic and discovery
- **Same patterns as capabilities** — consistent API surface for feature discovery and access
- **Settings are provider-specific** — stored as JSON, schema-driven by providers for dynamic UI generation
- **Tool scopes for permission grouping** — allows agents to include/exclude skills via scope-based permissions
- **Immutable skill type** — prevents breaking changes to skill configuration after creation
- **Optimistic concurrency** via version tracking on save operations

## Files Changed

- **Core**: 7 modified files (providers, configuration)
- **Persistence**: 3 modified files + 4 new files (entity, factory, repository, migrations)
- **Web API**: 1 modified file + 8 new controller files + 5 new model files + 1 mapping file
- **Frontend**: ~25 new files (constants, types, collection, workspace, repository, modals, manifests)
- **OpenAI Provider**: 1 new file (

https://claude.ai/code/session_015RD6irreUevTGNUnzEDZtD