### PR TITLE
Update default chat model to gemini-3-flash-preview

### DIFF
--- a/Umbraco.AI.Google/CLAUDE.md
+++ b/Umbraco.AI.Google/CLAUDE.md
@@ -48,8 +48,9 @@ public class GoogleProvider : AIProviderBase<GoogleProviderSettings>
 
 - Extends `AIChatCapabilityBase<GoogleProviderSettings>`
 - Creates `IChatClient` instances using Google.GenAI SDK with `AsIChatClient()` extension
-- Supports Gemini 2.0, 1.5 Pro, 1.5 Flash models
-- Handles model configuration with extended context windows
+- Dynamically discovers available Gemini chat models via API using include/exclude regex patterns
+- Resolves default model dynamically (prefers latest stable flash model)
+- Uses async `CreateClientAsync` override for model resolution
 
 ### Settings System
 
@@ -68,13 +69,11 @@ Values prefixed with `$` are resolved from `IConfiguration` (e.g., `"$Google:Api
 
 ### Supported Models
 
-**Chat Models:**
+**Chat Models:** Dynamically discovered from Google API. Filtered using include/exclude regex patterns:
+- **Include:** Gemini flash and pro variants (`^gemini-.*\b(flash|pro)\b`)
+- **Exclude:** Non-chat variants like image generation, TTS, audio, computer-use (`image|tts|audio|computer-use`)
 
-- `gemini-2.0-flash` (Gemini 2.0 Flash)
-- `gemini-2.0-flash-lite` (Gemini 2.0 Flash Lite)
-- `gemini-1.5-pro` (Gemini 1.5 Pro)
-- `gemini-1.5-flash` (Gemini 1.5 Flash)
-- `gemini-1.5-flash-8b` (Gemini 1.5 Flash 8B)
+No hardcoded model list — the provider adapts automatically as Google adds or deprecates models.
 
 **Key Features:**
 

--- a/Umbraco.AI.Google/src/Umbraco.AI.Google/GoogleChatCapability.cs
+++ b/Umbraco.AI.Google/src/Umbraco.AI.Google/GoogleChatCapability.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.AI;
 using Umbraco.AI.Core.Models;
 using Umbraco.AI.Core.Providers;
@@ -8,55 +9,31 @@ namespace Umbraco.AI.Google;
 /// <summary>
 /// AI chat capability for Google provider.
 /// </summary>
-public class GoogleChatCapability(GoogleProvider provider) : AIChatCapabilityBase<GoogleProviderSettings>(provider)
+public partial class GoogleChatCapability(GoogleProvider provider) : AIChatCapabilityBase<GoogleProviderSettings>(provider)
 {
-    private const string DefaultChatModel = "gemini-2.0-flash";
-
     private new GoogleProvider Provider => (GoogleProvider)base.Provider;
 
     /// <summary>
-    /// Known Gemini models that support chat.
+    /// Pattern that matches Gemini chat models (flash, pro variants).
     /// </summary>
-    private static readonly string[] KnownChatModels =
-    [
-        "gemini-2.0-flash",
-        "gemini-2.0-flash-lite",
-        "gemini-1.5-pro",
-        "gemini-1.5-flash",
-        "gemini-1.5-flash-8b",
-    ];
+    [GeneratedRegex(@"^gemini-.*\b(flash|pro)\b", RegexOptions.IgnoreCase)]
+    private static partial Regex IncludePattern();
+
+    /// <summary>
+    /// Pattern that excludes non-chat variants (image generation, TTS, audio, computer-use).
+    /// </summary>
+    [GeneratedRegex(@"image|tts|audio|computer-use", RegexOptions.IgnoreCase)]
+    private static partial Regex ExcludePattern();
 
     /// <inheritdoc />
     protected override async Task<IReadOnlyList<AIModelDescriptor>> GetModelsAsync(
         GoogleProviderSettings settings,
         CancellationToken cancellationToken = default)
     {
-        // Try to get models from API, fall back to known models if API call fails
-        try
-        {
-            var allModels = await Provider.GetAvailableModelIdsAsync(settings, cancellationToken);
+        var allModels = await Provider.GetAvailableModelIdsAsync(settings, cancellationToken);
 
-            // Filter to only include known chat models that are available from the API
-            var availableModels = allModels
-                .Where(id => KnownChatModels.Contains(id, StringComparer.OrdinalIgnoreCase))
-                .ToList();
-
-            if (availableModels.Count > 0)
-            {
-                return availableModels
-                    .Select(id => new AIModelDescriptor(
-                        new AIModelRef(Provider.Id, id),
-                        GoogleModelUtilities.FormatDisplayName(id)))
-                    .ToList();
-            }
-        }
-        catch
-        {
-            // Fall through to return known models
-        }
-
-        // Return hardcoded list of known chat models as fallback
-        return KnownChatModels
+        return allModels
+            .Where(IsChatModel)
             .Select(id => new AIModelDescriptor(
                 new AIModelRef(Provider.Id, id),
                 GoogleModelUtilities.FormatDisplayName(id)))
@@ -64,7 +41,45 @@ public class GoogleChatCapability(GoogleProvider provider) : AIChatCapabilityBas
     }
 
     /// <inheritdoc />
-    protected override IChatClient CreateClient(GoogleProviderSettings settings, string? modelId)
-        => GoogleProvider.CreateGoogleClient(settings)
-            .AsIChatClient(modelId ?? DefaultChatModel);
+    protected override async Task<IChatClient> CreateClientAsync(
+        GoogleProviderSettings settings,
+        string? modelId,
+        CancellationToken cancellationToken = default)
+    {
+        if (modelId is null)
+        {
+            modelId = await ResolveDefaultModelAsync(settings, cancellationToken);
+        }
+
+        if (modelId is null)
+        {
+            throw new InvalidOperationException(
+                "No Google chat models are available. " +
+                "Check API credentials, network connectivity, and that the Google API returns available models.");
+        }
+
+        return GoogleProvider.CreateGoogleClient(settings).AsIChatClient(modelId);
+    }
+
+    /// <summary>
+    /// Resolves the default chat model by querying the API for the latest flash model.
+    /// </summary>
+    private async Task<string?> ResolveDefaultModelAsync(
+        GoogleProviderSettings settings,
+        CancellationToken cancellationToken)
+    {
+        var allModels = await Provider.GetAvailableModelIdsAsync(settings, cancellationToken);
+
+        // Prefer stable flash models, then fall back to any chat-capable gemini model
+        return allModels
+            .Where(IsChatModel)
+            .OrderByDescending(id => id.Contains("flash", StringComparison.OrdinalIgnoreCase))
+            .ThenByDescending(id => !id.Contains("preview", StringComparison.OrdinalIgnoreCase))
+            .ThenByDescending(id => id)
+            .FirstOrDefault();
+    }
+
+    private static bool IsChatModel(string modelId)
+        => IncludePattern().IsMatch(modelId)
+           && !ExcludePattern().IsMatch(modelId);
 }


### PR DESCRIPTION
Gemini 2 is no longer available for new users and so can't be used, even on a free account. 

Gemini-3-flash-preview however does work

https://ai.google.dev/gemini-api/docs/deprecations#gemini_20_models
