### PR TITLE
fix: Prevent context / profile picker from re-fetching on unchanged value

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/context/components/context-picker/context-picker.element.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/context/components/context-picker/context-picker.element.ts
@@ -65,13 +65,25 @@ export class UaiContextPickerElement extends UmbFormControlMixin<
     private _loading = false;
 
     #setValue(val: string | string[] | undefined) {
-        if (!val) {
-            this._selection = [];
+        // Normalize to array for comparison
+        const newSelection = !val ? [] : Array.isArray(val) ? val : [val];
+
+        // Check if selection actually changed to avoid unnecessary API calls
+        const hasChanged =
+            newSelection.length !== this._selection.length ||
+            newSelection.some((id, index) => id !== this._selection[index]);
+
+        if (!hasChanged) {
+            return;
+        }
+
+        this._selection = newSelection;
+
+        if (newSelection.length === 0) {
             this._items = [];
             return;
         }
-        // Normalize to array internally
-        this._selection = Array.isArray(val) ? val : [val];
+
         this.#loadItems();
     }
 

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/components/profile-picker/profile-picker.element.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/components/profile-picker/profile-picker.element.ts
@@ -96,13 +96,25 @@ export class UaiProfilePickerElement extends UmbFormControlMixin<
     private _loading = false;
 
     #setValue(val: string | string[] | undefined) {
-        if (!val) {
-            this._selection = [];
+        // Normalize to array for comparison
+        const newSelection = !val ? [] : Array.isArray(val) ? val : [val];
+
+        // Check if selection actually changed to avoid unnecessary API calls
+        const hasChanged =
+            newSelection.length !== this._selection.length ||
+            newSelection.some((id, index) => id !== this._selection[index]);
+
+        if (!hasChanged) {
+            return;
+        }
+
+        this._selection = newSelection;
+
+        if (newSelection.length === 0) {
             this._items = [];
             return;
         }
-        // Normalize to array internally
-        this._selection = Array.isArray(val) ? val : [val];
+
         this.#loadItems();
     }
 


### PR DESCRIPTION
Fixes #70

Context picker and profile picker were calling `#loadItems()` on every value setter invocation, even when the value hadn't changed. This caused unnecessary API calls and loading flicker on each keystroke in a nearby form field.

Applies the same "check if value actually changed" guard that already exists in tool-picker, tool-scope-picker, and agent-surface-picker.

Generated with [Claude Code](https://claude.ai/code)