### PR TITLE
fix(core,agent,prompt): Fix SQLite migration NullReferenceException in Development mode

### DIFF
--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Persistence/Configuration/UmbracoBuilderExtensions.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Persistence/Configuration/UmbracoBuilderExtensions.cs
@@ -1,9 +1,7 @@
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.AI.Agent.Core.Agents;
 using Umbraco.AI.Agent.Persistence.Notifications;
 using Umbraco.AI.Agent.Persistence.Agents;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Extensions;
@@ -25,7 +23,7 @@ public static class UmbracoBuilderExtensions
         // Register DbContext with provider-specific migrations assembly
         builder.Services.AddUmbracoDbContext<UmbracoAIAgentDbContext>((options, connectionString, providerName, serviceProvider) =>
         {
-            ConfigureDatabaseProvider(options, connectionString, providerName);
+            UmbracoAIAgentDbContext.ConfigureProvider(options, connectionString, providerName);
         });
 
         // Replace in-memory repository with EF Core implementation
@@ -37,35 +35,4 @@ public static class UmbracoBuilderExtensions
         return builder;
     }
 
-    /// <summary>
-    /// Configures the EF Core database provider with the correct migrations assembly.
-    /// </summary>
-    internal static void ConfigureDatabaseProvider(
-        DbContextOptionsBuilder options,
-        string? connectionString,
-        string? providerName)
-    {
-        if (string.IsNullOrEmpty(connectionString) || string.IsNullOrEmpty(providerName))
-        {
-            return;
-        }
-
-        switch (providerName)
-        {
-            case Constants.ProviderNames.SQLServer:
-                options.UseSqlServer(connectionString, x =>
-                    x.MigrationsAssembly("Umbraco.AI.Agent.Persistence.SqlServer"));
-                break;
-
-            case Constants.ProviderNames.SQLLite:
-            case "Microsoft.Data.SQLite":
-                options.UseSqlite(connectionString, x =>
-                    x.MigrationsAssembly("Umbraco.AI.Agent.Persistence.Sqlite"));
-                break;
-
-            default:
-                throw new InvalidOperationException(
-                    $"Database provider '{providerName}' is not supported by Umbraco.AI.Agent.");
-        }
-    }
 }

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Persistence/Notifications/RunAgentMigrationNotificationHandler.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Persistence/Notifications/RunAgentMigrationNotificationHandler.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Umbraco.AI.Agent.Persistence.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Notifications;
@@ -38,7 +37,7 @@ internal sealed class RunAgentMigrationNotificationHandler : INotificationAsyncH
             // inner connection is disposed. Creating the context directly avoids the pooled factory.
             // See: https://github.com/umbraco/Umbraco-CMS/issues/22124
             var optionsBuilder = new DbContextOptionsBuilder<UmbracoAIAgentDbContext>();
-            UmbracoBuilderExtensions.ConfigureDatabaseProvider(
+            UmbracoAIAgentDbContext.ConfigureProvider(
                 optionsBuilder,
                 _connectionStrings.Value.ConnectionString,
                 _connectionStrings.Value.ProviderName);

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Persistence/UmbracoAIAgentDbContext.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Persistence/UmbracoAIAgentDbContext.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Umbraco.AI.Agent.Persistence.Agents;
+using Umbraco.Cms.Core;
 
 namespace Umbraco.AI.Agent.Persistence;
 
@@ -19,6 +20,38 @@ public class UmbracoAIAgentDbContext : DbContext
     public UmbracoAIAgentDbContext(DbContextOptions<UmbracoAIAgentDbContext> options)
         : base(options)
     {
+    }
+
+    /// <summary>
+    /// Configures the EF Core database provider with the correct migrations assembly.
+    /// </summary>
+    internal static void ConfigureProvider(
+        DbContextOptionsBuilder options,
+        string? connectionString,
+        string? providerName)
+    {
+        if (string.IsNullOrEmpty(connectionString) || string.IsNullOrEmpty(providerName))
+        {
+            return;
+        }
+
+        switch (providerName)
+        {
+            case Constants.ProviderNames.SQLServer:
+                options.UseSqlServer(connectionString, x =>
+                    x.MigrationsAssembly("Umbraco.AI.Agent.Persistence.SqlServer"));
+                break;
+
+            case Constants.ProviderNames.SQLLite:
+            case "Microsoft.Data.SQLite":
+                options.UseSqlite(connectionString, x =>
+                    x.MigrationsAssembly("Umbraco.AI.Agent.Persistence.Sqlite"));
+                break;
+
+            default:
+                throw new InvalidOperationException(
+                    $"Database provider '{providerName}' is not supported by Umbraco.AI.Agent.");
+        }
     }
 
     /// <inheritdoc />

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Persistence/Configuration/UmbracoBuilderExtensions.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Persistence/Configuration/UmbracoBuilderExtensions.cs
@@ -1,9 +1,7 @@
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.AI.Prompt.Core.Prompts;
 using Umbraco.AI.Prompt.Persistence.Notifications;
 using Umbraco.AI.Prompt.Persistence.Prompts;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Extensions;
@@ -25,7 +23,7 @@ public static class UmbracoBuilderExtensions
         // Register DbContext with provider-specific migrations assembly
         builder.Services.AddUmbracoDbContext<UmbracoAIPromptDbContext>((options, connectionString, providerName, serviceProvider) =>
         {
-            ConfigureDatabaseProvider(options, connectionString, providerName);
+            UmbracoAIPromptDbContext.ConfigureProvider(options, connectionString, providerName);
         });
 
         // Replace in-memory repository with EF Core implementation
@@ -37,35 +35,4 @@ public static class UmbracoBuilderExtensions
         return builder;
     }
 
-    /// <summary>
-    /// Configures the EF Core database provider with the correct migrations assembly.
-    /// </summary>
-    internal static void ConfigureDatabaseProvider(
-        DbContextOptionsBuilder options,
-        string? connectionString,
-        string? providerName)
-    {
-        if (string.IsNullOrEmpty(connectionString) || string.IsNullOrEmpty(providerName))
-        {
-            return;
-        }
-
-        switch (providerName)
-        {
-            case Constants.ProviderNames.SQLServer:
-                options.UseSqlServer(connectionString, x =>
-                    x.MigrationsAssembly("Umbraco.AI.Prompt.Persistence.SqlServer"));
-                break;
-
-            case Constants.ProviderNames.SQLLite:
-            case "Microsoft.Data.SQLite":
-                options.UseSqlite(connectionString, x =>
-                    x.MigrationsAssembly("Umbraco.AI.Prompt.Persistence.Sqlite"));
-                break;
-
-            default:
-                throw new InvalidOperationException(
-                    $"Database provider '{providerName}' is not supported by Umbraco.AI.Prompt.");
-        }
-    }
 }

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Persistence/Notifications/RunPromptMigrationNotificationHandler.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Persistence/Notifications/RunPromptMigrationNotificationHandler.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Umbraco.AI.Prompt.Persistence.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Notifications;
@@ -38,7 +37,7 @@ internal sealed class RunPromptMigrationNotificationHandler : INotificationAsync
             // inner connection is disposed. Creating the context directly avoids the pooled factory.
             // See: https://github.com/umbraco/Umbraco-CMS/issues/22124
             var optionsBuilder = new DbContextOptionsBuilder<UmbracoAIPromptDbContext>();
-            UmbracoBuilderExtensions.ConfigureDatabaseProvider(
+            UmbracoAIPromptDbContext.ConfigureProvider(
                 optionsBuilder,
                 _connectionStrings.Value.ConnectionString,
                 _connectionStrings.Value.ProviderName);

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Persistence/UmbracoAIPromptDbContext.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Persistence/UmbracoAIPromptDbContext.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Umbraco.AI.Prompt.Persistence.Prompts;
+using Umbraco.Cms.Core;
 
 namespace Umbraco.AI.Prompt.Persistence;
 
@@ -19,6 +20,38 @@ public class UmbracoAIPromptDbContext : DbContext
     public UmbracoAIPromptDbContext(DbContextOptions<UmbracoAIPromptDbContext> options)
         : base(options)
     {
+    }
+
+    /// <summary>
+    /// Configures the EF Core database provider with the correct migrations assembly.
+    /// </summary>
+    internal static void ConfigureProvider(
+        DbContextOptionsBuilder options,
+        string? connectionString,
+        string? providerName)
+    {
+        if (string.IsNullOrEmpty(connectionString) || string.IsNullOrEmpty(providerName))
+        {
+            return;
+        }
+
+        switch (providerName)
+        {
+            case Constants.ProviderNames.SQLServer:
+                options.UseSqlServer(connectionString, x =>
+                    x.MigrationsAssembly("Umbraco.AI.Prompt.Persistence.SqlServer"));
+                break;
+
+            case Constants.ProviderNames.SQLLite:
+            case "Microsoft.Data.SQLite":
+                options.UseSqlite(connectionString, x =>
+                    x.MigrationsAssembly("Umbraco.AI.Prompt.Persistence.Sqlite"));
+                break;
+
+            default:
+                throw new InvalidOperationException(
+                    $"Database provider '{providerName}' is not supported by Umbraco.AI.Prompt.");
+        }
     }
 
     /// <inheritdoc />

--- a/Umbraco.AI/src/Umbraco.AI.Persistence/Configuration/UmbracoBuilderExtensions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Persistence/Configuration/UmbracoBuilderExtensions.cs
@@ -42,7 +42,7 @@ public static class UmbracoBuilderExtensions
         // Register DbContext using Umbraco's database provider detection with migrations assembly config
         builder.Services.AddUmbracoDbContext<UmbracoAIDbContext>((options, connectionString, providerName, serviceProvider) =>
         {
-            ConfigureDatabaseProvider(options, connectionString, providerName);
+            UmbracoAIDbContext.ConfigureProvider(options, connectionString, providerName);
         });
 
         // Connection factory for entity/domain mapping with encryption support
@@ -74,37 +74,4 @@ public static class UmbracoBuilderExtensions
         return builder;
     }
 
-    /// <summary>
-    /// Configures the EF Core database provider with the correct migrations assembly.
-    /// </summary>
-    internal static void ConfigureDatabaseProvider(
-        DbContextOptionsBuilder options,
-        string? connectionString,
-        string? providerName)
-    {
-        if (string.IsNullOrEmpty(connectionString) || string.IsNullOrEmpty(providerName))
-        {
-            return;
-        }
-
-        // Configure provider with migrations assembly based on provider type
-        switch (providerName)
-        {
-            case Constants.ProviderNames.SQLServer:
-                options.UseSqlServer(connectionString, x =>
-                    x.MigrationsAssembly("Umbraco.AI.Persistence.SqlServer"));
-                break;
-
-            case Constants.ProviderNames.SQLLite:
-            case "Microsoft.Data.SQLite":
-                options.UseSqlite(connectionString, x =>
-                    x.MigrationsAssembly("Umbraco.AI.Persistence.Sqlite"));
-                break;
-
-            default:
-                throw new InvalidOperationException(
-                    $"The database provider '{providerName}' is not supported by Umbraco.AI.Persistence. " +
-                    $"Supported providers: SQL Server, SQLite.");
-        }
-    }
 }

--- a/Umbraco.AI/src/Umbraco.AI.Persistence/Notifications/RunAIMigrationNotificationHandler.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Persistence/Notifications/RunAIMigrationNotificationHandler.cs
@@ -4,8 +4,6 @@ using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Notifications;
 
-using AIBuilderExtensions = Umbraco.AI.Extensions.UmbracoBuilderExtensions;
-
 namespace Umbraco.AI.Persistence.Notifications;
 
 /// <summary>
@@ -34,7 +32,7 @@ public class RunAIMigrationNotificationHandler
         // inner connection is disposed. Creating the context directly avoids the pooled factory.
         // See: https://github.com/umbraco/Umbraco-CMS/issues/22124
         var optionsBuilder = new DbContextOptionsBuilder<UmbracoAIDbContext>();
-        AIBuilderExtensions.ConfigureDatabaseProvider(
+        UmbracoAIDbContext.ConfigureProvider(
             optionsBuilder,
             _connectionStrings.Value.ConnectionString,
             _connectionStrings.Value.ProviderName);

--- a/Umbraco.AI/src/Umbraco.AI.Persistence/UmbracoAIDbContext.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Persistence/UmbracoAIDbContext.cs
@@ -8,6 +8,7 @@ using Umbraco.AI.Persistence.Analytics.Usage;
 using Umbraco.AI.Persistence.Settings;
 using Umbraco.AI.Persistence.Versioning;
 using Umbraco.AI.Persistence.Tests;
+using Umbraco.Cms.Core;
 
 namespace Umbraco.AI.Persistence;
 
@@ -87,6 +88,39 @@ public class UmbracoAIDbContext : DbContext
     public UmbracoAIDbContext(DbContextOptions<UmbracoAIDbContext> options)
         : base(options)
     {
+    }
+
+    /// <summary>
+    /// Configures the EF Core database provider with the correct migrations assembly.
+    /// </summary>
+    internal static void ConfigureProvider(
+        DbContextOptionsBuilder options,
+        string? connectionString,
+        string? providerName)
+    {
+        if (string.IsNullOrEmpty(connectionString) || string.IsNullOrEmpty(providerName))
+        {
+            return;
+        }
+
+        switch (providerName)
+        {
+            case Constants.ProviderNames.SQLServer:
+                options.UseSqlServer(connectionString, x =>
+                    x.MigrationsAssembly("Umbraco.AI.Persistence.SqlServer"));
+                break;
+
+            case Constants.ProviderNames.SQLLite:
+            case "Microsoft.Data.SQLite":
+                options.UseSqlite(connectionString, x =>
+                    x.MigrationsAssembly("Umbraco.AI.Persistence.Sqlite"));
+                break;
+
+            default:
+                throw new InvalidOperationException(
+                    $"The database provider '{providerName}' is not supported by Umbraco.AI.Persistence. " +
+                    $"Supported providers: SQL Server, SQLite.");
+        }
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Root Cause

In Development mode, Umbraco's `EFCoreScope<T>.InitializeDatabase()` shares NPoco connections with EF Core contexts via `Database.SetDbConnection(transaction?.Connection)`. NPoco connections are wrapped with MiniProfiler's `ProfiledDbConnection` by the provider-specific interceptors. When these tainted contexts are later reused from the pooled `DbContextFactory`, `ProfiledDbConnection.ConnectionString` throws `NullReferenceException` because the inner connection has been disposed.

This affects any package that uses `AddUmbracoDbContext<T>()` and runs migrations via `IDbContextFactory<T>` on `UmbracoApplicationStartedNotification` — after scopes may have already tainted pooled contexts.

**Upstream issue:** https://github.com/umbraco/Umbraco-CMS/issues/22124

## Fix

Migration handlers now create a **standalone DbContext** that bypasses the pooled factory entirely:

1. Inject `IOptions<ConnectionStrings>` to read the connection string directly from Umbraco's configuration (including `|DataDirectory|` placeholder resolution)
2. Create a fresh `DbContextOptionsBuilder<T>` and configure the database provider with the correct migrations assembly
3. Instantiate the `DbContext` directly — no pool, no scope, no `ProfiledDbConnection`

This also eliminates the `MigrationConnectionConfig` singleton and `IDbContextFactory` injection that were in the initial version of this fix, making the approach simpler and removing duplicated classes across packages.

## Changes

| File | Change |
|------|--------|
| `*/Configuration/UmbracoBuilderExtensions.cs` | Remove `MigrationConnectionConfig`; revert `AddUmbracoDbContext` callback to original; make `ConfigureDatabaseProvider` `internal static` for migration handler access |
| `*/Notifications/Run*MigrationNotificationHandler.cs` | Replace `IDbContextFactory` + `MigrationConnectionConfig` with `IOptions<ConnectionStrings>`; create standalone context for migrations |

## Fixes

- SQLite `NullReferenceException` on every restart after initial boot
- Agent migration crash on fresh SQLite install (`PRAGMA foreign_keys`)
- Missing `AgentType` column on upgrade (migration was being skipped due to NRE)

Closes #89