### PR TITLE
fix(core): Filter search results by user start node permissions

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/SearchUmbracoTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/SearchUmbracoTool.cs
@@ -4,6 +4,7 @@ using Examine.Search;
 
 using Umbraco.AI.Core.Tools.Scopes;
 using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Extensions;
 
@@ -39,18 +40,22 @@ public class SearchUmbracoTool : AIToolBase<SearchUmbracoArgs>
 
     private readonly IExamineManager _examineManager;
     private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
 
     /// <summary>
     /// Initializes a new instance of <see cref="SearchUmbracoTool"/>.
     /// </summary>
     /// <param name="examineManager">The Examine manager.</param>
     /// <param name="umbracoContextAccessor">The Umbraco context accessor.</param>
+    /// <param name="backOfficeSecurityAccessor">The backoffice security accessor for user context.</param>
     public SearchUmbracoTool(
         IExamineManager examineManager,
-        IUmbracoContextAccessor umbracoContextAccessor)
+        IUmbracoContextAccessor umbracoContextAccessor,
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
     {
         _examineManager = examineManager;
         _umbracoContextAccessor = umbracoContextAccessor;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
     /// <inheritdoc />
@@ -98,11 +103,22 @@ public class SearchUmbracoTool : AIToolBase<SearchUmbracoArgs>
 
         try
         {
-            // Execute search
-            var searchResults = PerformSearch(index, args.Query, typeFilter, args.Tags, maxResults);
+            // Resolve user start node restrictions for content/media access filtering
+            var user = _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser;
+            int[]? startContentIds = null;
+            int[]? startMediaIds = null;
+
+            if (user is not null)
+            {
+                startContentIds = GetEffectiveStartNodeIds(user.StartContentIds, user.Groups.Select(g => g.StartContentId));
+                startMediaIds = GetEffectiveStartNodeIds(user.StartMediaIds, user.Groups.Select(g => g.StartMediaId));
+            }
+
+            // Execute search with start node filtering applied at query level
+            var searchResults = PerformSearch(index, args.Query, typeFilter, args.Tags, maxResults, startContentIds, startMediaIds);
 
             // Enrich results with published content data
-            var enrichedResults = EnrichResults(searchResults);
+            var enrichedResults = EnrichResults(searchResults, startContentIds, startMediaIds);
 
             return Task.FromResult<object>(new SearchUmbracoResult(
                 true,
@@ -118,7 +134,7 @@ public class SearchUmbracoTool : AIToolBase<SearchUmbracoArgs>
         }
     }
 
-    private ISearchResults PerformSearch(IIndex index, string query, string typeFilter, string[]? tags, int maxResults)
+    private ISearchResults PerformSearch(IIndex index, string query, string typeFilter, string[]? tags, int maxResults, int[]? startContentIds, int[]? startMediaIds)
     {
         var searcher = index.Searcher;
         var queryExecutor = searcher.CreateQuery();
@@ -151,6 +167,15 @@ public class SearchUmbracoTool : AIToolBase<SearchUmbracoArgs>
         if (tags is { Length: > 0 })
         {
             booleanQuery = booleanQuery.And().GroupedOr(["tags"], tags);
+        }
+
+        // Start node access filter — restricts results to content/media the user can access.
+        // The __Path field in Examine contains the ancestor chain (e.g., "-1,1234,5678"),
+        // so filtering on it ensures only items under the user's allowed start nodes are returned.
+        var pathFilter = BuildStartNodePathFilter(typeFilter, startContentIds, startMediaIds);
+        if (pathFilter is not null)
+        {
+            booleanQuery = booleanQuery.And().NativeQuery(pathFilter);
         }
 
         return booleanQuery.Execute(new QueryOptions(0, maxResults));
@@ -216,14 +241,101 @@ public class SearchUmbracoTool : AIToolBase<SearchUmbracoArgs>
         return sb.ToString();
     }
 
-    private IReadOnlyList<UmbracoSearchResultItem> EnrichResults(ISearchResults searchResults)
+    /// <summary>
+    /// Computes effective start node IDs by combining user-level and group-level start nodes.
+    /// User-level start nodes take precedence; if not set, group start nodes are used.
+    /// </summary>
+    internal static int[]? GetEffectiveStartNodeIds(int[]? userStartNodeIds, IEnumerable<int?> groupStartNodeIds)
     {
+        // User-level start nodes take precedence when set
+        if (userStartNodeIds is { Length: > 0 })
+        {
+            return userStartNodeIds;
+        }
+
+        // Fall back to group start nodes
+        var groupIds = groupStartNodeIds
+            .Where(id => id.HasValue)
+            .Select(id => id!.Value)
+            .Distinct()
+            .ToArray();
+
+        return groupIds.Length > 0 ? groupIds : null;
+    }
+
+    /// <summary>
+    /// Builds a Lucene query fragment to filter results by the user's start node path restrictions.
+    /// Returns null when no filtering is needed.
+    /// </summary>
+    internal static string? BuildStartNodePathFilter(string typeFilter, int[]? startContentIds, int[]? startMediaIds)
+    {
+        var contentRestricted = !IsUnrestricted(startContentIds);
+        var mediaRestricted = !IsUnrestricted(startMediaIds);
+
+        // When searching a specific type, only that type's restrictions matter
+        if (typeFilter == "content")
+        {
+            return contentRestricted ? BuildPathOrClause(startContentIds!) : null;
+        }
+
+        if (typeFilter == "media")
+        {
+            return mediaRestricted ? BuildPathOrClause(startMediaIds!) : null;
+        }
+
+        // typeFilter == "all": both content and media
+        if (!contentRestricted && !mediaRestricted)
+        {
+            return null;
+        }
+
+        if (contentRestricted && mediaRestricted)
+        {
+            // Both restricted — combine all start node IDs (content/media have separate path trees)
+            var allIds = startContentIds!.Concat(startMediaIds!).Distinct().ToArray();
+            return BuildPathOrClause(allIds);
+        }
+
+        // Mixed: one restricted, one unrestricted.
+        // Allow all items of the unrestricted type, restrict the other by path.
+        if (contentRestricted)
+        {
+            // Media is unrestricted; content must match start nodes
+            var pathClause = BuildPathOrClause(startContentIds!);
+            return $"(__IndexType:media OR ({pathClause}))";
+        }
+
+        // Content is unrestricted; media must match start nodes
+        var mediaPathClause = BuildPathOrClause(startMediaIds!);
+        return $"(__IndexType:content OR ({mediaPathClause}))";
+    }
+
+    internal static bool IsUnrestricted(int[]? ids)
+        => ids is null or { Length: 0 } || Array.Exists(ids, static id => id == -1);
+
+    private static string BuildPathOrClause(int[] startNodeIds)
+    {
+        // __Path is indexed as a tokenized field with comma-separated IDs.
+        // Each start node ID is searched as a term within the path.
+        var clauses = startNodeIds.Select(id => $"__Path:{id}");
+        return $"({string.Join(" OR ", clauses)})";
+    }
+
+    private IReadOnlyList<UmbracoSearchResultItem> EnrichResults(ISearchResults searchResults, int[]? startContentIds, int[]? startMediaIds)
+    {
+        var hasRestrictions = !IsUnrestricted(startContentIds) || !IsUnrestricted(startMediaIds);
         var enrichedResults = new List<UmbracoSearchResultItem>();
 
         // Try to get Umbraco context for enrichment
         if (!_umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext))
         {
-            // Return basic results without enrichment
+            // Without Umbraco context we can't verify paths for access control.
+            // If the user has start node restrictions, skip basic results to avoid leaking content.
+            if (hasRestrictions)
+            {
+                return enrichedResults;
+            }
+
             return searchResults.Select(r => CreateBasicResultItem(r)).ToList();
         }
 
@@ -254,9 +366,10 @@ public class SearchUmbracoTool : AIToolBase<SearchUmbracoArgs>
             {
                 enrichedResults.Add(CreateEnrichedResultItem(publishedItem, searchResult.Score, isMedia));
             }
-            else
+            else if (!hasRestrictions)
             {
-                // Fallback to basic result if not found in published cache
+                // Fallback to basic result only when there are no start node restrictions,
+                // since we can't verify the path without IPublishedContent.
                 enrichedResults.Add(CreateBasicResultItem(searchResult));
             }
         }

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Services/AIChatServiceTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Services/AIChatServiceTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Options;
 using Umbraco.AI.Core.Chat;
+using Umbraco.AI.Core.Guardrails;
 using Umbraco.AI.Core.Models;
 using Umbraco.AI.Core.Profiles;
 using Umbraco.AI.Core.RuntimeContext;
@@ -66,6 +67,7 @@ public class AIChatServiceTests
         _service = new AIChatService(
             _clientFactoryMock.Object,
             _profileServiceMock.Object,
+            new Mock<IAIGuardrailService>().Object,
             _optionsMock.Object,
             _eventAggregatorMock.Object,
             _contextAccessorMock.Object,

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/SearchUmbracoToolTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/SearchUmbracoToolTests.cs
@@ -3,6 +3,7 @@ using Moq;
 using Shouldly;
 using Umbraco.AI.Core.Tools;
 using Umbraco.AI.Core.Tools.Umbraco;
+using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Web;
 
 namespace Umbraco.AI.Tests.Unit.Tools.Umbraco;
@@ -11,13 +12,18 @@ public class SearchUmbracoToolTests
 {
     private readonly Mock<IExamineManager> _examineManagerMock;
     private readonly Mock<IUmbracoContextAccessor> _umbracoContextAccessorMock;
+    private readonly Mock<IBackOfficeSecurityAccessor> _backOfficeSecurityAccessorMock;
     private readonly IAITool _tool;
 
     public SearchUmbracoToolTests()
     {
         _examineManagerMock = new Mock<IExamineManager>();
         _umbracoContextAccessorMock = new Mock<IUmbracoContextAccessor>();
-        _tool = new SearchUmbracoTool(_examineManagerMock.Object, _umbracoContextAccessorMock.Object);
+        _backOfficeSecurityAccessorMock = new Mock<IBackOfficeSecurityAccessor>();
+        _tool = new SearchUmbracoTool(
+            _examineManagerMock.Object,
+            _umbracoContextAccessorMock.Object,
+            _backOfficeSecurityAccessorMock.Object);
     }
 
     [Fact]
@@ -196,4 +202,175 @@ public class SearchUmbracoToolTests
         result.ShouldNotContain("twelve");
         result.ShouldContain("ten");
     }
+
+    #region IsUnrestricted
+
+    [Fact]
+    public void IsUnrestricted_NullIds_ReturnsTrue()
+    {
+        SearchUmbracoTool.IsUnrestricted(null).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsUnrestricted_EmptyIds_ReturnsTrue()
+    {
+        SearchUmbracoTool.IsUnrestricted([]).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsUnrestricted_ContainsRootId_ReturnsTrue()
+    {
+        SearchUmbracoTool.IsUnrestricted([-1]).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsUnrestricted_ContainsRootIdAmongOthers_ReturnsTrue()
+    {
+        SearchUmbracoTool.IsUnrestricted([-1, 1234]).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsUnrestricted_SpecificIds_ReturnsFalse()
+    {
+        SearchUmbracoTool.IsUnrestricted([1234, 5678]).ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region GetEffectiveStartNodeIds
+
+    [Fact]
+    public void GetEffectiveStartNodeIds_UserIdsSet_ReturnsUserIds()
+    {
+        var result = SearchUmbracoTool.GetEffectiveStartNodeIds([100, 200], [300, 400]);
+
+        result.ShouldBe([100, 200]);
+    }
+
+    [Fact]
+    public void GetEffectiveStartNodeIds_NullUserIds_FallsBackToGroupIds()
+    {
+        var result = SearchUmbracoTool.GetEffectiveStartNodeIds(null, new int?[] { 300, 400 });
+
+        result.ShouldBe([300, 400]);
+    }
+
+    [Fact]
+    public void GetEffectiveStartNodeIds_EmptyUserIds_FallsBackToGroupIds()
+    {
+        var result = SearchUmbracoTool.GetEffectiveStartNodeIds([], new int?[] { 500 });
+
+        result.ShouldBe([500]);
+    }
+
+    [Fact]
+    public void GetEffectiveStartNodeIds_NullUserAndGroupIds_ReturnsNull()
+    {
+        var result = SearchUmbracoTool.GetEffectiveStartNodeIds(null, new int?[] { null, null });
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetEffectiveStartNodeIds_NullUserAndEmptyGroups_ReturnsNull()
+    {
+        var result = SearchUmbracoTool.GetEffectiveStartNodeIds(null, Enumerable.Empty<int?>());
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetEffectiveStartNodeIds_GroupIdsDeduplicates()
+    {
+        var result = SearchUmbracoTool.GetEffectiveStartNodeIds(null, new int?[] { 100, 100, 200 });
+
+        result.ShouldBe([100, 200]);
+    }
+
+    #endregion
+
+    #region BuildStartNodePathFilter
+
+    [Fact]
+    public void BuildStartNodePathFilter_ContentFilter_WithRestriction_ReturnsPathClause()
+    {
+        var result = SearchUmbracoTool.BuildStartNodePathFilter("content", [1234], null);
+
+        result.ShouldBe("(__Path:1234)");
+    }
+
+    [Fact]
+    public void BuildStartNodePathFilter_ContentFilter_Unrestricted_ReturnsNull()
+    {
+        var result = SearchUmbracoTool.BuildStartNodePathFilter("content", null, [5678]);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildStartNodePathFilter_MediaFilter_WithRestriction_ReturnsPathClause()
+    {
+        var result = SearchUmbracoTool.BuildStartNodePathFilter("media", null, [5678]);
+
+        result.ShouldBe("(__Path:5678)");
+    }
+
+    [Fact]
+    public void BuildStartNodePathFilter_MediaFilter_Unrestricted_ReturnsNull()
+    {
+        var result = SearchUmbracoTool.BuildStartNodePathFilter("media", [1234], null);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildStartNodePathFilter_AllFilter_BothUnrestricted_ReturnsNull()
+    {
+        var result = SearchUmbracoTool.BuildStartNodePathFilter("all", null, null);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildStartNodePathFilter_AllFilter_BothRestricted_CombinesIds()
+    {
+        var result = SearchUmbracoTool.BuildStartNodePathFilter("all", [100], [200]);
+
+        result.ShouldBe("(__Path:100 OR __Path:200)");
+    }
+
+    [Fact]
+    public void BuildStartNodePathFilter_AllFilter_OnlyContentRestricted_AllowsAllMedia()
+    {
+        var result = SearchUmbracoTool.BuildStartNodePathFilter("all", [100], null);
+
+        result.ShouldBe("(__IndexType:media OR ((__Path:100)))");
+    }
+
+    [Fact]
+    public void BuildStartNodePathFilter_AllFilter_OnlyMediaRestricted_AllowsAllContent()
+    {
+        var result = SearchUmbracoTool.BuildStartNodePathFilter("all", null, [200]);
+
+        result.ShouldBe("(__IndexType:content OR ((__Path:200)))");
+    }
+
+    [Fact]
+    public void BuildStartNodePathFilter_MultipleStartNodes_ReturnsOrClause()
+    {
+        var result = SearchUmbracoTool.BuildStartNodePathFilter("content", [100, 200, 300], null);
+
+        result.ShouldBe("(__Path:100 OR __Path:200 OR __Path:300)");
+    }
+
+    [Fact]
+    public void BuildStartNodePathFilter_RootAccess_ReturnsNull()
+    {
+        // -1 means root access (unrestricted)
+        var result = SearchUmbracoTool.BuildStartNodePathFilter("content", [-1], null);
+
+        result.ShouldBeNull();
+    }
+
+    #endregion
 }


### PR DESCRIPTION
The SearchUmbracoTool now respects Umbraco user start node restrictions
by filtering at the Examine query level using the __Path indexed field.
Users restricted to specific content/media subtrees will only see search
results within their allowed areas. Handles mixed restrictions (e.g.
content restricted but media unrestricted) and gracefully falls back to
no filtering when no user context is available.

https://claude.ai/code/session_01AXVRGZad3WYyUnRHBKewAp