### PR TITLE
fix: Exclude client dev files from NuGet package content

### DIFF
--- a/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Umbraco.AI.Agent.Copilot.csproj
+++ b/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Umbraco.AI.Agent.Copilot.csproj
@@ -22,8 +22,8 @@
     <ItemGroup>
         <!-- Dont include the client folder as part of packaging nuget build -->
         <Content Remove="Client\**" />
-        <Content Include="Client\package.json" />
-        <Content Include="Client\tsconfig.json" />
+        <Content Include="Client\package.json" Pack="false" />
+        <Content Include="Client\tsconfig.json" Pack="false" />
 
         <!-- However make the Umbraco-package.json included for dotnet pack or nuget package and visible to the solution -->
         <None Include="Client\public\umbraco-package.json" Pack="false" />

--- a/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Umbraco.AI.Agent.UI.csproj
+++ b/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Umbraco.AI.Agent.UI.csproj
@@ -22,8 +22,8 @@
     <ItemGroup>
         <!-- Dont include the client folder as part of packaging nuget build -->
         <Content Remove="Client\**" />
-        <Content Include="Client\package.json" />
-        <Content Include="Client\tsconfig.json" />
+        <Content Include="Client\package.json" Pack="false" />
+        <Content Include="Client\tsconfig.json" Pack="false" />
 
         <!-- However make the Umbraco-package.json included for dotnet pack or nuget package and visible to the solution -->
         <None Include="Client\public\umbraco-package.json" Pack="false" />

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Umbraco.AI.Agent.Web.StaticAssets.csproj
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Umbraco.AI.Agent.Web.StaticAssets.csproj
@@ -9,8 +9,8 @@
     <ItemGroup>
         <!-- Dont include the client folder as part of packaging nuget build -->
         <Content Remove="Client\**" />
-        <Content Include="Client\package.json" />
-        <Content Include="Client\tsconfig.json" />
+        <Content Include="Client\package.json" Pack="false" />
+        <Content Include="Client\tsconfig.json" Pack="false" />
 
         <!-- However make the Umbraco-package.json included for dotnet pack or nuget package and visible to the solution -->
         <None Include="Client\public\umbraco-package.json" Pack="false" />

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Umbraco.AI.Prompt.Web.StaticAssets.csproj
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Umbraco.AI.Prompt.Web.StaticAssets.csproj
@@ -9,8 +9,8 @@
     <ItemGroup>
         <!-- Dont include the client folder as part of packaging nuget build -->
         <Content Remove="Client\**" />
-        <Content Include="Client\package.json" />
-        <Content Include="Client\tsconfig.json" />
+        <Content Include="Client\package.json" Pack="false" />
+        <Content Include="Client\tsconfig.json" Pack="false" />
 
         <!-- However make the Umbraco-package.json included for dotnet pack or nuget package and visible to the solution -->
         <None Include="Client\public\umbraco-package.json" Pack="false" />

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Umbraco.AI.Web.StaticAssets.csproj
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Umbraco.AI.Web.StaticAssets.csproj
@@ -10,11 +10,11 @@
     <ItemGroup>
         <!-- Dont include the client folder as part of packaging nuget build -->
         <Content Remove="Client\**" />
-        <Content Include="Client\api-extractor.json" />
-        <Content Include="Client\package.json" />
-        <Content Include="Client\tsconfig.api.json" />
-        <Content Include="Client\tsconfig.app.json" />
-        <Content Include="Client\tsconfig.json" />
+        <Content Include="Client\api-extractor.json" Pack="false" />
+        <Content Include="Client\package.json" Pack="false" />
+        <Content Include="Client\tsconfig.api.json" Pack="false" />
+        <Content Include="Client\tsconfig.app.json" Pack="false" />
+        <Content Include="Client\tsconfig.json" Pack="false" />
 
         <!-- However make the Umbraco-package.json included for dotnet pack or nuget package and visible to the solution -->
         <None Include="Client\public\umbraco-package.json" Pack="false" />


### PR DESCRIPTION
Fixes #103

Add `Pack="false"` to `tsconfig.json`, `package.json` and `api-extractor.json` Content items in all Web.StaticAssets / frontend .csproj files.

When these files were included as `<Content>` without `Pack="false"`, they were packed as NuGet contentFiles and unpacked into the consuming project's NuGet cache. The TypeScript compiler then picked up tsconfig.json and failed because the src/ folder doesn't exist and some options require a newer TypeScript version.

Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/umbraco/Umbraco.AI/tree/claude/issue-103-20260319-2003