### PR TITLE
refactor(profiles): Remove any cast for response settings in type-mapper

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/type-mapper.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/type-mapper.ts
@@ -16,9 +16,6 @@ import { isChatSettings, isEmbeddingSettings } from "./types.js";
 
 export const UaiProfileTypeMapper = {
     toDetailModel(response: ProfileResponseModel): UaiProfileDetailModel {
-        // Note: Cast to access version until API client is regenerated
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const version = (response as any).version as number | undefined;
         return {
             unique: response.id,
             entityType: UAI_PROFILE_ENTITY_TYPE,
@@ -31,7 +28,7 @@ export const UaiProfileTypeMapper = {
             tags: response.tags ?? [],
             dateCreated: response.dateCreated,
             dateModified: response.dateModified,
-            version: version ?? 1,
+            version: response.version ?? 1,
         };
     },
 
@@ -73,30 +70,28 @@ export const UaiProfileTypeMapper = {
     /**
      * Maps API response settings to internal model.
      * The API uses polymorphic JSON with $type discriminator.
-     * Note: Uses 'any' cast because generated types may not include 'settings' until regenerated.
      */
     mapResponseSettings(response: ProfileResponseModel): UaiProfileSettings | null {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const settings = (response as any).settings as Record<string, unknown> | undefined;
+        const settings = response.settings;
         if (!settings) return null;
 
-        // The API returns settings with $type discriminator
-        const type = settings.$type as string;
-        if (type === "chat") {
+        if (settings.$type === "chat") {
+            const chat = settings as ChatProfileSettingsModel;
             return {
                 $type: "chat",
-                temperature: (settings.temperature as number) ?? null,
-                maxTokens: (settings.maxTokens as number) ?? null,
-                systemPromptTemplate: (settings.systemPromptTemplate as string) ?? null,
-                contextIds: (settings.contextIds as string[] | undefined) ?? [],
-                guardrailIds: (settings.guardrailIds as string[] | undefined) ?? [],
+                temperature: chat.temperature ?? null,
+                maxTokens: chat.maxTokens ?? null,
+                systemPromptTemplate: chat.systemPromptTemplate ?? null,
+                contextIds: chat.contextIds ?? [],
+                guardrailIds: chat.guardrailIds ?? [],
             } as UaiChatProfileSettings;
         }
 
-        if (type === "embedding") {
+        if (settings.$type === "embedding") {
+            const embedding = settings as EmbeddingProfileSettingsModel;
             return {
                 $type: "embedding",
-                dimensions: (settings.dimensions as number) ?? null,
+                dimensions: embedding.dimensions ?? null,
             } as UaiEmbeddingProfileSettings;
         }
 
@@ -112,7 +107,6 @@ export const UaiProfileTypeMapper = {
         if (!settings) return null;
 
         if (isChatSettings(settings)) {
-            // Note: Uses 'unknown' cast because guardrailIds is not in the generated ChatProfileSettingsModel yet
             return {
                 $type: "chat",
                 temperature: settings.temperature,
@@ -120,14 +114,14 @@ export const UaiProfileTypeMapper = {
                 systemPromptTemplate: settings.systemPromptTemplate,
                 contextIds: settings.contextIds,
                 guardrailIds: settings.guardrailIds,
-            } as unknown as ChatProfileSettingsModel;
+            } as ChatProfileSettingsModel;
         }
 
         if (isEmbeddingSettings(settings)) {
             return {
                 $type: "embedding",
                 dimensions: settings.dimensions,
-            } as unknown as EmbeddingProfileSettingsModel;
+            } as EmbeddingProfileSettingsModel;
         }
 
         return null;


### PR DESCRIPTION
Remove the `(response as any).settings` workaround in the profile type-mapper. The generated `ProfileResponseModel` already includes `settings` typed as `ChatProfileSettingsModel | EmbeddingProfileSettingsModel | null`, so the cast is no longer needed. Also cleaned up the similar `version` cast and the `unknown` cast in `mapRequestSettings`.

Generated with [Claude Code](https://claude.ai/code)