### PR TITLE
feat(prompt): Use structured output to prevent LLM preamble

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -63,7 +63,7 @@
 
   <!-- Provider packages -->
   <ItemGroup>
-    <PackageVersion Include="Anthropic" Version="12.3.0" />
+    <PackageVersion Include="Anthropic" Version="12.9.0" />
     <PackageVersion Include="AWSSDK.Bedrock" Version="4.0.19.3" />
     <PackageVersion Include="AWSSDK.BedrockRuntime" Version="4.0.15.1" />
     <PackageVersion Include="AWSSDK.Extensions.Bedrock.MEAI" Version="4.0.5.7" />

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
@@ -41,7 +41,7 @@ public class AnthropicChatCapability(AnthropicProvider provider) : AIChatCapabil
     /// <inheritdoc />
     protected override IChatClient CreateClient(AnthropicProviderSettings settings, string? modelId)
         => AnthropicProvider.CreateAnthropicClient(settings)
-            .AsIChatClient(modelId);
+            .Beta.AsIChatClient(modelId);
 
     private static bool IsChatModel(string modelId)
         => IncludePatterns.Any(p => p.IsMatch(modelId));

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/packages.lock.json
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Anthropic": {
         "type": "Direct",
-        "requested": "[12.3.0, )",
-        "resolved": "12.3.0",
-        "contentHash": "u4lWbqXH/7BtWurVGBvc6YjXcsjUYfFYj8ujRwymYygGgS/MECd/Q5uIYMJsEdQG+5kCeRxwT8GF2Bg/a29cVg==",
+        "requested": "[12.9.0, )",
+        "resolved": "12.9.0",
+        "contentHash": "GEnCMT4zwNIfj5NQCapo5vSzHoSJEm7o5OJXF7iRIdv7UCZkkVm9/m+dW2m/r9lmfu7HK0CiXq8EWFXqiCCANQ==",
         "dependencies": {
           "Microsoft.Extensions.AI.Abstractions": "10.2.0"
         }

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptResponseSchemas.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptResponseSchemas.cs
@@ -1,0 +1,37 @@
+namespace Umbraco.AI.Prompt.Core.Prompts;
+
+/// <summary>
+/// Structured response schema for single-value prompts (OptionCount=1).
+/// Used with <see cref="Microsoft.Extensions.AI.ChatResponseFormat.ForJsonSchema{T}"/>
+/// to constrain the LLM to return only the content value without preamble.
+/// </summary>
+/// <remarks>
+/// A wrapper object is necessary because many AI services require that the
+/// JSON schema have a top-level 'type=object'. Primitive types like string may fail.
+/// </remarks>
+internal sealed record SingleValueResponse
+{
+    public required string Value { get; init; }
+}
+
+/// <summary>
+/// Structured response schema for multi-option prompts (OptionCount>=2).
+/// Used with <see cref="Microsoft.Extensions.AI.ChatResponseFormat.ForJsonSchema{T}"/>
+/// to enforce the options JSON structure at the provider level.
+/// </summary>
+internal sealed record MultiOptionResponse
+{
+    public required IReadOnlyList<MultiOptionItem> Options { get; init; }
+}
+
+/// <summary>
+/// A single option within a <see cref="MultiOptionResponse"/>.
+/// </summary>
+internal sealed record MultiOptionItem
+{
+    public required string Label { get; init; }
+
+    public required string Value { get; init; }
+
+    public string? Description { get; init; }
+}

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptService.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptService.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.AI.Core.Chat;
@@ -21,8 +20,6 @@ namespace Umbraco.AI.Prompt.Core.Prompts;
 /// </summary>
 internal sealed class AIPromptService : IAIPromptService
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
-
     private readonly IAIPromptRepository _repository;
     private readonly IAIEntityVersionService _versionService;
     private readonly IAIChatService _chatService;
@@ -283,7 +280,9 @@ internal sealed class AIPromptService : IAIPromptService
             messages.Insert(0, new ChatMessage(ChatRole.System, contextContent));
         }
 
-        // 7.5. Inject format instructions based on option count
+        // 7.5. Inject format instructions based on option count.
+        // Inserted AFTER context messages so they appear closest to the user message,
+        // which makes LLMs more likely to follow them.
         if (prompt.OptionCount == 1)
         {
             var formatInstructions = """
@@ -293,7 +292,7 @@ internal sealed class AIPromptService : IAIPromptService
                 Do NOT wrap the value in markdown formatting unless the content itself requires it.
                 """;
 
-            messages.Insert(0, new ChatMessage(ChatRole.System, formatInstructions));
+            messages.Add(new ChatMessage(ChatRole.System, formatInstructions));
         }
         else if (prompt.OptionCount >= 2)
         {
@@ -307,29 +306,18 @@ internal sealed class AIPromptService : IAIPromptService
                 Generate exactly {{prompt.OptionCount}} distinct options for the user to choose from.
                 """;
 
-            messages.Insert(0, new ChatMessage(ChatRole.System, formatInstructions));
+            messages.Add(new ChatMessage(ChatRole.System, formatInstructions));
         }
 
-        // 8. Create ChatOptions with PromptId for context resolution, feature tracking, system tools, and structured output
+        // 8. Create ChatOptions with PromptId for context resolution, feature tracking, and system tools
         var chatOptions = new ChatOptions
         {
             Tools = _tools.ToSystemToolFunctions(_functionFactory).Cast<AITool>().ToList(),
-            ToolMode = ChatToolMode.Auto,
-            ResponseFormat = prompt.OptionCount switch
-            {
-                1 => ChatResponseFormat.ForJsonSchema<SingleValueResponse>(
-                    schemaName: "single_value",
-                    schemaDescription: "A single content value without any preamble or postamble"),
-                >= 2 => ChatResponseFormat.ForJsonSchema<MultiOptionResponse>(
-                    schemaName: "multi_option",
-                    schemaDescription: "Multiple distinct content options for the user to choose from"),
-                _ => null
-            }
+            ToolMode = ChatToolMode.Auto
         };
 
-        // 10. Execute via chat service — use profile override if provided
         var profileId = options.ProfileIdOverride ?? prompt.ProfileId;
-        var response = await _chatService.GetChatResponseAsync(chat =>
+        void ConfigureChat(AIChatBuilder chat)
         {
             chat.WithAlias($"prompt-{prompt.Alias}")
                 .WithChatOptions(chatOptions)
@@ -338,35 +326,101 @@ internal sealed class AIPromptService : IAIPromptService
             {
                 chat.WithProfile(profileId.Value);
             }
-        }, messages, cancellationToken);
+        }
 
-        var responseText = response.Text ?? string.Empty;
+        // 10. Execute and build result based on option count.
+        // For OptionCount 1 and 2+, use structured output via GetStructuredResponseAsync<T>
+        // which delegates to M.E.AI's structured output extensions (schema, ResponseFormat, deserialization).
+        AIPromptExecutionResult result;
 
-        // 11. Build ResultOptions based on option count
-        var result = prompt.OptionCount switch
+        switch (prompt.OptionCount)
         {
-            0 => new AIPromptExecutionResult
+            case 0:
             {
-                Content = responseText,
-                Usage = response.Usage,
-                Messages = messages,
-                ResultOptions = [] // Empty array for informational
-            },
+                var response = await _chatService.GetChatResponseAsync(ConfigureChat, messages, cancellationToken);
+                result = new AIPromptExecutionResult
+                {
+                    Content = response.Text ?? string.Empty,
+                    Usage = response.Usage,
+                    Messages = messages,
+                    ResultOptions = [] // Empty array for informational
+                };
+                break;
+            }
 
-            1 => BuildSingleValueResult(responseText, response.Usage, messages, request),
+            case 1:
+            {
+                var response = await _chatService.GetStructuredResponseAsync<SingleValueResponse>(
+                    ConfigureChat, messages, cancellationToken);
+                var responseText = response.Text ?? string.Empty;
 
-            >= 2 => BuildMultiOptionResult(responseText, response.Usage, messages, request)
-                ?? await ParseMultipleResultResponseWithRetryAsync(
-                    prompt,
-                    messages,
-                    chatOptions,
-                    responseText,
-                    response.Usage,
-                    request,
-                    cancellationToken),
+                var displayValue = response.TryGetResult(out var parsed) ? parsed.Value : responseText;
+                result = new AIPromptExecutionResult
+                {
+                    Content = responseText,
+                    Usage = response.Usage,
+                    Messages = messages,
+                    ResultOptions =
+                    [
+                        new AIPromptExecutionResult.AIPromptResultOption
+                        {
+                            Label = "Result",
+                            DisplayValue = displayValue,
+                            Description = null,
+                            ValueChange = new AIValueChange
+                            {
+                                Path = request.PropertyAlias,
+                                Value = displayValue,
+                                Culture = request.Culture,
+                                Segment = request.Segment
+                            }
+                        }
+                    ]
+                };
+                break;
+            }
 
-            _ => throw new InvalidOperationException($"Invalid option count: {prompt.OptionCount}")
-        };
+            case >= 2:
+            {
+                var response = await _chatService.GetStructuredResponseAsync<MultiOptionResponse>(
+                    ConfigureChat, messages, cancellationToken);
+                var responseText = response.Text ?? string.Empty;
+
+                if (response.TryGetResult(out var parsed) && parsed.Options is { Count: > 0 })
+                {
+                    result = new AIPromptExecutionResult
+                    {
+                        Content = responseText,
+                        Usage = response.Usage,
+                        Messages = messages,
+                        ResultOptions = parsed.Options.Select(option => new AIPromptExecutionResult.AIPromptResultOption
+                        {
+                            Label = option.Label,
+                            DisplayValue = option.Value,
+                            Description = option.Description,
+                            ValueChange = new AIValueChange
+                            {
+                                Path = request.PropertyAlias,
+                                Value = option.Value,
+                                Culture = request.Culture,
+                                Segment = request.Segment
+                            }
+                        }).ToList()
+                    };
+                }
+                else
+                {
+                    // Structured output not honored — fall back to retry-based parsing
+                    result = await ParseMultipleResultResponseWithRetryAsync(
+                        prompt, messages, chatOptions, responseText,
+                        response.Usage, request, cancellationToken);
+                }
+                break;
+            }
+
+            default:
+                throw new InvalidOperationException($"Invalid option count: {prompt.OptionCount}");
+        }
 
         // Publish executed notification (after execution)
         var executedNotification = new AIPromptExecutedNotification(prompt, request, result, eventMessages)
@@ -399,105 +453,6 @@ internal sealed class AIPromptService : IAIPromptService
         }
 
         return context;
-    }
-
-    /// <summary>
-    /// Builds a single-value result, attempting to extract the value from structured JSON output.
-    /// Falls back to using the raw response text if the provider did not return structured JSON.
-    /// </summary>
-    private static AIPromptExecutionResult BuildSingleValueResult(
-        string responseText,
-        UsageDetails? usage,
-        IReadOnlyList<ChatMessage> messages,
-        AIPromptExecutionRequest request)
-    {
-        var displayValue = TryDeserializeSingleValue(responseText) ?? responseText;
-
-        return new AIPromptExecutionResult
-        {
-            Content = responseText,
-            Usage = usage,
-            Messages = messages,
-            ResultOptions =
-            [
-                new AIPromptExecutionResult.AIPromptResultOption
-                {
-                    Label = "Result",
-                    DisplayValue = displayValue,
-                    Description = null,
-                    ValueChange = new AIValueChange
-                    {
-                        Path = request.PropertyAlias,
-                        Value = displayValue,
-                        Culture = request.Culture,
-                        Segment = request.Segment
-                    }
-                }
-            ]
-        };
-    }
-
-    /// <summary>
-    /// Attempts to deserialize a structured single-value response.
-    /// Returns the extracted value, or null if the response is not valid structured JSON.
-    /// </summary>
-    internal static string? TryDeserializeSingleValue(string responseText)
-    {
-        try
-        {
-            var response = JsonSerializer.Deserialize<SingleValueResponse>(responseText, JsonOptions);
-            return response?.Value;
-        }
-        catch (JsonException)
-        {
-            return null;
-        }
-    }
-
-    /// <summary>
-    /// Attempts to build a multi-option result from structured JSON output.
-    /// Returns null if the response is not valid structured JSON, allowing fallback to retry-based parsing.
-    /// </summary>
-    internal static AIPromptExecutionResult? BuildMultiOptionResult(
-        string responseText,
-        UsageDetails? usage,
-        IReadOnlyList<ChatMessage> messages,
-        AIPromptExecutionRequest request)
-    {
-        try
-        {
-            var response = JsonSerializer.Deserialize<MultiOptionResponse>(responseText, JsonOptions);
-            if (response?.Options is not { Count: > 0 })
-            {
-                return null;
-            }
-
-            var resultOptions = response.Options.Select(option => new AIPromptExecutionResult.AIPromptResultOption
-            {
-                Label = option.Label,
-                DisplayValue = option.Value,
-                Description = option.Description,
-                ValueChange = new AIValueChange
-                {
-                    Path = request.PropertyAlias,
-                    Value = option.Value,
-                    Culture = request.Culture,
-                    Segment = request.Segment
-                }
-            }).ToList();
-
-            return new AIPromptExecutionResult
-            {
-                Content = responseText,
-                Usage = usage,
-                Messages = messages.ToList(),
-                ResultOptions = resultOptions
-            };
-        }
-        catch (JsonException)
-        {
-            return null;
-        }
     }
 
     /// <summary>

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptService.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptService.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.AI.Core.Chat;
@@ -20,6 +21,8 @@ namespace Umbraco.AI.Prompt.Core.Prompts;
 /// </summary>
 internal sealed class AIPromptService : IAIPromptService
 {
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
     private readonly IAIPromptRepository _repository;
     private readonly IAIEntityVersionService _versionService;
     private readonly IAIChatService _chatService;
@@ -280,8 +283,19 @@ internal sealed class AIPromptService : IAIPromptService
             messages.Insert(0, new ChatMessage(ChatRole.System, contextContent));
         }
 
-        // 7.5. Inject format instructions for multiple options
-        if (prompt.OptionCount >= 2)
+        // 7.5. Inject format instructions based on option count
+        if (prompt.OptionCount == 1)
+        {
+            var formatInstructions = """
+                IMPORTANT: Return ONLY the requested content value.
+                Do NOT include any preamble, introduction, or explanation before the value.
+                Do NOT include any closing remarks, suggestions, or follow-up text after the value.
+                Do NOT wrap the value in markdown formatting unless the content itself requires it.
+                """;
+
+            messages.Insert(0, new ChatMessage(ChatRole.System, formatInstructions));
+        }
+        else if (prompt.OptionCount >= 2)
         {
             var formatInstructions = $$"""
                 IMPORTANT: Return your response as a JSON object with an "options" array containing {{prompt.OptionCount}} options.
@@ -290,35 +304,27 @@ internal sealed class AIPromptService : IAIPromptService
                 - "value": The actual content
                 - "description": Optional brief explanation
 
-                Example format:
-                ```json
-                {
-                  "options": [
-                    {
-                      "label": "Formal Tone",
-                      "value": "The content in formal style...",
-                      "description": "Professional and business-appropriate"
-                    },
-                    {
-                      "label": "Casual Style",
-                      "value": "The content in casual style...",
-                      "description": "Friendly and conversational"
-                    }
-                  ]
-                }
-                ```
-
                 Generate exactly {{prompt.OptionCount}} distinct options for the user to choose from.
                 """;
 
             messages.Insert(0, new ChatMessage(ChatRole.System, formatInstructions));
         }
 
-        // 8. Create ChatOptions with PromptId for context resolution, feature tracking, and system tools
+        // 8. Create ChatOptions with PromptId for context resolution, feature tracking, system tools, and structured output
         var chatOptions = new ChatOptions
         {
             Tools = _tools.ToSystemToolFunctions(_functionFactory).Cast<AITool>().ToList(),
-            ToolMode = ChatToolMode.Auto
+            ToolMode = ChatToolMode.Auto,
+            ResponseFormat = prompt.OptionCount switch
+            {
+                1 => ChatResponseFormat.ForJsonSchema<SingleValueResponse>(
+                    schemaName: "single_value",
+                    schemaDescription: "A single content value without any preamble or postamble"),
+                >= 2 => ChatResponseFormat.ForJsonSchema<MultiOptionResponse>(
+                    schemaName: "multi_option",
+                    schemaDescription: "Multiple distinct content options for the user to choose from"),
+                _ => null
+            }
         };
 
         // 10. Execute via chat service — use profile override if provided
@@ -347,36 +353,17 @@ internal sealed class AIPromptService : IAIPromptService
                 ResultOptions = [] // Empty array for informational
             },
 
-            1 => new AIPromptExecutionResult
-            {
-                Content = responseText,
-                Usage = response.Usage,
-                Messages = messages,
-                ResultOptions = [
-                    new AIPromptExecutionResult.AIPromptResultOption
-                    {
-                        Label = "Result",
-                        DisplayValue = responseText,
-                        Description = null,
-                        ValueChange = new AIValueChange
-                        {
-                            Path = request.PropertyAlias,
-                            Value = responseText,
-                            Culture = request.Culture,
-                            Segment = request.Segment
-                        }
-                    }
-                ]
-            },
+            1 => BuildSingleValueResult(responseText, response.Usage, messages, request),
 
-            >= 2 => await ParseMultipleResultResponseWithRetryAsync(
-                prompt,
-                messages,
-                chatOptions,
-                responseText,
-                response.Usage,
-                request,
-                cancellationToken),
+            >= 2 => BuildMultiOptionResult(responseText, response.Usage, messages, request)
+                ?? await ParseMultipleResultResponseWithRetryAsync(
+                    prompt,
+                    messages,
+                    chatOptions,
+                    responseText,
+                    response.Usage,
+                    request,
+                    cancellationToken),
 
             _ => throw new InvalidOperationException($"Invalid option count: {prompt.OptionCount}")
         };
@@ -412,6 +399,105 @@ internal sealed class AIPromptService : IAIPromptService
         }
 
         return context;
+    }
+
+    /// <summary>
+    /// Builds a single-value result, attempting to extract the value from structured JSON output.
+    /// Falls back to using the raw response text if the provider did not return structured JSON.
+    /// </summary>
+    private static AIPromptExecutionResult BuildSingleValueResult(
+        string responseText,
+        UsageDetails? usage,
+        IReadOnlyList<ChatMessage> messages,
+        AIPromptExecutionRequest request)
+    {
+        var displayValue = TryDeserializeSingleValue(responseText) ?? responseText;
+
+        return new AIPromptExecutionResult
+        {
+            Content = responseText,
+            Usage = usage,
+            Messages = messages,
+            ResultOptions =
+            [
+                new AIPromptExecutionResult.AIPromptResultOption
+                {
+                    Label = "Result",
+                    DisplayValue = displayValue,
+                    Description = null,
+                    ValueChange = new AIValueChange
+                    {
+                        Path = request.PropertyAlias,
+                        Value = displayValue,
+                        Culture = request.Culture,
+                        Segment = request.Segment
+                    }
+                }
+            ]
+        };
+    }
+
+    /// <summary>
+    /// Attempts to deserialize a structured single-value response.
+    /// Returns the extracted value, or null if the response is not valid structured JSON.
+    /// </summary>
+    internal static string? TryDeserializeSingleValue(string responseText)
+    {
+        try
+        {
+            var response = JsonSerializer.Deserialize<SingleValueResponse>(responseText, JsonOptions);
+            return response?.Value;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to build a multi-option result from structured JSON output.
+    /// Returns null if the response is not valid structured JSON, allowing fallback to retry-based parsing.
+    /// </summary>
+    internal static AIPromptExecutionResult? BuildMultiOptionResult(
+        string responseText,
+        UsageDetails? usage,
+        IReadOnlyList<ChatMessage> messages,
+        AIPromptExecutionRequest request)
+    {
+        try
+        {
+            var response = JsonSerializer.Deserialize<MultiOptionResponse>(responseText, JsonOptions);
+            if (response?.Options is not { Count: > 0 })
+            {
+                return null;
+            }
+
+            var resultOptions = response.Options.Select(option => new AIPromptExecutionResult.AIPromptResultOption
+            {
+                Label = option.Label,
+                DisplayValue = option.Value,
+                Description = option.Description,
+                ValueChange = new AIValueChange
+                {
+                    Path = request.PropertyAlias,
+                    Value = option.Value,
+                    Culture = request.Culture,
+                    Segment = request.Segment
+                }
+            }).ToList();
+
+            return new AIPromptExecutionResult
+            {
+                Content = responseText,
+                Usage = usage,
+                Messages = messages.ToList(),
+                ResultOptions = resultOptions
+            };
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
     }
 
     /// <summary>

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptService.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptService.cs
@@ -350,7 +350,7 @@ internal sealed class AIPromptService : IAIPromptService
 
             case 1:
             {
-                var response = await _chatService.GetStructuredResponseAsync<SingleValueResponse>(
+                var response = await _chatService.GetStructuredChatResponseAsync<SingleValueResponse>(
                     ConfigureChat, messages, cancellationToken);
                 var responseText = response.Text ?? string.Empty;
 
@@ -382,7 +382,7 @@ internal sealed class AIPromptService : IAIPromptService
 
             case >= 2:
             {
-                var response = await _chatService.GetStructuredResponseAsync<MultiOptionResponse>(
+                var response = await _chatService.GetStructuredChatResponseAsync<MultiOptionResponse>(
                     ConfigureChat, messages, cancellationToken);
                 var responseText = response.Text ?? string.Empty;
 

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/prompt/property-actions/prompt-preview-modal.element.ts
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/prompt/property-actions/prompt-preview-modal.element.ts
@@ -179,11 +179,12 @@ export class UaiPromptPreviewModalElement extends UmbModalBaseElement<
     }
 
     #renderSingleOption() {
+        const displayValue = this._resultOptions?.[0]?.displayValue ?? this._response;
         return html`
             <div class="response-content copy-container">
                 <umb-icon name="icon-wand color-blue" class="option-icon"></umb-icon>
-                <div style="white-space: pre-wrap;word-break: break-word;">${this._response}</div>
-                ${this.#renderCopyButton(this._response)}
+                <div style="white-space: pre-wrap;word-break: break-word;">${displayValue}</div>
+                ${this.#renderCopyButton(displayValue)}
             </div>
         `;
     }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Chat/AIChatService.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Chat/AIChatService.cs
@@ -201,7 +201,7 @@ internal sealed class AIChatService : IAIChatService
         }
     }
 
-    public async Task<ChatResponse<T>> GetStructuredResponseAsync<T>(
+    public async Task<ChatResponse<T>> GetStructuredChatResponseAsync<T>(
         Action<AIChatBuilder> configure,
         IEnumerable<ChatMessage> messages,
         CancellationToken cancellationToken = default)

--- a/Umbraco.AI/src/Umbraco.AI.Core/Chat/AIChatService.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Chat/AIChatService.cs
@@ -201,6 +201,83 @@ internal sealed class AIChatService : IAIChatService
         }
     }
 
+    public async Task<ChatResponse<T>> GetStructuredResponseAsync<T>(
+        Action<AIChatBuilder> configure,
+        IEnumerable<ChatMessage> messages,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        ArgumentNullException.ThrowIfNull(messages);
+
+        var builder = BuildChat(configure);
+
+        // Pass-through mode: skip notifications and duration tracking.
+        if (builder.IsPassThrough)
+        {
+            return await ExecuteStructuredChatAsync<T>(builder, messages, cancellationToken);
+        }
+
+        // Publish executing notification
+        var eventMessages = new EventMessages();
+        var executingNotification = new AIChatExecutingNotification(
+            builder.Id, builder.Alias!, builder.Name, builder.ProfileId, eventMessages);
+        await _eventAggregator.PublishAsync(executingNotification, cancellationToken);
+
+        if (executingNotification.Cancel)
+        {
+            var errorMessages = string.Join("; ", eventMessages.GetAll().Select(m => m.Message));
+            throw new InvalidOperationException($"Inline chat execution cancelled: {errorMessages}");
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+        bool isSuccess = false;
+
+        try
+        {
+            var response = await ExecuteStructuredChatAsync<T>(builder, messages, cancellationToken);
+            isSuccess = true;
+            return response;
+        }
+        finally
+        {
+            var executedNotification = new AIChatExecutedNotification(
+                builder.Id, builder.Alias!, builder.Name, builder.ProfileId,
+                stopwatch.Elapsed, isSuccess, eventMessages);
+            await _eventAggregator.PublishAsync(executedNotification, cancellationToken);
+        }
+    }
+
+    private async Task<ChatResponse<T>> ExecuteStructuredChatAsync<T>(
+        AIChatBuilder builder,
+        IEnumerable<ChatMessage> messages,
+        CancellationToken cancellationToken)
+    {
+        var scopeExisted = _contextAccessor.Context is not null;
+        IAIRuntimeContextScope? createdScope = null;
+
+        try
+        {
+            if (!scopeExisted)
+            {
+                createdScope = _scopeProvider.CreateScope(builder.ContextItems ?? []);
+                _contributors.Populate(createdScope.Context);
+            }
+
+            await ResolveBuilderAliasesAsync(builder, cancellationToken);
+            builder.PopulateContext(_contextAccessor.Context!, setFeatureMetadata: !builder.IsPassThrough);
+
+            var profile = await ResolveProfileAsync(builder.ProfileId, builder.ProfileAlias, cancellationToken);
+            var chatClient = await _clientFactory.CreateClientAsync(profile, cancellationToken);
+            var mergedOptions = MergeOptions(profile, builder.ChatOptions);
+
+            return await chatClient.GetResponseAsync<T>(messages.ToList(), mergedOptions, cancellationToken: cancellationToken);
+        }
+        finally
+        {
+            createdScope?.Dispose();
+        }
+    }
+
     private async Task<ChatResponse> ExecuteInlineChatAsync(
         AIChatBuilder builder,
         IEnumerable<ChatMessage> messages,

--- a/Umbraco.AI/src/Umbraco.AI.Core/Chat/IAIChatService.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Chat/IAIChatService.cs
@@ -115,6 +115,35 @@ public interface IAIChatService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets a structured chat response using an inline chat builder, requesting the
+    /// response match type <typeparamref name="T"/>. Delegates to M.E.AI's structured
+    /// output extensions which handle schema generation, response format negotiation,
+    /// and deserialization.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Use <see cref="ChatResponse{T}.TryGetResult"/> for safe access when the provider
+    /// may not honor structured output, or <see cref="ChatResponse{T}.Result"/> when
+    /// structured output is expected to succeed. The raw response text is always available
+    /// via <see cref="ChatResponse.Text"/>.
+    /// </para>
+    /// <para>
+    /// Callers should NOT set <see cref="ChatOptions.ResponseFormat"/> via
+    /// <see cref="InlineChat.AIChatBuilder.WithChatOptions"/> — the structured output
+    /// extension sets it automatically based on <typeparamref name="T"/>.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="T">The type of structured output to request.</typeparam>
+    /// <param name="configure">Action to configure the inline chat via the builder.</param>
+    /// <param name="messages">The chat messages to send.</param>
+    /// <param name="cancellationToken">Cancellation token for the async operation.</param>
+    /// <returns>A typed chat response that can be deserialized to <typeparamref name="T"/>.</returns>
+    Task<ChatResponse<T>> GetStructuredResponseAsync<T>(
+        Action<AIChatBuilder> configure,
+        IEnumerable<ChatMessage> messages,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Creates a reusable inline chat client with scope management per-call.
     /// </summary>
     /// <remarks>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Chat/IAIChatService.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Chat/IAIChatService.cs
@@ -138,7 +138,7 @@ public interface IAIChatService
     /// <param name="messages">The chat messages to send.</param>
     /// <param name="cancellationToken">Cancellation token for the async operation.</param>
     /// <returns>A typed chat response that can be deserialized to <typeparamref name="T"/>.</returns>
-    Task<ChatResponse<T>> GetStructuredResponseAsync<T>(
+    Task<ChatResponse<T>> GetStructuredChatResponseAsync<T>(
         Action<AIChatBuilder> configure,
         IEnumerable<ChatMessage> messages,
         CancellationToken cancellationToken = default);


### PR DESCRIPTION
## Summary
- Use M.E.AI's `ChatResponseFormat.ForJsonSchema<T>()` to enforce response structure at the provider level for prompt execution
- For **OptionCount=1**: Constrains LLM to return `{"value": "..."}` via a `SingleValueResponse` schema, eliminating preamble/postamble. Falls back to raw text for providers that don't support structured output.
- For **OptionCount>=2**: Enforces `{"options": [...]}` structure via `MultiOptionResponse` schema, improving JSON reliability. Falls back to existing regex+retry parsing if structured output isn't supported.
- Adds concise system message for OptionCount=1 instructing no preamble/postamble
- Simplifies OptionCount>=2 format instructions by removing verbose JSON example (schema handles structure)

## Test plan
- [x] Build passes (`dotnet build Umbraco.AI.Prompt/Umbraco.AI.Prompt.slnx`)
- [x] All 49 existing unit tests pass
- [ ] Manual: Start demo site, create prompt with OptionCount=1, execute — verify no preamble in result
- [ ] Manual: Create prompt with OptionCount=3, execute — verify clean JSON parsing without retries
- [ ] Manual: Test with multiple providers (OpenAI, Anthropic) to verify fallback works for providers with varying structured output support

🤖 Generated with [Claude Code](https://claude.com/claude-code)