### PR TITLE
fix: Version-stamp JS entry paths in umbraco-package.json to bust browser cache

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,9 @@
 <Project>
+  <PropertyGroup>
+    <!-- Repo root directory, used for locating shared build scripts -->
+    <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
+  </PropertyGroup>
+
   <Target Name="DisableCloudBuildNumberInAzureDevOps"
           AfterTargets="GetUmbracoBuildVersion"
           BeforeTargets="SetCloudBuildNumberWithVersion"

--- a/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Umbraco.AI.Agent.Copilot.csproj
+++ b/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Umbraco.AI.Agent.Copilot.csproj
@@ -40,5 +40,6 @@
             <_PackageManifestFiles Include="wwwroot\umbraco-package.json" />
         </ItemGroup>
         <JsonPathUpdateValue JsonFile="%(_PackageManifestFiles.FullPath)" Path="$.version" Value="&quot;$(PackageVersion)&quot;" />
+        <Exec Command="node &quot;$(RepoRoot)scripts/build/version-package-manifest.js&quot; &quot;$(PackageVersion)&quot; &quot;%(_PackageManifestFiles.FullPath)&quot;" />
     </Target>
 </Project>

--- a/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Umbraco.AI.Agent.UI.csproj
+++ b/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Umbraco.AI.Agent.UI.csproj
@@ -40,5 +40,6 @@
             <_PackageManifestFiles Include="wwwroot\umbraco-package.json" />
         </ItemGroup>
         <JsonPathUpdateValue JsonFile="%(_PackageManifestFiles.FullPath)" Path="$.version" Value="&quot;$(PackageVersion)&quot;" />
+        <Exec Command="node &quot;$(RepoRoot)scripts/build/version-package-manifest.js&quot; &quot;$(PackageVersion)&quot; &quot;%(_PackageManifestFiles.FullPath)&quot;" />
     </Target>
 </Project>

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Umbraco.AI.Agent.Web.StaticAssets.csproj
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Umbraco.AI.Agent.Web.StaticAssets.csproj
@@ -28,5 +28,6 @@
             <_PackageManifestFiles Include="wwwroot\umbraco-package.json" />
         </ItemGroup>
         <JsonPathUpdateValue JsonFile="%(_PackageManifestFiles.FullPath)" Path="$.version" Value="&quot;$(PackageVersion)&quot;" />
+        <Exec Command="node &quot;$(RepoRoot)scripts/build/version-package-manifest.js&quot; &quot;$(PackageVersion)&quot; &quot;%(_PackageManifestFiles.FullPath)&quot;" />
     </Target>
 </Project>

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Umbraco.AI.Prompt.Web.StaticAssets.csproj
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Umbraco.AI.Prompt.Web.StaticAssets.csproj
@@ -28,5 +28,6 @@
             <_PackageManifestFiles Include="wwwroot\umbraco-package.json" />
         </ItemGroup>
         <JsonPathUpdateValue JsonFile="%(_PackageManifestFiles.FullPath)" Path="$.version" Value="&quot;$(PackageVersion)&quot;" />
+        <Exec Command="node &quot;$(RepoRoot)scripts/build/version-package-manifest.js&quot; &quot;$(PackageVersion)&quot; &quot;%(_PackageManifestFiles.FullPath)&quot;" />
     </Target>
 </Project>

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Umbraco.AI.Web.StaticAssets.csproj
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Umbraco.AI.Web.StaticAssets.csproj
@@ -30,6 +30,7 @@
             <_PackageManifestFiles Include="wwwroot\umbraco-package.json" />
         </ItemGroup>
         <JsonPathUpdateValue JsonFile="%(_PackageManifestFiles.FullPath)" Path="$.version" Value="&quot;$(PackageVersion)&quot;" />
+        <Exec Command="node &quot;$(RepoRoot)scripts/build/version-package-manifest.js&quot; &quot;$(PackageVersion)&quot; &quot;%(_PackageManifestFiles.FullPath)&quot;" />
     </Target>
     
 </Project>

--- a/scripts/build/version-package-manifest.js
+++ b/scripts/build/version-package-manifest.js
@@ -23,9 +23,17 @@ const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
 
 function addVersion(url) {
     if (!url || typeof url !== 'string') return url;
-    // Don't double-add version
-    if (url.includes('?v=')) return url;
-    return `${url}?v=${version}`;
+
+    const qIndex = url.indexOf('?');
+    if (qIndex === -1) {
+        return `${url}?v=${version}`;
+    }
+
+    // Preserve existing query params and set/update 'v'
+    const base = url.substring(0, qIndex);
+    const params = new URLSearchParams(url.substring(qIndex + 1));
+    params.set('v', version);
+    return `${base}?${params.toString()}`;
 }
 
 // Update js paths in extensions

--- a/scripts/build/version-package-manifest.js
+++ b/scripts/build/version-package-manifest.js
@@ -1,0 +1,48 @@
+/**
+ * Adds a version query string to all JS paths in umbraco-package.json
+ * to bust browser cache after package upgrades.
+ *
+ * The entry-point files (e.g. umbraco-ai-manifests.js) use stable names but
+ * dynamically import Vite-hashed chunks that change every build. Without
+ * cache-busting on the entry files themselves, browsers serve stale cached
+ * entry files that reference chunks which no longer exist after an upgrade.
+ *
+ * Usage: node version-package-manifest.js <version> <manifest-path>
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+
+const [,, version, manifestPath] = process.argv;
+
+if (!version || !manifestPath) {
+    console.error('Usage: node version-package-manifest.js <version> <manifest-path>');
+    process.exit(1);
+}
+
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+
+function addVersion(url) {
+    if (!url || typeof url !== 'string') return url;
+    // Don't double-add version
+    if (url.includes('?v=')) return url;
+    return `${url}?v=${version}`;
+}
+
+// Update js paths in extensions
+if (Array.isArray(manifest.extensions)) {
+    for (const ext of manifest.extensions) {
+        if (ext.js) {
+            ext.js = addVersion(ext.js);
+        }
+    }
+}
+
+// Update importmap imports
+if (manifest.importmap?.imports) {
+    for (const key of Object.keys(manifest.importmap.imports)) {
+        manifest.importmap.imports[key] = addVersion(manifest.importmap.imports[key]);
+    }
+}
+
+writeFileSync(manifestPath, JSON.stringify(manifest, null, 4) + '\n');
+console.log(`Added version query string (v=${version}) to JS paths in ${manifestPath}`);


### PR DESCRIPTION
Fixes #114

## Summary

- Extends the existing `UpdatePackageManifestVersion` MSBuild target in all five static asset projects to append `?v={PackageVersion}` to every JS path in `umbraco-package.json`
- Adds a new `scripts/build/version-package-manifest.js` Node.js script that handles the stamping
- Adds `$(RepoRoot)` property to `Directory.Build.targets` for cross-package script resolution

## How it works

Stable-named entry files (e.g. `umbraco-ai-manifests.js`) are cached by the browser across upgrades and contain dynamic imports of Vite-hashed chunks that change each build. By appending `?v=1.8.0` to the entry file URLs in `umbraco-package.json`, each version gets a distinct URL that the browser won't confuse with a cached older version.

Only runs on CI builds where `ContinuousIntegrationBuild=true` and `PackageVersion` is set by Nerdbank.GitVersioning.

Generated with [Claude Code](https://claude.ai/code)