### PR TITLE
fix: Preserve UTC DateTimeKind when serializing persisted datetimes

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Persistence/AuditLog/AIAuditLogFactory.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Persistence/AuditLog/AIAuditLogFactory.cs
@@ -33,8 +33,8 @@ internal static class AIAuditLogFactory
         return new AIAuditLog
         {
             Id = entity.Id,
-            StartTime = entity.StartTime,
-            EndTime = entity.EndTime,
+            StartTime = DateTime.SpecifyKind(entity.StartTime, DateTimeKind.Utc),
+            EndTime = entity.EndTime.HasValue ? DateTime.SpecifyKind(entity.EndTime.Value, DateTimeKind.Utc) : null,
             Status = (AIAuditLogStatus)entity.Status,
             ErrorCategory = entity.ErrorCategory.HasValue ? (AIAuditLogErrorCategory)entity.ErrorCategory.Value : null,
             ErrorMessage = entity.ErrorMessage,

--- a/Umbraco.AI/src/Umbraco.AI.Web/Api/Common/Json/UtcDateTimeJsonConverter.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Web/Api/Common/Json/UtcDateTimeJsonConverter.cs
@@ -30,8 +30,12 @@ public class UtcDateTimeJsonConverter : JsonConverter<DateTime>
     /// <inheritdoc />
     public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
     {
-        // Always convert to UTC and format with explicit "Z" suffix
-        var utcDateTime = value.Kind == DateTimeKind.Utc ? value : value.ToUniversalTime();
+        // Always convert to UTC and format with explicit "Z" suffix.
+        // Treat Unspecified as UTC (project convention: all persisted datetimes are UTC).
+        // Only Local kind needs actual conversion via ToUniversalTime().
+        var utcDateTime = value.Kind == DateTimeKind.Local
+            ? value.ToUniversalTime()
+            : DateTime.SpecifyKind(value, DateTimeKind.Utc);
         writer.WriteStringValue(utcDateTime.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"));
     }
 }
@@ -68,8 +72,12 @@ public class UtcNullableDateTimeJsonConverter : JsonConverter<DateTime?>
             return;
         }
 
-        // Always convert to UTC and format with explicit "Z" suffix
-        var utcDateTime = value.Value.Kind == DateTimeKind.Utc ? value.Value : value.Value.ToUniversalTime();
+        // Always convert to UTC and format with explicit "Z" suffix.
+        // Treat Unspecified as UTC (project convention: all persisted datetimes are UTC).
+        // Only Local kind needs actual conversion via ToUniversalTime().
+        var utcDateTime = value.Value.Kind == DateTimeKind.Local
+            ? value.Value.ToUniversalTime()
+            : DateTime.SpecifyKind(value.Value, DateTimeKind.Utc);
         writer.WriteStringValue(utcDateTime.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"));
     }
 }


### PR DESCRIPTION
Fixes a timezone offset bug where AI log timestamps were displayed incorrectly on non-UTC servers (e.g. IST dev machines).

IEF Core strips `DateTimeKind` when round-tripping datetimes through the database, returning `Unspecified`. `UtcDateTimeJsonConverter` was calling `ToUniversalTime()` on these, which treats `Unspecified` as local server time and applies a double UTC offset.

Two fixes:
1. `AIAuditLogFactory.BuildDomain()` now specifies UTC kind when mapping `StartTime` and `EndTime` from the entity
2. `UtcDateTimeJsonConverter` (both nullable and non-nullable) now treats `Unspecified` as UTC and only converts `Local` kind values

Fixes #108

Generated with [Claude Code](https://claude.ai/code)