### PR TITLE
fix(audit-log): Use CancellationToken.None for audit log queue operations

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Core/AuditLog/Middleware/AIAuditingChatClient.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/AuditLog/Middleware/AIAuditingChatClient.cs
@@ -50,6 +50,8 @@ internal sealed class AIAuditingChatClient : DelegatingChatClient
             var response = await InnerClient.GetResponseAsync(chatMessages, options, cancellationToken);
 
             // Complete audit-log (if exists)
+            // Use CancellationToken.None so the status update is always persisted,
+            // even if the original request was cancelled (e.g. client disconnected)
             if (auditLog is not null)
             {
                 await _auditLogService.QueueCompleteAuditLogAsync(
@@ -60,7 +62,7 @@ internal sealed class AIAuditingChatClient : DelegatingChatClient
                         Data = response.Messages,
                         Usage = response.Usage,
                     },
-                    cancellationToken);
+                    CancellationToken.None);
             }
 
             return response;
@@ -69,8 +71,10 @@ internal sealed class AIAuditingChatClient : DelegatingChatClient
         {
             if (auditLog is not null)
             {
+                // Use CancellationToken.None so the failure status is always persisted,
+                // even if the original request was cancelled (e.g. client disconnected)
                 await _auditLogService.QueueRecordAuditLogFailureAsync(
-                    auditLog, auditPrompt, ex, cancellationToken);
+                    auditLog, auditPrompt, ex, CancellationToken.None);
             }
 
             throw;
@@ -124,6 +128,8 @@ internal sealed class AIAuditingChatClient : DelegatingChatClient
         }
 
         // Mark audit-log as completed (only reached if no exception during streaming)
+        // Use CancellationToken.None so the status update is always persisted,
+        // even if the original request was cancelled (e.g. client disconnected)
         if (auditLog is not null)
         {
             var trackingChatClient = InnerClient.GetService<AITrackingChatClient>();
@@ -136,7 +142,7 @@ internal sealed class AIAuditingChatClient : DelegatingChatClient
                     Data = trackingChatClient?.LastResponseMessages,
                     Usage = trackingChatClient?.LastUsageDetails,
                 },
-                cancellationToken);
+                CancellationToken.None);
         }
 
         auditScope?.Dispose();
@@ -172,8 +178,10 @@ internal sealed class AIAuditingChatClient : DelegatingChatClient
             {
                 if (auditLog is not null)
                 {
+                    // Use CancellationToken.None so the failure status is always persisted,
+                    // even if the original request was cancelled (e.g. client disconnected)
                     await _auditLogService.QueueRecordAuditLogFailureAsync(
-                        auditLog, auditPrompt, ex, cancellationToken);
+                        auditLog, auditPrompt, ex, CancellationToken.None);
                 }
 
                 auditScope?.Dispose();

--- a/Umbraco.AI/src/Umbraco.AI.Core/AuditLog/Middleware/AIAuditingEmbeddingGenerator.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/AuditLog/Middleware/AIAuditingEmbeddingGenerator.cs
@@ -84,6 +84,8 @@ internal sealed class AIAuditingEmbeddingGenerator : DelegatingEmbeddingGenerato
             {
                 var trackingGenerator = InnerGenerator as AITrackingEmbeddingGenerator<string, Embedding<float>>;
 
+                // Use CancellationToken.None so the status update is always persisted,
+                // even if the original request was cancelled (e.g. client disconnected)
                 await _auditLogService.QueueCompleteAuditLogAsync(
                     auditLog,
                     auditPrompt,
@@ -92,7 +94,7 @@ internal sealed class AIAuditingEmbeddingGenerator : DelegatingEmbeddingGenerato
                         Usage = trackingGenerator?.LastUsageDetails,
                         Data = trackingGenerator?.LastEmbeddings
                     },
-                    cancellationToken);
+                    CancellationToken.None);
             }
 
             return result;
@@ -101,8 +103,10 @@ internal sealed class AIAuditingEmbeddingGenerator : DelegatingEmbeddingGenerato
         {
             if (auditLog is not null)
             {
+                // Use CancellationToken.None so the failure status is always persisted,
+                // even if the original request was cancelled (e.g. client disconnected)
                 await _auditLogService.QueueRecordAuditLogFailureAsync(
-                    auditLog, auditPrompt, ex, cancellationToken);
+                    auditLog, auditPrompt, ex, CancellationToken.None);
             }
 
             throw;

--- a/Umbraco.AI/src/Umbraco.AI.Core/AuditLog/Middleware/AIAuditingSpeechToTextClient.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/AuditLog/Middleware/AIAuditingSpeechToTextClient.cs
@@ -50,6 +50,8 @@ internal sealed class AIAuditingSpeechToTextClient : AIBoundSpeechToTextClientBa
             var response = await base.GetTextAsync(audioSpeechStream, options, cancellationToken);
 
             // Complete audit-log (if exists)
+            // Use CancellationToken.None so the status update is always persisted,
+            // even if the original request was cancelled (e.g. client disconnected)
             if (auditLog is not null)
             {
                 await _auditLogService.QueueCompleteAuditLogAsync(
@@ -59,7 +61,7 @@ internal sealed class AIAuditingSpeechToTextClient : AIBoundSpeechToTextClientBa
                     {
                         Data = response.Text,
                     },
-                    cancellationToken);
+                    CancellationToken.None);
             }
 
             return response;
@@ -68,8 +70,10 @@ internal sealed class AIAuditingSpeechToTextClient : AIBoundSpeechToTextClientBa
         {
             if (auditLog is not null)
             {
+                // Use CancellationToken.None so the failure status is always persisted,
+                // even if the original request was cancelled (e.g. client disconnected)
                 await _auditLogService.QueueRecordAuditLogFailureAsync(
-                    auditLog, auditPrompt, ex, cancellationToken);
+                    auditLog, auditPrompt, ex, CancellationToken.None);
             }
 
             throw;
@@ -121,6 +125,8 @@ internal sealed class AIAuditingSpeechToTextClient : AIBoundSpeechToTextClientBa
         }
 
         // Mark audit-log as completed (only reached if no exception during streaming)
+        // Use CancellationToken.None so the status update is always persisted,
+        // even if the original request was cancelled (e.g. client disconnected)
         if (auditLog is not null)
         {
             var trackingClient = InnerClient.GetService<AITrackingSpeechToTextClient>();
@@ -132,7 +138,7 @@ internal sealed class AIAuditingSpeechToTextClient : AIBoundSpeechToTextClientBa
                 {
                     Data = trackingClient?.LastTranscriptionText,
                 },
-                cancellationToken);
+                CancellationToken.None);
         }
 
         auditScope?.Dispose();
@@ -168,8 +174,10 @@ internal sealed class AIAuditingSpeechToTextClient : AIBoundSpeechToTextClientBa
             {
                 if (auditLog is not null)
                 {
+                    // Use CancellationToken.None so the failure status is always persisted,
+                    // even if the original request was cancelled (e.g. client disconnected)
                     await _auditLogService.QueueRecordAuditLogFailureAsync(
-                        auditLog, auditPrompt, ex, cancellationToken);
+                        auditLog, auditPrompt, ex, CancellationToken.None);
                 }
 
                 auditScope?.Dispose();

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Middleware/AIAuditingChatClientTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Middleware/AIAuditingChatClientTests.cs
@@ -1,0 +1,166 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Options;
+using Umbraco.AI.Core.AuditLog;
+using Umbraco.AI.Core.AuditLog.Middleware;
+using Umbraco.AI.Core.Models;
+using Umbraco.AI.Core.RuntimeContext;
+using Umbraco.AI.Tests.Common.Fakes;
+
+namespace Umbraco.AI.Tests.Unit.Middleware;
+
+public class AIAuditingChatClientTests
+{
+    private readonly Mock<IAIRuntimeContextAccessor> _contextAccessorMock;
+    private readonly Mock<IAIAuditLogService> _auditLogServiceMock;
+    private readonly Mock<IAIAuditLogFactory> _auditLogFactoryMock;
+    private readonly IOptionsMonitor<AIAuditLogOptions> _auditLogOptions;
+    private readonly AIAuditLog _auditLog;
+
+    public AIAuditingChatClientTests()
+    {
+        _contextAccessorMock = new Mock<IAIRuntimeContextAccessor>();
+        _auditLogServiceMock = new Mock<IAIAuditLogService>();
+        _auditLogFactoryMock = new Mock<IAIAuditLogFactory>();
+
+        var optionsMock = new Mock<IOptionsMonitor<AIAuditLogOptions>>();
+        optionsMock.Setup(x => x.CurrentValue).Returns(new AIAuditLogOptions { Enabled = true });
+        _auditLogOptions = optionsMock.Object;
+
+        _auditLog = new AIAuditLog { Id = Guid.NewGuid() };
+        _auditLogFactoryMock
+            .Setup(x => x.Create(It.IsAny<AIAuditContext>(), It.IsAny<IReadOnlyDictionary<string, string>?>(), It.IsAny<Guid?>()))
+            .Returns(_auditLog);
+
+        // Enable auditing by returning a non-null runtime context
+        var runtimeContext = new AIRuntimeContext([]);
+        _contextAccessorMock.Setup(x => x.Context).Returns(runtimeContext);
+
+        _auditLogServiceMock
+            .Setup(x => x.QueueStartAuditLogAsync(It.IsAny<AIAuditLog>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
+        _auditLogServiceMock
+            .Setup(x => x.QueueCompleteAuditLogAsync(It.IsAny<AIAuditLog>(), It.IsAny<AIAuditPrompt?>(), It.IsAny<AIAuditResponse?>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
+        _auditLogServiceMock
+            .Setup(x => x.QueueRecordAuditLogFailureAsync(It.IsAny<AIAuditLog>(), It.IsAny<AIAuditPrompt?>(), It.IsAny<Exception>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_OnSuccess_QueuesCompletionWithNoneToken()
+    {
+        // Arrange
+        var client = CreateClient(new FakeChatClient("response"));
+
+        // Act
+        await client.GetResponseAsync([new ChatMessage(ChatRole.User, "hello")]);
+
+        // Assert — status update must use CancellationToken.None so it isn't skipped on disconnects
+        _auditLogServiceMock.Verify(x => x.QueueCompleteAuditLogAsync(
+            _auditLog,
+            It.IsAny<AIAuditPrompt?>(),
+            It.IsAny<AIAuditResponse?>(),
+            CancellationToken.None), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_OnException_QueuesFailureWithNoneToken()
+    {
+        // Arrange — inner client throws regardless of cancellation token state
+        var innerClient = new FakeChatClient((_, _, _) => Task.FromException<ChatResponse>(new InvalidOperationException("AI error")));
+        var client = CreateClient(innerClient);
+
+        // Use an already-cancelled token to simulate client disconnection
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act & Assert
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            client.GetResponseAsync([new ChatMessage(ChatRole.User, "hello")], cancellationToken: cts.Token));
+
+        // The failure must be recorded with CancellationToken.None so it isn't dropped when the
+        // request token is cancelled (the original cause of entries being stuck in "Running")
+        _auditLogServiceMock.Verify(x => x.QueueRecordAuditLogFailureAsync(
+            _auditLog,
+            It.IsAny<AIAuditPrompt?>(),
+            It.IsAny<Exception>(),
+            CancellationToken.None), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_OnSuccess_QueuesCompletionWithNoneToken()
+    {
+        // Arrange
+        var client = CreateClient(new FakeChatClient("hello world"));
+
+        // Act — consume the stream fully
+        await foreach (var _ in client.GetStreamingResponseAsync([new ChatMessage(ChatRole.User, "hi")]))
+        {
+        }
+
+        // Assert
+        _auditLogServiceMock.Verify(x => x.QueueCompleteAuditLogAsync(
+            _auditLog,
+            It.IsAny<AIAuditPrompt?>(),
+            It.IsAny<AIAuditResponse?>(),
+            CancellationToken.None), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_OnException_QueuesFailureWithNoneToken()
+    {
+        // Arrange — inner client throws during streaming
+        var throwingClient = new ThrowingStreamingChatClient(new HttpRequestException("Connection reset"));
+        var client = CreateClient(throwingClient);
+
+        // Act & Assert
+        await Should.ThrowAsync<HttpRequestException>(async () =>
+        {
+            await foreach (var _ in client.GetStreamingResponseAsync([new ChatMessage(ChatRole.User, "hi")]))
+            {
+            }
+        });
+
+        // The failure must be recorded with CancellationToken.None so it isn't dropped when the
+        // request token is cancelled (the original cause of entries being stuck in "Running")
+        _auditLogServiceMock.Verify(x => x.QueueRecordAuditLogFailureAsync(
+            _auditLog,
+            It.IsAny<AIAuditPrompt?>(),
+            It.IsAny<Exception>(),
+            CancellationToken.None), Times.Once);
+    }
+
+    private AIAuditingChatClient CreateClient(IChatClient innerClient) =>
+        new(innerClient, _contextAccessorMock.Object, _auditLogServiceMock.Object,
+            _auditLogFactoryMock.Object, _auditLogOptions);
+
+    /// <summary>
+    /// A chat client whose streaming implementation throws on the first MoveNextAsync call.
+    /// Used to simulate connection resets and similar mid-stream errors.
+    /// </summary>
+    private sealed class ThrowingStreamingChatClient : IChatClient
+    {
+        private readonly Exception _exception;
+
+        public ThrowingStreamingChatClient(Exception exception) => _exception = exception;
+
+        public Task<ChatResponse> GetResponseAsync(IEnumerable<ChatMessage> chatMessages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+            => Task.FromException<ChatResponse>(_exception);
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> chatMessages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            throw _exception;
+#pragma warning disable CS0162 // Unreachable code - required to satisfy IAsyncEnumerable<T> return type
+            yield break;
+#pragma warning restore CS0162
+        }
+
+        public ChatClientMetadata Metadata => new("ThrowingClient", null, null);
+        public object? GetService(Type serviceType, object? key = null) => null;
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
Fixes #109

Audit log entries were getting stuck in "Running" status when the original HTTP request was cancelled (e.g. client disconnect, timeout). The queue operations for recording completion or failure used the request's CancellationToken, which was already cancelled in those scenarios.

Fix by passing CancellationToken.None to QueueCompleteAuditLogAsync and QueueRecordAuditLogFailureAsync across all three auditing middleware clients (chat, embedding, speech-to-text).

Generated with [Claude Code](https://claude.ai/code)