### PR TITLE
feat(core,prompt): Image crop syntax + auto-downscale for AI prompts

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -77,6 +77,7 @@
   <ItemGroup>
     <PackageVersion Include="DocumentFormat.OpenXml" Version="[3.3.0, 3.999.999)" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="[10.0.0, 10.999.999)" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="[3.1.11, 3.999.999)" />
     <PackageVersion Include="SmartReader" Version="0.11.0" />
   </ItemGroup>
 

--- a/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/packages.lock.json
+++ b/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/packages.lock.json
@@ -1443,6 +1443,7 @@
           "Microsoft.Extensions.AI": "[10.2.0, )",
           "Microsoft.Extensions.Caching.Memory": "[10.0.0, 10.999.999)",
           "Microsoft.Extensions.Options": "[10.0.0, 10.999.999)",
+          "SixLabors.ImageSharp": "[3.1.11, 3.999.999)",
           "SmartReader": "[0.11.0, )",
           "Umbraco.Cms.Api.Management": "[17.1.0, 17.999.999)",
           "Umbraco.Cms.Core": "[17.1.0, 17.999.999)",
@@ -1494,6 +1495,12 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
           "Microsoft.Extensions.Primitives": "10.0.0"
         }
+      },
+      "SixLabors.ImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[3.1.11, 3.999.999)",
+        "resolved": "3.1.11",
+        "contentHash": "JfPLyigLthuE50yi6tMt7Amrenr/fA31t2CvJyhy/kQmfulIBAqo5T/YFUSRHtuYPXRSaUHygFeh6Qd933EoSw=="
       },
       "SmartReader": {
         "type": "CentralTransitive",

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/packages.lock.json
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/packages.lock.json
@@ -1418,6 +1418,7 @@
           "Microsoft.Extensions.AI": "[10.2.0, )",
           "Microsoft.Extensions.Caching.Memory": "[10.0.0, 10.999.999)",
           "Microsoft.Extensions.Options": "[10.0.0, 10.999.999)",
+          "SixLabors.ImageSharp": "[3.1.11, 3.999.999)",
           "SmartReader": "[0.11.0, )",
           "Umbraco.Cms.Api.Management": "[17.1.0, 17.999.999)",
           "Umbraco.Cms.Core": "[17.1.0, 17.999.999)",
@@ -1469,6 +1470,12 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
           "Microsoft.Extensions.Primitives": "10.0.0"
         }
+      },
+      "SixLabors.ImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[3.1.11, 3.999.999)",
+        "resolved": "3.1.11",
+        "contentHash": "JfPLyigLthuE50yi6tMt7Amrenr/fA31t2CvJyhy/kQmfulIBAqo5T/YFUSRHtuYPXRSaUHygFeh6Qd933EoSw=="
       },
       "SmartReader": {
         "type": "CentralTransitive",

--- a/Umbraco.AI.Google/src/Umbraco.AI.Google/packages.lock.json
+++ b/Umbraco.AI.Google/src/Umbraco.AI.Google/packages.lock.json
@@ -1464,6 +1464,7 @@
           "Microsoft.Extensions.AI": "[10.2.0, )",
           "Microsoft.Extensions.Caching.Memory": "[10.0.0, 10.999.999)",
           "Microsoft.Extensions.Options": "[10.0.0, 10.999.999)",
+          "SixLabors.ImageSharp": "[3.1.11, 3.999.999)",
           "SmartReader": "[0.11.0, )",
           "Umbraco.Cms.Api.Management": "[17.1.0, 17.999.999)",
           "Umbraco.Cms.Core": "[17.1.0, 17.999.999)",
@@ -1515,6 +1516,12 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
           "Microsoft.Extensions.Primitives": "10.0.0"
         }
+      },
+      "SixLabors.ImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[3.1.11, 3.999.999)",
+        "resolved": "3.1.11",
+        "contentHash": "JfPLyigLthuE50yi6tMt7Amrenr/fA31t2CvJyhy/kQmfulIBAqo5T/YFUSRHtuYPXRSaUHygFeh6Qd933EoSw=="
       },
       "SmartReader": {
         "type": "CentralTransitive",

--- a/Umbraco.AI.MicrosoftFoundry/src/Umbraco.AI.MicrosoftFoundry/packages.lock.json
+++ b/Umbraco.AI.MicrosoftFoundry/src/Umbraco.AI.MicrosoftFoundry/packages.lock.json
@@ -1503,6 +1503,7 @@
           "Microsoft.Extensions.AI": "[10.2.0, )",
           "Microsoft.Extensions.Caching.Memory": "[10.0.0, 10.999.999)",
           "Microsoft.Extensions.Options": "[10.0.0, 10.999.999)",
+          "SixLabors.ImageSharp": "[3.1.11, 3.999.999)",
           "SmartReader": "[0.11.0, )",
           "Umbraco.Cms.Api.Management": "[17.1.0, 17.999.999)",
           "Umbraco.Cms.Core": "[17.1.0, 17.999.999)",
@@ -1554,6 +1555,12 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
           "Microsoft.Extensions.Primitives": "10.0.3"
         }
+      },
+      "SixLabors.ImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[3.1.11, 3.999.999)",
+        "resolved": "3.1.11",
+        "contentHash": "JfPLyigLthuE50yi6tMt7Amrenr/fA31t2CvJyhy/kQmfulIBAqo5T/YFUSRHtuYPXRSaUHygFeh6Qd933EoSw=="
       },
       "SmartReader": {
         "type": "CentralTransitive",

--- a/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/packages.lock.json
+++ b/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/packages.lock.json
@@ -1441,6 +1441,7 @@
           "Microsoft.Extensions.AI": "[10.2.0, )",
           "Microsoft.Extensions.Caching.Memory": "[10.0.0, 10.999.999)",
           "Microsoft.Extensions.Options": "[10.0.0, 10.999.999)",
+          "SixLabors.ImageSharp": "[3.1.11, 3.999.999)",
           "SmartReader": "[0.11.0, )",
           "Umbraco.Cms.Api.Management": "[17.1.0, 17.999.999)",
           "Umbraco.Cms.Core": "[17.1.0, 17.999.999)",
@@ -1492,6 +1493,12 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
           "Microsoft.Extensions.Primitives": "10.0.0"
         }
+      },
+      "SixLabors.ImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[3.1.11, 3.999.999)",
+        "resolved": "3.1.11",
+        "contentHash": "JfPLyigLthuE50yi6tMt7Amrenr/fA31t2CvJyhy/kQmfulIBAqo5T/YFUSRHtuYPXRSaUHygFeh6Qd933EoSw=="
       },
       "SmartReader": {
         "type": "CentralTransitive",

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptService.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptService.cs
@@ -235,6 +235,15 @@ internal sealed class AIPromptService : IAIPromptService
             runtimeContext.SetValue(CoreConstants.ContextKeys.EntityId, request.EntityId);
         }
 
+        // If no EntityType was set by contributors, use request.EntityType as fallback.
+        // Downstream resolvers (e.g. ContentContextResolver) rely on this to route to
+        // the correct published cache — without it, media-scoped prompts would query
+        // the document cache with a media key and fail to materialise the node.
+        if (!runtimeContext.Data.ContainsKey(CoreConstants.ContextKeys.EntityType) && !string.IsNullOrEmpty(request.EntityType))
+        {
+            runtimeContext.SetValue(CoreConstants.ContextKeys.EntityType, request.EntityType);
+        }
+
         // If no ElementId was set by contributors, use request.ElementId as fallback
         if (!runtimeContext.Data.ContainsKey(CoreConstants.ContextKeys.ElementId) && request.ElementId.HasValue && request.ElementId.Value != Guid.Empty)
         {

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Templates/Processors/ImageTemplateVariableProcessor.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Templates/Processors/ImageTemplateVariableProcessor.cs
@@ -9,7 +9,11 @@ namespace Umbraco.AI.Prompt.Core.Templates.Processors;
 
 /// <summary>
 /// Template variable processor that handles image content.
-/// Handles prefixed variables like {{image:umbracoFile}} or {{image:mediaProperty}}.
+/// Handles prefixed variables like <c>{{image:umbracoFile}}</c> or
+/// <c>{{image:umbracoFile#cropAlias}}</c>. Everything after the first
+/// <c>#</c> in the path is treated as an image cropper crop alias and
+/// applied via <see cref="IAIUmbracoMediaResolver"/> before the image
+/// is sent to the AI provider.
 /// Fetches the property value from the current entity using Umbraco's content/media services.
 /// Returns the image followed by a reference name that the AI can use to identify it.
 /// </summary>
@@ -42,7 +46,12 @@ internal sealed class ImageTemplateVariableProcessor : IAITemplateVariableProces
         ArgumentNullException.ThrowIfNull(context);
 
         var results = new List<AIContent>();
-        
+
+        // Split the path on '#' to separate the property alias from an optional crop alias.
+        // Property aliases are identifier-safe and can never contain '#', so the first '#'
+        // cleanly marks the crop suffix.
+        var (propertyAlias, cropAlias) = SplitPath(path);
+
         // Get the entity ID and type from context
         if (!TryGetEntityInfo(context, out var entityId, out var entityType))
         {
@@ -62,15 +71,15 @@ internal sealed class ImageTemplateVariableProcessor : IAITemplateVariableProces
         }
 
         // Get the property value
-        var propertyValue = entity.GetValue(path);
+        var propertyValue = entity.GetValue(propertyAlias);
         if (propertyValue is null)
         {
             _logger.LogWarning("Cannot process image variable '{Path}': property not found on entity {EntityId}", path, entityId);
             return results;
         }
 
-        // Use the media resolver to get the image content
-        var imageContent = await _mediaResolver.ResolveAsync(propertyValue, cancellationToken);
+        // Use the media resolver to get the image content, applying the crop when specified.
+        var imageContent = await _mediaResolver.ResolveAsync(propertyValue, cropAlias, cancellationToken);
         if (imageContent is null)
         {
             _logger.LogWarning("Cannot process image variable '{Path}': failed to resolve image from property value", path);
@@ -80,15 +89,36 @@ internal sealed class ImageTemplateVariableProcessor : IAITemplateVariableProces
         // Return the image as DataContent
         results.Add(new DataContent(imageContent.Data, imageContent.MediaType));
 
-        // Return a reference name that the AI can use to identify this image
-        // Use the entity name if available, otherwise use the property alias
-        var referenceName = !string.IsNullOrWhiteSpace(entity.Name)
+        // Return a reference name that the AI can use to identify this image.
+        // When a crop was requested, include the crop alias so the AI can distinguish
+        // multiple crops of the same source image in a single prompt.
+        var baseName = !string.IsNullOrWhiteSpace(entity.Name)
             ? entity.Name
-            : $"image_{path}";
+            : $"image_{propertyAlias}";
+
+        var referenceName = string.IsNullOrWhiteSpace(cropAlias)
+            ? baseName
+            : $"{baseName} ({cropAlias})";
 
         results.Add(new TextContent($" [Image: {referenceName}]"));
 
         return results;
+    }
+
+    private static (string PropertyAlias, string? CropAlias) SplitPath(string path)
+    {
+        var hashIndex = path.IndexOf('#');
+        if (hashIndex < 0)
+        {
+            return (path, null);
+        }
+
+        var propertyAlias = path[..hashIndex];
+        var cropAlias = path[(hashIndex + 1)..];
+
+        return (
+            propertyAlias,
+            string.IsNullOrWhiteSpace(cropAlias) ? null : cropAlias);
     }
 
     private static bool TryGetEntityInfo(IReadOnlyDictionary<string, object?> context, out Guid entityId, out string entityType)

--- a/Umbraco.AI.Prompt/tests/Umbraco.AI.Prompt.Tests.Unit/Prompts/AIPromptTemplateServiceTests.cs
+++ b/Umbraco.AI.Prompt/tests/Umbraco.AI.Prompt.Tests.Unit/Prompts/AIPromptTemplateServiceTests.cs
@@ -193,7 +193,7 @@ public class AIPromptTemplateServiceTests
         _mockMediaService.Setup(s => s.GetById(entityId)).Returns(mockMedia.Object);
 
         _mockImageResolver
-            .Setup(r => r.ResolveAsync(It.IsAny<object?>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.ResolveAsync(It.IsAny<object?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new AIMediaContent { Data = new byte[] { 1, 2, 3 }, MediaType = "image/png" });
 
         // Act
@@ -224,7 +224,7 @@ public class AIPromptTemplateServiceTests
         _mockMediaService.Setup(s => s.GetById(entityId)).Returns(mockMedia.Object);
 
         _mockImageResolver
-            .Setup(r => r.ResolveAsync(It.IsAny<object?>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.ResolveAsync(It.IsAny<object?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((AIMediaContent?)null);
 
         // Act
@@ -457,7 +457,7 @@ public class AIPromptTemplateServiceTests
         _mockMediaService.Setup(s => s.GetById(entityId)).Returns(mockMedia.Object);
 
         _mockImageResolver
-            .Setup(r => r.ResolveAsync(imagePath, It.IsAny<CancellationToken>()))
+            .Setup(r => r.ResolveAsync(imagePath, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new AIMediaContent { Data = new byte[] { 1, 2, 3 }, MediaType = mediaType });
     }
 

--- a/Umbraco.AI.Prompt/tests/Umbraco.AI.Prompt.Tests.Unit/Templates/ImageTemplateVariableProcessorTests.cs
+++ b/Umbraco.AI.Prompt/tests/Umbraco.AI.Prompt.Tests.Unit/Templates/ImageTemplateVariableProcessorTests.cs
@@ -53,7 +53,7 @@ public class ImageTemplateVariableProcessorTests
         _mockMediaService.Setup(s => s.GetById(entityId)).Returns(mockMedia);
 
         _mockResolver
-            .Setup(r => r.ResolveAsync("/media/12345/image.png", It.IsAny<CancellationToken>()))
+            .Setup(r => r.ResolveAsync("/media/12345/image.png", It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new AIMediaContent { Data = imageData, MediaType = "image/png" });
 
         // Act
@@ -82,7 +82,7 @@ public class ImageTemplateVariableProcessorTests
         _mockContentService.Setup(s => s.GetById(entityId)).Returns(mockContent);
 
         _mockResolver
-            .Setup(r => r.ResolveAsync("/media/uploads/photo.jpg", It.IsAny<CancellationToken>()))
+            .Setup(r => r.ResolveAsync("/media/uploads/photo.jpg", It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new AIMediaContent { Data = imageData, MediaType = "image/jpeg" });
 
         // Act
@@ -95,6 +95,53 @@ public class ImageTemplateVariableProcessorTests
         ((TextContent)result[1]).Text.ShouldBe(" [Image: Test Content]");
         _mockContentService.Verify(s => s.GetById(entityId), Times.Once);
         _mockMediaService.Verify(s => s.GetById(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithCropSuffix_ForwardsCropAliasAndAnnotatesReferenceName()
+    {
+        // Arrange
+        var entityId = Guid.NewGuid();
+        var imageData = new byte[] { 0xFF, 0xD8, 0xFF };
+        var context = CreateContext(entityId, "media");
+
+        var mockMedia = CreateMockMedia("/media/hero.png", "Hero Image");
+        _mockMediaService.Setup(s => s.GetById(entityId)).Returns(mockMedia);
+
+        _mockResolver
+            .Setup(r => r.ResolveAsync("/media/hero.png", "content3Col", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AIMediaContent { Data = imageData, MediaType = "image/jpeg" });
+
+        // Act
+        var result = (await _processor.ProcessAsync("umbracoFile#content3Col", context)).ToList();
+
+        // Assert
+        result.Count.ShouldBe(2);
+        ((TextContent)result[1]).Text.ShouldBe(" [Image: Hero Image (content3Col)]");
+        _mockResolver.Verify(
+            r => r.ResolveAsync("/media/hero.png", "content3Col", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithEmptyCropSuffix_TreatsAsNoCrop()
+    {
+        // {{image:umbracoFile#}} should be indistinguishable from {{image:umbracoFile}}
+        var entityId = Guid.NewGuid();
+        var imageData = new byte[] { 0xFF, 0xD8, 0xFF };
+        var context = CreateContext(entityId, "media");
+
+        var mockMedia = CreateMockMedia("/media/hero.png", "Hero");
+        _mockMediaService.Setup(s => s.GetById(entityId)).Returns(mockMedia);
+
+        _mockResolver
+            .Setup(r => r.ResolveAsync("/media/hero.png", (string?)null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AIMediaContent { Data = imageData, MediaType = "image/jpeg" });
+
+        var result = (await _processor.ProcessAsync("umbracoFile#", context)).ToList();
+
+        result.Count.ShouldBe(2);
+        ((TextContent)result[1]).Text.ShouldBe(" [Image: Hero]");
     }
 
     [Fact]
@@ -176,7 +223,7 @@ public class ImageTemplateVariableProcessorTests
         _mockMediaService.Setup(s => s.GetById(entityId)).Returns(mockMedia);
 
         _mockResolver
-            .Setup(r => r.ResolveAsync(It.IsAny<object?>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.ResolveAsync(It.IsAny<object?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((AIMediaContent?)null);
 
         // Act
@@ -201,7 +248,7 @@ public class ImageTemplateVariableProcessorTests
         _mockMediaService.Setup(s => s.GetById(entityId)).Returns(mockMedia);
 
         _mockResolver
-            .Setup(r => r.ResolveAsync(It.IsAny<object?>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.ResolveAsync(It.IsAny<object?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new AIMediaContent { Data = new byte[] { 1, 2, 3 }, MediaType = "image/png" });
 
         // Act
@@ -227,7 +274,7 @@ public class ImageTemplateVariableProcessorTests
         _mockMediaService.Setup(s => s.GetById(entityId)).Returns(mockMedia);
 
         _mockResolver
-            .Setup(r => r.ResolveAsync(It.IsAny<object?>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.ResolveAsync(It.IsAny<object?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new AIMediaContent { Data = new byte[] { 1, 2, 3 }, MediaType = "image/png" });
 
         // Act
@@ -251,7 +298,7 @@ public class ImageTemplateVariableProcessorTests
         _mockMediaService.Setup(s => s.GetById(entityId)).Returns(mockMedia);
 
         _mockResolver
-            .Setup(r => r.ResolveAsync(It.IsAny<object?>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.ResolveAsync(It.IsAny<object?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new AIMediaContent { Data = new byte[] { 1, 2, 3 }, MediaType = "image/png" });
 
         // Act
@@ -290,7 +337,7 @@ public class ImageTemplateVariableProcessorTests
         _mockMediaService.Setup(s => s.GetById(entityId)).Returns(mockMedia);
 
         _mockResolver
-            .Setup(r => r.ResolveAsync(It.IsAny<object?>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.ResolveAsync(It.IsAny<object?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new AIMediaContent { Data = new byte[] { 1, 2, 3 }, MediaType = "image/png" });
 
         // Act

--- a/Umbraco.AI/src/Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.cs
@@ -16,6 +16,7 @@ using Umbraco.AI.Core.Contexts.Resolvers;
 using Umbraco.AI.Core.Contexts.ResourceTypes;
 using Umbraco.AI.Core.EditableModels;
 using Umbraco.AI.Core.FileProcessing;
+using Umbraco.AI.Core.Media;
 using Umbraco.AI.Core.Embeddings;
 using Umbraco.AI.Core.EntityAdapter;
 using Umbraco.AI.Core.EntityAdapter.Adapters;
@@ -66,6 +67,9 @@ public static partial class UmbracoBuilderExtensions
 
         // Bind AIAnalyticsOptions from "Umbraco:AI:Analytics" section
         services.Configure<AIAnalyticsOptions>(config.GetSection("Umbraco:AI:Analytics"));
+
+        // Bind AIMediaOptions from "Umbraco:AI:Media" section
+        services.Configure<AIMediaOptions>(config.GetSection("Umbraco:AI:Media"));
 
         // Security infrastructure
         services.AddSingleton<IAISensitiveFieldProtector, AISensitiveFieldProtector>();

--- a/Umbraco.AI/src/Umbraco.AI.Core/Contexts/Resolvers/ContentContextResolver.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Contexts/Resolvers/ContentContextResolver.cs
@@ -7,19 +7,24 @@ using Umbraco.Extensions;
 namespace Umbraco.AI.Core.Contexts.Resolvers;
 
 /// <summary>
-/// Resolves context from content nodes by finding the nearest context picker property value.
+/// Resolves context from document or media nodes by finding the nearest context picker property value.
 /// </summary>
 /// <remarks>
 /// <para>
-/// This resolver reads the content ID from <see cref="IAIRuntimeContextAccessor"/>, preferring
+/// This resolver reads the entity ID from <see cref="IAIRuntimeContextAccessor"/>, preferring
 /// <see cref="AIRuntimeContextKeys.ParentEntityId"/> (for new entities) over
-/// <see cref="AIRuntimeContextKeys.EntityId"/>. It then walks up the content tree
-/// (current node + ancestors) to find the nearest property using the AI Context
-/// Picker editor (<c>Uai.ContextPicker</c>).
+/// <see cref="AIRuntimeContextKeys.EntityId"/>, dispatches to the document or media
+/// published cache based on <see cref="AIRuntimeContextKeys.EntityType"/>, then walks
+/// up the tree (current node + ancestors) to find the nearest property using the AI
+/// Context Picker editor (<c>Uai.ContextPicker</c>).
 /// </para>
 /// <para>
 /// The first non-empty context picker value found while walking up the tree is used.
-/// This allows content to inherit context from parent/ancestor nodes.
+/// This allows items to inherit context from parent/ancestor nodes.
+/// </para>
+/// <para>
+/// Members are skipped because members do not form a tree that can be walked for
+/// inherited context values.
 /// </para>
 /// </remarks>
 internal sealed class ContentContextResolver : IAIContextResolver
@@ -59,13 +64,10 @@ internal sealed class ContentContextResolver : IAIContextResolver
             return AIContextResolverResult.Empty;
         }
 
-        // This resolver walks the document tree. If we know the entity being
-        // edited is a media or member, skip early — the document cache has no
-        // entry for those keys and Umbraco's HybridCache would throw a
-        // "content type not found" inside GetById trying to materialise them.
+        // Members have no tree to walk for inherited context picker values, so
+        // there's nothing meaningful to resolve for them.
         var entityType = _runtimeContextAccessor.Context?.GetValue<string>(Constants.ContextKeys.EntityType);
-        if (!string.IsNullOrEmpty(entityType)
-            && !string.Equals(entityType, "document", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(entityType, "member", StringComparison.OrdinalIgnoreCase))
         {
             return AIContextResolverResult.Empty;
         }
@@ -73,21 +75,26 @@ internal sealed class ContentContextResolver : IAIContextResolver
         // Ensure UmbracoContext exists (not automatically created for backoffice API requests)
         using var contextReference = _umbracoContextFactory.EnsureUmbracoContext();
 
-        // Get the published content. GetById materialises the cached node and
-        // can throw when the node references a content type that can no longer
-        // be resolved (e.g. the type was deleted, or a caller unexpectedly
-        // passed a non-document key without setting EntityType). Treat those
-        // as "no document context available" rather than failing the prompt.
+        // Dispatch to the appropriate published cache based on the entity type.
+        // Both caches return IPublishedContent, so the tree-walking logic below
+        // is identical for documents and media. GetById materialises the cached
+        // node and can throw when the node's content type can no longer be
+        // resolved (e.g. type deleted, or a document key passed against the
+        // media cache); treat any such failure as "no context available"
+        // rather than aborting the whole prompt.
         IPublishedContent? content;
         try
         {
-            content = contextReference.UmbracoContext.Content?.GetById(contentId.Value);
+            content = string.Equals(entityType, "media", StringComparison.OrdinalIgnoreCase)
+                ? contextReference.UmbracoContext.Media?.GetById(contentId.Value)
+                : contextReference.UmbracoContext.Content?.GetById(contentId.Value);
         }
         catch (Exception ex)
         {
             _logger.LogWarning(
                 ex,
-                "Failed to resolve content {ContentId} for context injection; skipping document context",
+                "Failed to resolve {EntityType} {ContentId} for context injection; skipping",
+                entityType ?? "document",
                 contentId.Value);
             return AIContextResolverResult.Empty;
         }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Contexts/Resolvers/ContentContextResolver.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Contexts/Resolvers/ContentContextResolver.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Umbraco.AI.Core.RuntimeContext;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Web;
@@ -26,6 +27,7 @@ internal sealed class ContentContextResolver : IAIContextResolver
     private readonly IAIRuntimeContextAccessor _runtimeContextAccessor;
     private readonly IAIContextService _contextService;
     private readonly IUmbracoContextFactory _umbracoContextFactory;
+    private readonly ILogger<ContentContextResolver> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ContentContextResolver"/> class.
@@ -33,14 +35,17 @@ internal sealed class ContentContextResolver : IAIContextResolver
     /// <param name="runtimeContextAccessor">The runtime context accessor.</param>
     /// <param name="contextService">The context service.</param>
     /// <param name="umbracoContextFactory">The Umbraco context factory.</param>
+    /// <param name="logger">The logger.</param>
     public ContentContextResolver(
         IAIRuntimeContextAccessor runtimeContextAccessor,
         IAIContextService contextService,
-        IUmbracoContextFactory umbracoContextFactory)
+        IUmbracoContextFactory umbracoContextFactory,
+        ILogger<ContentContextResolver> logger)
     {
         _runtimeContextAccessor = runtimeContextAccessor;
         _contextService = contextService;
         _umbracoContextFactory = umbracoContextFactory;
+        _logger = logger;
     }
 
     /// <inheritdoc />
@@ -54,11 +59,39 @@ internal sealed class ContentContextResolver : IAIContextResolver
             return AIContextResolverResult.Empty;
         }
 
+        // This resolver walks the document tree. If we know the entity being
+        // edited is a media or member, skip early — the document cache has no
+        // entry for those keys and Umbraco's HybridCache would throw a
+        // "content type not found" inside GetById trying to materialise them.
+        var entityType = _runtimeContextAccessor.Context?.GetValue<string>(Constants.ContextKeys.EntityType);
+        if (!string.IsNullOrEmpty(entityType)
+            && !string.Equals(entityType, "document", StringComparison.OrdinalIgnoreCase))
+        {
+            return AIContextResolverResult.Empty;
+        }
+
         // Ensure UmbracoContext exists (not automatically created for backoffice API requests)
         using var contextReference = _umbracoContextFactory.EnsureUmbracoContext();
 
-        // Get the published content
-        var content = contextReference.UmbracoContext.Content?.GetById(contentId.Value);
+        // Get the published content. GetById materialises the cached node and
+        // can throw when the node references a content type that can no longer
+        // be resolved (e.g. the type was deleted, or a caller unexpectedly
+        // passed a non-document key without setting EntityType). Treat those
+        // as "no document context available" rather than failing the prompt.
+        IPublishedContent? content;
+        try
+        {
+            content = contextReference.UmbracoContext.Content?.GetById(contentId.Value);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to resolve content {ContentId} for context injection; skipping document context",
+                contentId.Value);
+            return AIContextResolverResult.Empty;
+        }
+
         if (content is null)
         {
             return AIContextResolverResult.Empty;

--- a/Umbraco.AI/src/Umbraco.AI.Core/Media/AIImageCropper.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Media/AIImageCropper.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Logging;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Processing;
 
 namespace Umbraco.AI.Core.Media;
@@ -81,14 +80,7 @@ internal static class AIImageCropper
                 image.Mutate(ctx => ctx.Resize(crop.Width, crop.Height));
             }
 
-            using var output = new MemoryStream();
-            image.SaveAsJpeg(output, new JpegEncoder { Quality = 90 });
-
-            return new AIMediaContent
-            {
-                Data = output.ToArray(),
-                MediaType = "image/jpeg"
-            };
+            return AIImageEncoder.Encode(image, jpegQuality: 90);
         }
     }
 }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Media/AIImageCropper.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Media/AIImageCropper.cs
@@ -1,0 +1,95 @@
+using Microsoft.Extensions.Logging;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Processing;
+using Umbraco.AI.Prompt.Core.Media;
+
+namespace Umbraco.AI.Core.Media;
+
+/// <summary>
+/// Applies named image cropper crops to raw image bytes. Used when a prompt
+/// template requests a specific crop via the <c>#cropAlias</c> suffix.
+/// </summary>
+internal static class AIImageCropper
+{
+    /// <summary>
+    /// Returns a copy of <paramref name="content"/> cropped to the named crop's
+    /// coordinates and resized to the crop's target dimensions. When the named
+    /// crop is missing, has no coordinates, or the image cannot be decoded, the
+    /// original content is returned unchanged.
+    /// </summary>
+    /// <param name="content">Source image bytes.</param>
+    /// <param name="crops">Crop definitions from the image cropper payload.</param>
+    /// <param name="cropAlias">Alias of the crop to apply.</param>
+    /// <param name="logger">Logger for diagnostic warnings.</param>
+    public static AIMediaContent ApplyCrop(
+        AIMediaContent content,
+        IReadOnlyList<ImageCropperCrop> crops,
+        string cropAlias,
+        ILogger logger)
+    {
+        var crop = crops.FirstOrDefault(
+            c => string.Equals(c.Alias, cropAlias, StringComparison.OrdinalIgnoreCase));
+
+        if (crop is null)
+        {
+            logger.LogWarning(
+                "Image cropper value has no crop with alias '{CropAlias}'; using original image",
+                cropAlias);
+            return content;
+        }
+
+        if (crop.Coordinates is null)
+        {
+            logger.LogWarning(
+                "Crop '{CropAlias}' has no coordinates defined; using original image",
+                cropAlias);
+            return content;
+        }
+
+        Image image;
+        try
+        {
+            image = Image.Load(content.Data);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to decode image for crop '{CropAlias}'; using original", cropAlias);
+            return content;
+        }
+
+        using (image)
+        {
+            var coords = crop.Coordinates;
+
+            // Coordinates are proportional (0..1) in the image cropper JSON format.
+            var x = (int)Math.Round((double)coords.X1 * image.Width);
+            var y = (int)Math.Round((double)coords.Y1 * image.Height);
+            var w = (int)Math.Round((double)(coords.X2 - coords.X1) * image.Width);
+            var h = (int)Math.Round((double)(coords.Y2 - coords.Y1) * image.Height);
+
+            // Clamp to image bounds defensively — malformed coordinates shouldn't crash.
+            x = Math.Clamp(x, 0, Math.Max(0, image.Width - 1));
+            y = Math.Clamp(y, 0, Math.Max(0, image.Height - 1));
+            w = Math.Clamp(w, 1, image.Width - x);
+            h = Math.Clamp(h, 1, image.Height - y);
+
+            image.Mutate(ctx => ctx.Crop(new Rectangle(x, y, w, h)));
+
+            // Resize to the crop's declared target dimensions when specified.
+            if (crop.Width > 0 && crop.Height > 0)
+            {
+                image.Mutate(ctx => ctx.Resize(crop.Width, crop.Height));
+            }
+
+            using var output = new MemoryStream();
+            image.SaveAsJpeg(output, new JpegEncoder { Quality = 90 });
+
+            return new AIMediaContent
+            {
+                Data = output.ToArray(),
+                MediaType = "image/jpeg"
+            };
+        }
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Media/AIImageCropper.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Media/AIImageCropper.cs
@@ -60,11 +60,26 @@ internal static class AIImageCropper
         {
             var coords = crop.Coordinates;
 
-            // Coordinates are proportional (0..1) in the image cropper JSON format.
-            var x = (int)Math.Round((double)coords.X1 * image.Width);
-            var y = (int)Math.Round((double)coords.Y1 * image.Height);
-            var w = (int)Math.Round((double)(coords.X2 - coords.X1) * image.Width);
-            var h = (int)Math.Round((double)(coords.Y2 - coords.Y1) * image.Height);
+            // Umbraco's image cropper stores coordinates as 0..1 fractions but with
+            // an asymmetric meaning: X1/Y1 are offsets from the left/top edges, while
+            // X2/Y2 are offsets from the *right* and *bottom* edges — not absolute
+            // positions. So the real crop rectangle edges are:
+            //
+            //   left   = X1
+            //   top    = Y1
+            //   right  = 1 - X2
+            //   bottom = 1 - Y2
+            //
+            // Matches Umbraco.Cms.Imaging.ImageSharp.ImageProcessors.CropWebProcessor.
+            var left = Math.Clamp((double)coords.X1, 0, 1);
+            var top = Math.Clamp((double)coords.Y1, 0, 1);
+            var right = Math.Clamp(1 - (double)coords.X2, 0, 1);
+            var bottom = Math.Clamp(1 - (double)coords.Y2, 0, 1);
+
+            var x = (int)Math.Round(left * image.Width);
+            var y = (int)Math.Round(top * image.Height);
+            var w = (int)Math.Round((right - left) * image.Width);
+            var h = (int)Math.Round((bottom - top) * image.Height);
 
             // Clamp to image bounds defensively — malformed coordinates shouldn't crash.
             x = Math.Clamp(x, 0, Math.Max(0, image.Width - 1));

--- a/Umbraco.AI/src/Umbraco.AI.Core/Media/AIImageDownscaler.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Media/AIImageDownscaler.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Logging;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Processing;
 
 namespace Umbraco.AI.Core.Media;
@@ -85,20 +84,13 @@ internal static class AIImageDownscaler
                 image.Mutate(x => x.Resize(newWidth, newHeight));
             }
 
-            using var output = new MemoryStream();
-            image.SaveAsJpeg(output, new JpegEncoder { Quality = options.JpegQuality });
-
-            var resized = new AIMediaContent
-            {
-                Data = output.ToArray(),
-                MediaType = "image/jpeg"
-            };
+            var resized = AIImageEncoder.Encode(image, options.JpegQuality);
 
             logger.LogDebug(
-                "Downscaled image {Path}: {OldBytes} bytes ({OldDim}px) -> {NewBytes} bytes ({NewDim}px)",
+                "Downscaled image {Path}: {OldBytes} bytes ({OldDim}px) -> {NewBytes} bytes ({NewDim}px, {Format})",
                 pathForLogging,
                 content.Data.Length, longestEdge,
-                resized.Data.Length, Math.Max(image.Width, image.Height));
+                resized.Data.Length, Math.Max(image.Width, image.Height), resized.MediaType);
 
             return resized;
         }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Media/AIImageDownscaler.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Media/AIImageDownscaler.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Logging;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Processing;
+using Umbraco.AI.Prompt.Core.Media;
+
+namespace Umbraco.AI.Core.Media;
+
+/// <summary>
+/// Provides image downscaling used by the media resolver to keep payloads
+/// within AI provider limits. Pure function over byte data — no file IO.
+/// </summary>
+internal static class AIImageDownscaler
+{
+    /// <summary>
+    /// Returns a downscaled copy of <paramref name="content"/> when it exceeds the
+    /// byte or dimension thresholds in <paramref name="options"/>, or the original
+    /// content when it is within limits, animated, or cannot be decoded.
+    /// </summary>
+    public static AIMediaContent DownscaleIfNeeded(
+        AIMediaContent content,
+        AIMediaOptions options,
+        ILogger logger,
+        string pathForLogging = "")
+    {
+        if (!options.AutoDownscale)
+        {
+            return content;
+        }
+
+        // Cheap header-only read to inspect dimensions without decoding pixels.
+        ImageInfo? info;
+        try
+        {
+            info = Image.Identify(content.Data);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to inspect image header for {Path}; passing through unchanged", pathForLogging);
+            return content;
+        }
+
+        if (info is null)
+        {
+            // Unrecognised format — let the provider decide what to do with it.
+            return content;
+        }
+
+        var longestEdge = Math.Max(info.Width, info.Height);
+        var oversizedBytes = content.Data.LongLength > options.MaxSizeBytes;
+        var oversizedDimension = longestEdge > options.MaxDimension;
+
+        if (!oversizedBytes && !oversizedDimension)
+        {
+            return content;
+        }
+
+        Image image;
+        try
+        {
+            image = Image.Load(content.Data);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to decode image {Path} for downscale; passing through unchanged", pathForLogging);
+            return content;
+        }
+
+        using (image)
+        {
+            // Animated images (GIF/WebP/APNG) would lose animation if re-encoded to JPEG.
+            // Pass through and let the provider handle/reject as it sees fit.
+            if (image.Frames.Count > 1)
+            {
+                logger.LogWarning(
+                    "Image {Path} exceeds limits ({Bytes} bytes, {LongestEdge}px) but is animated ({Frames} frames); passing through unchanged",
+                    pathForLogging, content.Data.Length, longestEdge, image.Frames.Count);
+                return content;
+            }
+
+            if (oversizedDimension)
+            {
+                var ratio = (double)options.MaxDimension / longestEdge;
+                var newWidth = Math.Max(1, (int)Math.Round(image.Width * ratio));
+                var newHeight = Math.Max(1, (int)Math.Round(image.Height * ratio));
+                image.Mutate(x => x.Resize(newWidth, newHeight));
+            }
+
+            using var output = new MemoryStream();
+            image.SaveAsJpeg(output, new JpegEncoder { Quality = options.JpegQuality });
+
+            var resized = new AIMediaContent
+            {
+                Data = output.ToArray(),
+                MediaType = "image/jpeg"
+            };
+
+            logger.LogDebug(
+                "Downscaled image {Path}: {OldBytes} bytes ({OldDim}px) -> {NewBytes} bytes ({NewDim}px)",
+                pathForLogging,
+                content.Data.Length, longestEdge,
+                resized.Data.Length, Math.Max(image.Width, image.Height));
+
+            return resized;
+        }
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Media/AIImageEncoder.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Media/AIImageEncoder.cs
@@ -1,0 +1,60 @@
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Umbraco.AI.Core.Media;
+
+/// <summary>
+/// Encodes a decoded <see cref="Image"/> to bytes, choosing a format that
+/// preserves alpha when the source has a transparent channel. Shared by the
+/// downscaler and cropper so both re-encode paths avoid silently flattening
+/// PNG/WebP transparency to an opaque JPEG.
+/// </summary>
+internal static class AIImageEncoder
+{
+    /// <summary>
+    /// Encodes <paramref name="image"/> to PNG when it carries an alpha channel
+    /// (lossless, transparency preserved), otherwise to JPEG at the given
+    /// quality (smaller payload for opaque/photographic content).
+    /// </summary>
+    public static AIMediaContent Encode(Image image, int jpegQuality = 85)
+    {
+        using var output = new MemoryStream();
+
+        if (HasAlpha(image))
+        {
+            image.SaveAsPng(output);
+            return new AIMediaContent
+            {
+                Data = output.ToArray(),
+                MediaType = "image/png"
+            };
+        }
+
+        image.SaveAsJpeg(output, new JpegEncoder { Quality = jpegQuality });
+        return new AIMediaContent
+        {
+            Data = output.ToArray(),
+            MediaType = "image/jpeg"
+        };
+    }
+
+    private static bool HasAlpha(Image image)
+    {
+        // Prefer the explicit AlphaRepresentation when the decoder populated it.
+        var alpha = image.PixelType.AlphaRepresentation;
+        if (alpha is PixelAlphaRepresentation.Associated or PixelAlphaRepresentation.Unassociated)
+        {
+            return true;
+        }
+        if (alpha is PixelAlphaRepresentation.None)
+        {
+            return false;
+        }
+
+        // AlphaRepresentation is nullable and not every ImageSharp decoder populates it
+        // (notably the PNG decoder leaves it null even for 32-bpp RGBA images). Fall
+        // back to the runtime pixel type — any of these formats carries an alpha channel.
+        return image is Image<Rgba32> or Image<Bgra32> or Image<Rgba64> or Image<La16> or Image<La32>;
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Media/AIMediaOptions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Media/AIMediaOptions.cs
@@ -1,0 +1,37 @@
+namespace Umbraco.AI.Core.Media;
+
+/// <summary>
+/// Configuration options for AI media resolution, including automatic
+/// downscaling of oversized images before they are sent to AI providers.
+/// </summary>
+public class AIMediaOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether oversized images are automatically
+    /// downscaled before being sent to AI providers. Default is <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    /// Most providers enforce hard limits on image payload size and/or pixel dimensions
+    /// (e.g. Anthropic Claude rejects images above 5 MB). Leaving this enabled protects
+    /// against those limits at the cost of a single re-encode for oversized inputs.
+    /// </remarks>
+    public bool AutoDownscale { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the maximum allowed byte size of an image payload after resolution.
+    /// Images above this size are re-encoded. Default is 4 MB.
+    /// </summary>
+    public long MaxSizeBytes { get; set; } = 4 * 1024 * 1024;
+
+    /// <summary>
+    /// Gets or sets the maximum allowed pixel dimension (longest edge) for an image.
+    /// Images above this dimension are resized proportionally. Default is 2048.
+    /// </summary>
+    public int MaxDimension { get; set; } = 2048;
+
+    /// <summary>
+    /// Gets or sets the JPEG quality (1-100) used when re-encoding oversized images.
+    /// Lower values produce smaller files at the cost of visual fidelity. Default is 85.
+    /// </summary>
+    public int JpegQuality { get; set; } = 85;
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Media/AIUmbracoMediaResolver.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Media/AIUmbracoMediaResolver.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.AI.Core.Media;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Services;
 
@@ -22,15 +24,18 @@ internal sealed class AIUmbracoMediaResolver : IAIUmbracoMediaResolver
 
     private readonly IMediaService _mediaService;
     private readonly MediaFileManager _mediaFileManager;
+    private readonly IOptionsMonitor<AIMediaOptions> _optionsMonitor;
     private readonly ILogger<AIUmbracoMediaResolver> _logger;
 
     public AIUmbracoMediaResolver(
         IMediaService mediaService,
         MediaFileManager mediaFileManager,
+        IOptionsMonitor<AIMediaOptions> optionsMonitor,
         ILogger<AIUmbracoMediaResolver> logger)
     {
         _mediaService = mediaService;
         _mediaFileManager = mediaFileManager;
+        _optionsMonitor = optionsMonitor;
         _logger = logger;
     }
 
@@ -248,10 +253,12 @@ internal sealed class AIUmbracoMediaResolver : IAIUmbracoMediaResolver
         using var memoryStream = new MemoryStream();
         stream.CopyTo(memoryStream);
 
-        return new AIMediaContent
+        var content = new AIMediaContent
         {
             Data = memoryStream.ToArray(),
             MediaType = mediaType
         };
+
+        return AIImageDownscaler.DownscaleIfNeeded(content, _optionsMonitor.CurrentValue, _logger, relativePath);
     }
 }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Media/AIUmbracoMediaResolver.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Media/AIUmbracoMediaResolver.cs
@@ -75,6 +75,20 @@ internal sealed class AIUmbracoMediaResolver : IAIUmbracoMediaResolver
                 return Task.FromResult<AIMediaContent?>(null);
             }
 
+            // Crop and downscale are image-only transforms; audio and other
+            // non-image payloads short-circuit here to avoid wasted decode attempts
+            // and misleading "failed to decode image" warnings.
+            if (!content.MediaType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+            {
+                if (!string.IsNullOrWhiteSpace(cropAlias))
+                {
+                    _logger.LogWarning(
+                        "Crop '{CropAlias}' requested on non-image media ({MediaType}); ignored",
+                        cropAlias, content.MediaType);
+                }
+                return Task.FromResult<AIMediaContent?>(content);
+            }
+
             // Step 2: if a crop was requested, try to pull the image cropper metadata
             // from the source value (either directly from the cropper JSON, or by
             // reading the umbracoFile property of the referenced media).
@@ -93,7 +107,7 @@ internal sealed class AIUmbracoMediaResolver : IAIUmbracoMediaResolver
                 }
             }
 
-            // Step 3: enforce AI provider size/dimension limits (no-op for non-images)
+            // Step 3: enforce AI provider size/dimension limits
             var downscaled = AIImageDownscaler.DownscaleIfNeeded(
                 content,
                 _optionsMonitor.CurrentValue,

--- a/Umbraco.AI/src/Umbraco.AI.Core/Media/AIUmbracoMediaResolver.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Media/AIUmbracoMediaResolver.cs
@@ -40,37 +40,62 @@ internal sealed class AIUmbracoMediaResolver : IAIUmbracoMediaResolver
     }
 
     /// <inheritdoc />
-    public async Task<AIMediaContent?> ResolveAsync(object? value, CancellationToken cancellationToken = default)
+    public Task<AIMediaContent?> ResolveAsync(object? value, string? cropAlias = null, CancellationToken cancellationToken = default)
     {
         if (value is null)
         {
-            return null;
+            return Task.FromResult<AIMediaContent?>(null);
         }
 
         try
         {
-            // Try to extract a file path or media key from the value
+            // Step 1: extract a raw file path or media key from the value
             var (filePath, mediaKey) = ExtractPathOrKey(value);
 
-            // If we have a media key, resolve via media service
-            if (mediaKey.HasValue)
+            AIMediaContent? content = mediaKey.HasValue
+                ? LoadFromMediaKey(mediaKey.Value)
+                : !string.IsNullOrEmpty(filePath) ? LoadFromPath(filePath) : null;
+
+            if (content is null)
             {
-                return ResolveFromMediaKey(mediaKey.Value);
+                if (filePath is null && !mediaKey.HasValue)
+                {
+                    _logger.LogWarning("Could not extract image path or media key from value: {ValueType}", value.GetType().Name);
+                }
+                return Task.FromResult<AIMediaContent?>(null);
             }
 
-            // If we have a file path, read directly from storage
-            if (!string.IsNullOrEmpty(filePath))
+            // Step 2: if a crop was requested, try to pull the image cropper metadata
+            // from the source value (either directly from the cropper JSON, or by
+            // reading the umbracoFile property of the referenced media).
+            if (!string.IsNullOrWhiteSpace(cropAlias))
             {
-                return ResolveFromPath(filePath);
+                var cropper = TryExtractCropperPayload(value, mediaKey);
+                if (cropper?.Crops is { Count: > 0 })
+                {
+                    content = AIImageCropper.ApplyCrop(content, cropper.Crops, cropAlias, _logger);
+                }
+                else
+                {
+                    _logger.LogWarning(
+                        "Crop '{CropAlias}' requested but no image cropper data is available on the source value; using original image",
+                        cropAlias);
+                }
             }
 
-            _logger.LogWarning("Could not extract image path or media key from value: {ValueType}", value.GetType().Name);
-            return null;
+            // Step 3: enforce AI provider size/dimension limits
+            var downscaled = AIImageDownscaler.DownscaleIfNeeded(
+                content,
+                _optionsMonitor.CurrentValue,
+                _logger,
+                filePath ?? mediaKey?.ToString() ?? string.Empty);
+
+            return Task.FromResult<AIMediaContent?>(downscaled);
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to resolve image from value: {ValueType}", value.GetType().Name);
-            return null;
+            return Task.FromResult<AIMediaContent?>(null);
         }
     }
 
@@ -176,7 +201,7 @@ internal sealed class AIUmbracoMediaResolver : IAIUmbracoMediaResolver
         return (null, null);
     }
 
-    private AIMediaContent? ResolveFromMediaKey(Guid mediaKey)
+    private AIMediaContent? LoadFromMediaKey(Guid mediaKey)
     {
         var media = _mediaService.GetById(mediaKey);
         if (media is null)
@@ -217,10 +242,10 @@ internal sealed class AIUmbracoMediaResolver : IAIUmbracoMediaResolver
             return null;
         }
 
-        return ResolveFromPath(filePath);
+        return LoadFromPath(filePath);
     }
 
-    private AIMediaContent? ResolveFromPath(string filePath)
+    private AIMediaContent? LoadFromPath(string filePath)
     {
         // Normalize the path - remove leading /media/ if present since MediaFileManager works with relative paths
         var relativePath = filePath;
@@ -253,12 +278,55 @@ internal sealed class AIUmbracoMediaResolver : IAIUmbracoMediaResolver
         using var memoryStream = new MemoryStream();
         stream.CopyTo(memoryStream);
 
-        var content = new AIMediaContent
+        return new AIMediaContent
         {
             Data = memoryStream.ToArray(),
             MediaType = mediaType
         };
+    }
 
-        return AIImageDownscaler.DownscaleIfNeeded(content, _optionsMonitor.CurrentValue, _logger, relativePath);
+    private ImageCropperPayload? TryExtractCropperPayload(object value, Guid? mediaKey)
+    {
+        // Case 1: we resolved via a media key — read the umbracoFile property from
+        // the media and try to parse it as an image cropper payload.
+        if (mediaKey.HasValue)
+        {
+            var media = _mediaService.GetById(mediaKey.Value);
+            var umbracoFile = media?.GetValue<string>("umbracoFile");
+            return TryParseCropperJson(umbracoFile);
+        }
+
+        // Case 2: value is cropper JSON directly.
+        if (value is string str && str.StartsWith('{'))
+        {
+            return TryParseCropperJson(str);
+        }
+
+        if (value is JsonElement { ValueKind: JsonValueKind.Object } element)
+        {
+            return TryParseCropperJson(element.GetRawText());
+        }
+
+        return null;
+    }
+
+    private ImageCropperPayload? TryParseCropperJson(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json) || !json.TrimStart().StartsWith('{'))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<ImageCropperPayload>(
+                json,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogDebug(ex, "Failed to parse image cropper payload; crop selection will fall back to original image");
+            return null;
+        }
     }
 }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Media/IAIUmbracoMediaResolver.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Media/IAIUmbracoMediaResolver.cs
@@ -18,9 +18,15 @@ public interface IAIUmbracoMediaResolver
     ///         <item><description>File path string - read directly from storage</description></item>
     ///     </list>
     /// </param>
+    /// <param name="cropAlias">
+    ///     Optional image cropper crop alias. When supplied, the resolver will apply the
+    ///     matching crop defined on the image cropper payload before returning. Callers
+    ///     requesting a crop that does not exist, or values without an image cropper
+    ///     payload, fall back to the uncropped original.
+    /// </param>
     /// <param name="cancellationToken"></param>
     /// <returns>
     /// The resolved media content, or <c>null</c> if the value cannot be resolved to media.
     /// </returns>
-    Task<AIMediaContent?> ResolveAsync(object? value, CancellationToken cancellationToken = default);
+    Task<AIMediaContent?> ResolveAsync(object? value, string? cropAlias = null, CancellationToken cancellationToken = default);
 }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Media/ImageCropperPayload.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Media/ImageCropperPayload.cs
@@ -1,0 +1,49 @@
+using System.Text.Json.Serialization;
+
+namespace Umbraco.AI.Core.Media;
+
+/// <summary>
+/// Minimal DTO representing the image cropper JSON payload stored on the
+/// Umbraco <c>umbracoFile</c> property. Intentionally decoupled from
+/// <c>Umbraco.Cms.Core.PropertyEditors.ValueConverters.ImageCropperValue</c>
+/// so we can deserialise via System.Text.Json without dragging in CMS
+/// internals or Newtonsoft attributes.
+/// </summary>
+internal sealed class ImageCropperPayload
+{
+    [JsonPropertyName("src")]
+    public string? Src { get; set; }
+
+    [JsonPropertyName("crops")]
+    public List<ImageCropperCrop>? Crops { get; set; }
+}
+
+internal sealed class ImageCropperCrop
+{
+    [JsonPropertyName("alias")]
+    public string? Alias { get; set; }
+
+    [JsonPropertyName("width")]
+    public int Width { get; set; }
+
+    [JsonPropertyName("height")]
+    public int Height { get; set; }
+
+    [JsonPropertyName("coordinates")]
+    public ImageCropperCropCoordinates? Coordinates { get; set; }
+}
+
+internal sealed class ImageCropperCropCoordinates
+{
+    [JsonPropertyName("x1")]
+    public decimal X1 { get; set; }
+
+    [JsonPropertyName("y1")]
+    public decimal Y1 { get; set; }
+
+    [JsonPropertyName("x2")]
+    public decimal X2 { get; set; }
+
+    [JsonPropertyName("y2")]
+    public decimal Y2 { get; set; }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/GetUmbracoMediaItem.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/GetUmbracoMediaItem.cs
@@ -35,7 +35,7 @@ public class GetUmbracoMediaItem(IAIRuntimeContextAccessor runtimeContextAccesso
     /// <inheritdoc />
     protected override async Task<object> ExecuteAsync(GetUmbracoMediaItemArgs args, CancellationToken ct)
     {
-        var media = await mediaResolver.ResolveAsync(args.MediaKey, ct);
+        var media = await mediaResolver.ResolveAsync(args.MediaKey, cancellationToken: ct);
         if (media is null)
         {
             return new { success = false, message = "Media item could not be found or is not a valid media type" };

--- a/Umbraco.AI/src/Umbraco.AI.Core/Umbraco.AI.Core.csproj
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Umbraco.AI.Core.csproj
@@ -10,6 +10,7 @@
         <PackageReference Include="Microsoft.Extensions.AI" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
         <PackageReference Include="Microsoft.Extensions.Options" />
+        <PackageReference Include="SixLabors.ImageSharp" />
         <PackageReference Include="SmartReader" />
         <PackageReference Include="Umbraco.Cms.Core" />
         <PackageReference Include="Umbraco.Cms.Infrastructure" />

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Media/AIImageCropperTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Media/AIImageCropperTests.cs
@@ -10,7 +10,12 @@ public class AIImageCropperTests
     [Fact]
     public void ApplyCrop_WithMatchingCropAlias_ReturnsCroppedAndResizedImage()
     {
-        // 2000x1000 red source, crop defines left half (0..0.5) at 400x400 target.
+        // Umbraco cropper coords for "left half, full height" on a 2000x1000 source:
+        //   X1 = 0.0 (crop starts at left edge)
+        //   Y1 = 0.0 (crop starts at top edge)
+        //   X2 = 0.5 (crop right edge sits 0.5 from the right, i.e. halfway across)
+        //   Y2 = 0.0 (crop bottom extends all the way to the bottom)
+        // Resized to 400x400 target.
         var content = CreatePngContent(2000, 1000);
         var crops = new List<ImageCropperCrop>
         {
@@ -19,7 +24,7 @@ public class AIImageCropperTests
                 Alias = "content3Col",
                 Width = 400,
                 Height = 400,
-                Coordinates = new ImageCropperCropCoordinates { X1 = 0m, Y1 = 0m, X2 = 0.5m, Y2 = 1m }
+                Coordinates = new ImageCropperCropCoordinates { X1 = 0m, Y1 = 0m, X2 = 0.5m, Y2 = 0m }
             }
         };
 
@@ -31,6 +36,41 @@ public class AIImageCropperTests
         using var resultImage = Image.Load(result.Data);
         resultImage.Width.ShouldBe(400);
         resultImage.Height.ShouldBe(400);
+    }
+
+    [Fact]
+    public void ApplyCrop_WithOffsetFromEdgeSemantics_ExtractsRightHalf()
+    {
+        // Regression test for crop-coordinate semantics.
+        //
+        // Umbraco stores X2/Y2 as distances from the *right* and *bottom* edges,
+        // not absolute positions. For a "right half" crop on a 2000-wide source
+        // the stored coordinates are therefore X1=0.5 (start halfway across),
+        // X2=0.0 (zero distance from the right edge, i.e. crop extends to the right).
+        //
+        // Treating X2 as an absolute end coordinate would compute the width as
+        // (X2 - X1) * sourceWidth = -1000, clamping to a 1-pixel sliver. This
+        // test asserts the crop rectangle is the full right half (1000px wide).
+        //
+        // No target dimensions are set so the output mirrors the natural crop
+        // rectangle size — isolates coordinate interpretation from resizing.
+        var content = CreatePngContent(2000, 1000);
+        var crops = new List<ImageCropperCrop>
+        {
+            new()
+            {
+                Alias = "rightHalf",
+                Width = 0,
+                Height = 0,
+                Coordinates = new ImageCropperCropCoordinates { X1 = 0.5m, Y1 = 0m, X2 = 0m, Y2 = 0m }
+            }
+        };
+
+        var result = AIImageCropper.ApplyCrop(content, crops, "rightHalf", NullLogger.Instance);
+
+        using var resultImage = Image.Load(result.Data);
+        resultImage.Width.ShouldBe(1000);
+        resultImage.Height.ShouldBe(1000);
     }
 
     [Fact]
@@ -134,20 +174,21 @@ public class AIImageCropperTests
     [Fact]
     public void ApplyCrop_WithoutTargetDimensions_CropsOnlyAtNaturalSize()
     {
-        // 1000x1000 source, crop takes the full image but declares no target dims
+        // 1000x1000 source, centre 500x500 crop. Umbraco offset-from-edge coords:
+        // 0.25 from every edge leaves a centred 500x500 rectangle.
         var content = CreatePngContent(1000, 1000);
         var crops = new List<ImageCropperCrop>
         {
             new()
             {
-                Alias = "full",
+                Alias = "centre",
                 Width = 0,
                 Height = 0,
-                Coordinates = new ImageCropperCropCoordinates { X1 = 0.25m, Y1 = 0.25m, X2 = 0.75m, Y2 = 0.75m }
+                Coordinates = new ImageCropperCropCoordinates { X1 = 0.25m, Y1 = 0.25m, X2 = 0.25m, Y2 = 0.25m }
             }
         };
 
-        var result = AIImageCropper.ApplyCrop(content, crops, "full", NullLogger.Instance);
+        var result = AIImageCropper.ApplyCrop(content, crops, "centre", NullLogger.Instance);
 
         using var resultImage = Image.Load(result.Data);
         resultImage.Width.ShouldBe(500);

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Media/AIImageCropperTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Media/AIImageCropperTests.cs
@@ -1,0 +1,137 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using Umbraco.AI.Core.Media;
+using Umbraco.AI.Prompt.Core.Media;
+
+namespace Umbraco.AI.Tests.Unit.Media;
+
+public class AIImageCropperTests
+{
+    [Fact]
+    public void ApplyCrop_WithMatchingCropAlias_ReturnsCroppedAndResizedImage()
+    {
+        // 2000x1000 red source, crop defines left half (0..0.5) at 400x400 target.
+        var content = CreatePngContent(2000, 1000);
+        var crops = new List<ImageCropperCrop>
+        {
+            new()
+            {
+                Alias = "content3Col",
+                Width = 400,
+                Height = 400,
+                Coordinates = new ImageCropperCropCoordinates { X1 = 0m, Y1 = 0m, X2 = 0.5m, Y2 = 1m }
+            }
+        };
+
+        var result = AIImageCropper.ApplyCrop(content, crops, "content3Col", NullLogger.Instance);
+
+        result.ShouldNotBeSameAs(content);
+        result.MediaType.ShouldBe("image/jpeg");
+
+        using var resultImage = Image.Load(result.Data);
+        resultImage.Width.ShouldBe(400);
+        resultImage.Height.ShouldBe(400);
+    }
+
+    [Fact]
+    public void ApplyCrop_WithUnknownCropAlias_ReturnsOriginal()
+    {
+        var content = CreatePngContent(100, 100);
+        var crops = new List<ImageCropperCrop>
+        {
+            new() { Alias = "square", Coordinates = new ImageCropperCropCoordinates() }
+        };
+
+        var result = AIImageCropper.ApplyCrop(content, crops, "nonexistent", NullLogger.Instance);
+
+        result.ShouldBeSameAs(content);
+    }
+
+    [Fact]
+    public void ApplyCrop_WithCropMatchingAliasButNoCoordinates_ReturnsOriginal()
+    {
+        var content = CreatePngContent(100, 100);
+        var crops = new List<ImageCropperCrop>
+        {
+            new() { Alias = "named", Coordinates = null }
+        };
+
+        var result = AIImageCropper.ApplyCrop(content, crops, "named", NullLogger.Instance);
+
+        result.ShouldBeSameAs(content);
+    }
+
+    [Fact]
+    public void ApplyCrop_WithAliasCaseInsensitive_FindsMatch()
+    {
+        var content = CreatePngContent(200, 200);
+        var crops = new List<ImageCropperCrop>
+        {
+            new()
+            {
+                Alias = "Content3Col",
+                Width = 100,
+                Height = 100,
+                Coordinates = new ImageCropperCropCoordinates { X1 = 0m, Y1 = 0m, X2 = 0.5m, Y2 = 0.5m }
+            }
+        };
+
+        var result = AIImageCropper.ApplyCrop(content, crops, "content3col", NullLogger.Instance);
+
+        result.ShouldNotBeSameAs(content);
+    }
+
+    [Fact]
+    public void ApplyCrop_WithCorruptBytes_ReturnsOriginal()
+    {
+        var content = new AIMediaContent
+        {
+            Data = new byte[] { 0x00, 0x01, 0x02, 0x03 },
+            MediaType = "image/png"
+        };
+        var crops = new List<ImageCropperCrop>
+        {
+            new()
+            {
+                Alias = "any",
+                Coordinates = new ImageCropperCropCoordinates { X1 = 0m, Y1 = 0m, X2 = 1m, Y2 = 1m }
+            }
+        };
+
+        var result = AIImageCropper.ApplyCrop(content, crops, "any", NullLogger.Instance);
+
+        result.ShouldBeSameAs(content);
+    }
+
+    [Fact]
+    public void ApplyCrop_WithoutTargetDimensions_CropsOnlyAtNaturalSize()
+    {
+        // 1000x1000 source, crop takes the full image but declares no target dims
+        var content = CreatePngContent(1000, 1000);
+        var crops = new List<ImageCropperCrop>
+        {
+            new()
+            {
+                Alias = "full",
+                Width = 0,
+                Height = 0,
+                Coordinates = new ImageCropperCropCoordinates { X1 = 0.25m, Y1 = 0.25m, X2 = 0.75m, Y2 = 0.75m }
+            }
+        };
+
+        var result = AIImageCropper.ApplyCrop(content, crops, "full", NullLogger.Instance);
+
+        using var resultImage = Image.Load(result.Data);
+        resultImage.Width.ShouldBe(500);
+        resultImage.Height.ShouldBe(500);
+    }
+
+    private static AIMediaContent CreatePngContent(int width, int height)
+    {
+        using var image = new Image<Rgba32>(width, height);
+        using var stream = new MemoryStream();
+        image.SaveAsPng(stream);
+        return new AIMediaContent { Data = stream.ToArray(), MediaType = "image/png" };
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Media/AIImageCropperTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Media/AIImageCropperTests.cs
@@ -104,6 +104,34 @@ public class AIImageCropperTests
     }
 
     [Fact]
+    public void ApplyCrop_WhenPngHasAlpha_PreservesAsPngAndKeepsTransparency()
+    {
+        // Rgba32 with transparent pixels — cropping must not flatten transparency
+        // to an opaque JPEG background.
+        var content = CreatePngWithAlphaContent(2000, 2000);
+        var crops = new List<ImageCropperCrop>
+        {
+            new()
+            {
+                Alias = "half",
+                Width = 400,
+                Height = 400,
+                Coordinates = new ImageCropperCropCoordinates { X1 = 0m, Y1 = 0m, X2 = 0.5m, Y2 = 0.5m }
+            }
+        };
+
+        var result = AIImageCropper.ApplyCrop(content, crops, "half", NullLogger.Instance);
+
+        result.MediaType.ShouldBe("image/png");
+
+        using var resultImage = Image.Load<Rgba32>(result.Data);
+        resultImage.Width.ShouldBe(400);
+        resultImage.Height.ShouldBe(400);
+        // Source fill was A=128; a centre pixel should stay non-opaque after crop+resize.
+        resultImage[200, 200].A.ShouldBeLessThan((byte)255);
+    }
+
+    [Fact]
     public void ApplyCrop_WithoutTargetDimensions_CropsOnlyAtNaturalSize()
     {
         // 1000x1000 source, crop takes the full image but declares no target dims
@@ -126,9 +154,37 @@ public class AIImageCropperTests
         resultImage.Height.ShouldBe(500);
     }
 
+    // Opaque PNG (Rgb24) — round-trips through Image.Load as no-alpha, so the
+    // cropper is free to re-encode as JPEG.
     private static AIMediaContent CreatePngContent(int width, int height)
     {
+        using var image = new Image<Rgb24>(width, height);
+        using var stream = new MemoryStream();
+        image.SaveAsPng(stream);
+        return new AIMediaContent { Data = stream.ToArray(), MediaType = "image/png" };
+    }
+
+    // PNG with alpha (Rgba32). A uniform fully-transparent image gets optimised
+    // by the encoder into a palette/grayscale form without alpha; fill with a
+    // semi-transparent colour so the alpha channel survives the round-trip.
+    // Top-left pixel is made fully transparent so assertions have a concrete
+    // reference point after cropping from the (0,0) origin.
+    private static AIMediaContent CreatePngWithAlphaContent(int width, int height)
+    {
         using var image = new Image<Rgba32>(width, height);
+        image.ProcessPixelRows(accessor =>
+        {
+            for (int y = 0; y < accessor.Height; y++)
+            {
+                var row = accessor.GetRowSpan(y);
+                for (int x = 0; x < row.Length; x++)
+                {
+                    row[x] = new Rgba32(255, 0, 0, 128);
+                }
+            }
+        });
+        image[0, 0] = new Rgba32(0, 0, 0, 0);
+
         using var stream = new MemoryStream();
         image.SaveAsPng(stream);
         return new AIMediaContent { Data = stream.ToArray(), MediaType = "image/png" };

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Media/AIImageDownscalerTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Media/AIImageDownscalerTests.cs
@@ -1,0 +1,158 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Gif;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.PixelFormats;
+using Umbraco.AI.Core.Media;
+using Umbraco.AI.Prompt.Core.Media;
+
+namespace Umbraco.AI.Tests.Unit.Media;
+
+public class AIImageDownscalerTests
+{
+    [Fact]
+    public void DownscaleIfNeeded_WhenAutoDownscaleDisabled_ReturnsOriginal()
+    {
+        var content = CreatePngContent(width: 4000, height: 3000);
+        var options = new AIMediaOptions { AutoDownscale = false, MaxDimension = 512 };
+
+        var result = AIImageDownscaler.DownscaleIfNeeded(content, options, NullLogger.Instance);
+
+        result.ShouldBeSameAs(content);
+    }
+
+    [Fact]
+    public void DownscaleIfNeeded_WhenImageWithinLimits_ReturnsOriginal()
+    {
+        var content = CreatePngContent(width: 100, height: 100);
+        var options = new AIMediaOptions { MaxDimension = 2048, MaxSizeBytes = 10 * 1024 * 1024 };
+
+        var result = AIImageDownscaler.DownscaleIfNeeded(content, options, NullLogger.Instance);
+
+        result.ShouldBeSameAs(content);
+    }
+
+    [Fact]
+    public void DownscaleIfNeeded_WhenDimensionExceeded_ResizesToLongestEdge()
+    {
+        // 4000x3000 -> longest edge 4000, limit 2048, ratio 0.512
+        var content = CreatePngContent(width: 4000, height: 3000);
+        var options = new AIMediaOptions { MaxDimension = 2048, MaxSizeBytes = long.MaxValue };
+
+        var result = AIImageDownscaler.DownscaleIfNeeded(content, options, NullLogger.Instance);
+
+        result.ShouldNotBeSameAs(content);
+        result.MediaType.ShouldBe("image/jpeg");
+
+        using var resultImage = Image.Load(result.Data);
+        resultImage.Width.ShouldBe(2048);
+        resultImage.Height.ShouldBe(1536); // 3000 * 0.512 = 1536
+    }
+
+    [Fact]
+    public void DownscaleIfNeeded_WithPortraitImage_ResizesByHeight()
+    {
+        // 1000x3000 -> longest edge 3000 (height), limit 1500
+        var content = CreatePngContent(width: 1000, height: 3000);
+        var options = new AIMediaOptions { MaxDimension = 1500, MaxSizeBytes = long.MaxValue };
+
+        var result = AIImageDownscaler.DownscaleIfNeeded(content, options, NullLogger.Instance);
+
+        using var resultImage = Image.Load(result.Data);
+        resultImage.Height.ShouldBe(1500);
+        resultImage.Width.ShouldBe(500);
+    }
+
+    [Fact]
+    public void DownscaleIfNeeded_WhenByteSizeExceededButDimensionFine_ReencodesWithoutResize()
+    {
+        // Large PNG (uncompressed noise) that exceeds the byte cap but not the dim cap.
+        // A 1500x1500 random-noise PNG will be well over 1 MB.
+        var content = CreateNoisePngContent(width: 1500, height: 1500);
+        content.Data.Length.ShouldBeGreaterThan(1_000_000);
+
+        var options = new AIMediaOptions { MaxDimension = 4096, MaxSizeBytes = 500_000 };
+
+        var result = AIImageDownscaler.DownscaleIfNeeded(content, options, NullLogger.Instance);
+
+        result.MediaType.ShouldBe("image/jpeg");
+
+        using var resultImage = Image.Load(result.Data);
+        resultImage.Width.ShouldBe(1500);
+        resultImage.Height.ShouldBe(1500);
+        result.Data.Length.ShouldBeLessThan(content.Data.Length);
+    }
+
+    [Fact]
+    public void DownscaleIfNeeded_WhenAnimated_ReturnsOriginal()
+    {
+        // Animated GIF with 2 frames, large enough to trip limits.
+        var content = CreateAnimatedGifContent(width: 3000, height: 3000, frames: 2);
+        var options = new AIMediaOptions { MaxDimension = 512, MaxSizeBytes = 1 };
+
+        var result = AIImageDownscaler.DownscaleIfNeeded(content, options, NullLogger.Instance);
+
+        result.ShouldBeSameAs(content);
+    }
+
+    [Fact]
+    public void DownscaleIfNeeded_WithCorruptBytes_ReturnsOriginal()
+    {
+        var content = new AIMediaContent
+        {
+            Data = new byte[] { 0x00, 0x01, 0x02, 0x03, 0xFF, 0xFE },
+            MediaType = "image/png"
+        };
+        var options = new AIMediaOptions();
+
+        var result = AIImageDownscaler.DownscaleIfNeeded(content, options, NullLogger.Instance);
+
+        result.ShouldBeSameAs(content);
+    }
+
+    private static AIMediaContent CreatePngContent(int width, int height)
+    {
+        using var image = new Image<Rgba32>(width, height);
+        using var stream = new MemoryStream();
+        image.SaveAsPng(stream);
+        return new AIMediaContent { Data = stream.ToArray(), MediaType = "image/png" };
+    }
+
+    private static AIMediaContent CreateNoisePngContent(int width, int height)
+    {
+        using var image = new Image<Rgba32>(width, height);
+        var random = new Random(42);
+        image.ProcessPixelRows(accessor =>
+        {
+            for (int y = 0; y < accessor.Height; y++)
+            {
+                var row = accessor.GetRowSpan(y);
+                for (int x = 0; x < row.Length; x++)
+                {
+                    row[x] = new Rgba32(
+                        (byte)random.Next(256),
+                        (byte)random.Next(256),
+                        (byte)random.Next(256),
+                        255);
+                }
+            }
+        });
+
+        using var stream = new MemoryStream();
+        image.SaveAsPng(stream, new PngEncoder { CompressionLevel = PngCompressionLevel.NoCompression });
+        return new AIMediaContent { Data = stream.ToArray(), MediaType = "image/png" };
+    }
+
+    private static AIMediaContent CreateAnimatedGifContent(int width, int height, int frames)
+    {
+        using var image = new Image<Rgba32>(width, height);
+        for (int i = 1; i < frames; i++)
+        {
+            image.Frames.CreateFrame();
+        }
+
+        using var stream = new MemoryStream();
+        image.SaveAsGif(stream, new GifEncoder());
+        return new AIMediaContent { Data = stream.ToArray(), MediaType = "image/gif" };
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Media/AIImageDownscalerTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Media/AIImageDownscalerTests.cs
@@ -95,6 +95,28 @@ public class AIImageDownscalerTests
     }
 
     [Fact]
+    public void DownscaleIfNeeded_WhenPngHasAlpha_PreservesAsPngAndKeepsTransparency()
+    {
+        // 4000x3000 Rgba32 with semi-transparent fill — re-encoding to JPEG would
+        // silently flatten the alpha channel, so output must stay PNG and keep
+        // non-opaque pixels intact.
+        var content = CreatePngWithAlphaContent(width: 4000, height: 3000);
+        var options = new AIMediaOptions { MaxDimension = 2048, MaxSizeBytes = long.MaxValue };
+
+        var result = AIImageDownscaler.DownscaleIfNeeded(content, options, NullLogger.Instance);
+
+        result.ShouldNotBeSameAs(content);
+        result.MediaType.ShouldBe("image/png");
+
+        using var resultImage = Image.Load<Rgba32>(result.Data);
+        resultImage.Width.ShouldBe(2048);
+        resultImage.Height.ShouldBe(1536);
+        // Source fill was A=128; a centre pixel (well away from the single A=0 pixel)
+        // should still read as non-opaque after resize.
+        resultImage[1024, 768].A.ShouldBeLessThan((byte)255);
+    }
+
+    [Fact]
     public void DownscaleIfNeeded_WithCorruptBytes_ReturnsOriginal()
     {
         var content = new AIMediaContent
@@ -109,9 +131,37 @@ public class AIImageDownscalerTests
         result.ShouldBeSameAs(content);
     }
 
+    // Opaque PNG (Rgb24) — round-trips through Image.Load as no-alpha, so the
+    // downscaler is free to re-encode as JPEG.
     private static AIMediaContent CreatePngContent(int width, int height)
     {
+        using var image = new Image<Rgb24>(width, height);
+        using var stream = new MemoryStream();
+        image.SaveAsPng(stream);
+        return new AIMediaContent { Data = stream.ToArray(), MediaType = "image/png" };
+    }
+
+    // PNG with alpha (Rgba32). A uniform fully-transparent image gets optimised
+    // by the encoder into a palette/grayscale form without alpha; fill with a
+    // semi-transparent colour so the alpha channel survives the round-trip.
+    // Top-left pixel is made fully transparent so assertions have a concrete
+    // reference point.
+    private static AIMediaContent CreatePngWithAlphaContent(int width, int height)
+    {
         using var image = new Image<Rgba32>(width, height);
+        image.ProcessPixelRows(accessor =>
+        {
+            for (int y = 0; y < accessor.Height; y++)
+            {
+                var row = accessor.GetRowSpan(y);
+                for (int x = 0; x < row.Length; x++)
+                {
+                    row[x] = new Rgba32(255, 0, 0, 128);
+                }
+            }
+        });
+        image[0, 0] = new Rgba32(0, 0, 0, 0);
+
         using var stream = new MemoryStream();
         image.SaveAsPng(stream);
         return new AIMediaContent { Data = stream.ToArray(), MediaType = "image/png" };
@@ -119,7 +169,7 @@ public class AIImageDownscalerTests
 
     private static AIMediaContent CreateNoisePngContent(int width, int height)
     {
-        using var image = new Image<Rgba32>(width, height);
+        using var image = new Image<Rgb24>(width, height);
         var random = new Random(42);
         image.ProcessPixelRows(accessor =>
         {
@@ -128,11 +178,10 @@ public class AIImageDownscalerTests
                 var row = accessor.GetRowSpan(y);
                 for (int x = 0; x < row.Length; x++)
                 {
-                    row[x] = new Rgba32(
+                    row[x] = new Rgb24(
                         (byte)random.Next(256),
                         (byte)random.Next(256),
-                        (byte)random.Next(256),
-                        255);
+                        (byte)random.Next(256));
                 }
             }
         });


### PR DESCRIPTION
Closes #122.

## Summary

Two changes that together address the oversized-image issue reported by @deanleigh:

1. **Auto-downscale safety net** — oversized images are now automatically resized + JPEG re-encoded before being sent to the AI provider. Defaults (4 MB / 2048px longest edge / JPEG 85) keep us under every current provider limit. Configurable via `Umbraco:AI:Media`.
2. **Named-crop syntax in `{{image:...}}` variables** — editors can now request a specific image cropper crop with a `#` suffix, e.g. `{{image:umbracoFile#content3Col}}`. The crop is applied server-side via ImageSharp, and the crop alias is included in the AI-facing reference name so a single prompt can describe multiple crops of the same source distinctly (addressing Dean's Note 2 about per-crop alt text).

## Why `#` as the crop separator

Reserved `.` for future nested property navigation inside block lists / element context (see `d7684bf9`). `#` has the fragment intuition, doesn't clash with any Umbraco identifier convention, and parses cleanly.

## Configuration

```json
{
  "Umbraco": {
    "AI": {
      "Media": {
        "AutoDownscale": true,
        "MaxSizeBytes": 4194304,
        "MaxDimension": 2048,
        "JpegQuality": 85
      }
    }
  }
}
```

## Behaviour notes

- Animated images (GIF/WebP/APNG) are passed through unchanged — re-encoding to JPEG would silently drop animation. If they exceed provider limits the provider will reject them.
- Unknown crop aliases fall back to the uncropped original with a warning logged — the prompt still runs.
- Media values without a cropper payload (plain path, media picker only) ignore the crop suffix and fall back to the original with a warning.
- New package: `SixLabors.ImageSharp` `[3.1.11, 3.999.999)`. Already transitively present in any Umbraco CMS install via `SixLabors.ImageSharp.Web`, so the licensing posture of an Umbraco site doesn't change.

## Test plan

- [x] Unit tests for downscaler (7): disabled passthrough, within-limits passthrough, dimension-exceeded resize (landscape + portrait), byte-exceeded reencode without resize, animated passthrough, corrupt input
- [x] Unit tests for cropper (6): match + resize, unknown alias, alias without coordinates, case-insensitive match, corrupt input, crop without target dimensions
- [x] Unit tests for `#` suffix parsing in template processor (2): cropAlias forwarded + reference name annotated; empty suffix equivalent to no suffix
- [x] Full suite green: 698 Core + 51 Prompt
- [ ] Manual smoke on demo site with an 8+ MB original (Anthropic previously rejected with "image exceeds 5 MB maximum")
- [ ] Manual smoke with `{{image:umbracoFile#someCrop}}` against an Umbraco media item with crops defined

🤖 Generated with [Claude Code](https://claude.com/claude-code)