### PR TITLE
Route-register mock entity editor modal for block grid support

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/components/mock-entity/cms-mock-entity-editor-tab.element.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/components/mock-entity/cms-mock-entity-editor-tab.element.ts
@@ -1,0 +1,87 @@
+import { css, customElement, html, nothing, property, repeat } from "@umbraco-cms/backoffice/external/lit";
+import { UmbLitElement } from "@umbraco-cms/backoffice/lit-element";
+import { UmbDataPathPropertyValueQuery } from "@umbraco-cms/backoffice/validation";
+import type { UmbPropertyTypeModel } from "@umbraco-cms/backoffice/content-type";
+import type { GroupViewModel, TabViewModel } from "./types.js";
+
+const elementName = "uai-cms-mock-entity-editor-tab";
+
+/**
+ * Routed view for a single tab of the CMS mock entity editor.
+ *
+ * Mirrors the CMS block-workspace-view-edit-tab pattern: renders a uui-box
+ * per group (plus one for root properties if any) and lets the parent
+ * umb-property-dataset supply the property dataset + variant contexts.
+ *
+ * Property data-paths are computed as invariant (null culture/segment)
+ * because mock entities in the test workspace do not vary.
+ */
+@customElement(elementName)
+export class UaiCmsMockEntityEditorTabElement extends UmbLitElement {
+    @property({ attribute: false })
+    tab?: TabViewModel;
+
+    override render() {
+        const tab = this.tab;
+        if (!tab) return nothing;
+
+        return html`
+            ${tab.rootProperties.length > 0
+                ? html`<uui-box>${this.#renderProperties(tab.rootProperties)}</uui-box>`
+                : nothing}
+            ${repeat(
+                tab.groups,
+                (group) => group.key,
+                (group) => this.#renderGroup(group),
+            )}
+        `;
+    }
+
+    #renderGroup(group: GroupViewModel) {
+        return html`
+            <uui-box .headline=${group.name}>
+                ${this.#renderProperties(group.properties)}
+            </uui-box>
+        `;
+    }
+
+    #renderProperties(properties: UmbPropertyTypeModel[]) {
+        return repeat(
+            properties,
+            (prop) => prop.alias,
+            (prop) => html`
+                <umb-property-type-based-property
+                    data-path=${this.#dataPathFor(prop.alias)}
+                    .property=${prop}
+                ></umb-property-type-based-property>
+            `,
+        );
+    }
+
+    #dataPathFor(alias: string): string {
+        // Mock entities are invariant; match the CMS block-workspace-view-edit-property
+        // pattern so local validation reporting resolves correctly for nested editors.
+        return `$.values[${UmbDataPathPropertyValueQuery({ alias, culture: null, segment: null })}].value`;
+    }
+
+    static override styles = css`
+        :host {
+            display: block;
+            padding: var(--uui-size-layout-1);
+        }
+        uui-box {
+            --uui-box-default-padding: 0 var(--uui-size-space-5);
+        }
+        uui-box + uui-box {
+            margin-top: var(--uui-size-layout-1);
+        }
+    `;
+}
+
+export { UaiCmsMockEntityEditorTabElement as element };
+
+declare global {
+    interface HTMLElementTagNameMap {
+        [elementName]: UaiCmsMockEntityEditorTabElement;
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/components/mock-entity/cms-mock-entity-editor.element.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/components/mock-entity/cms-mock-entity-editor.element.ts
@@ -1,4 +1,4 @@
-import { css, customElement, html, nothing, property, repeat, state } from "@umbraco-cms/backoffice/external/lit";
+import { css, html, customElement, nothing, property, repeat, state } from "@umbraco-cms/backoffice/external/lit";
 import { UmbLitElement } from "@umbraco-cms/backoffice/lit-element";
 import { UmbChangeEvent } from "@umbraco-cms/backoffice/event";
 import { UmbDocumentTypeDetailRepository } from "@umbraco-cms/backoffice/document-type";
@@ -10,46 +10,35 @@ import type {
     UmbContentTypeModel,
 } from "@umbraco-cms/backoffice/content-type";
 import type { UmbPropertyValueData, UmbPropertyDatasetElement } from "@umbraco-cms/backoffice/property";
+import type { UmbRoute, UmbRouterSlotChangeEvent, UmbRouterSlotInitEvent } from "@umbraco-cms/backoffice/router";
+import { encodeFolderName } from "@umbraco-cms/backoffice/router";
+import type { GroupViewModel, MergedContainer, TabViewModel } from "./types.js";
+import type { UaiCmsMockEntityEditorTabElement } from "./cms-mock-entity-editor-tab.element.js";
 
 const elementName = "uai-cms-mock-entity-editor";
 
-/**
- * A merged container that combines containers from the main type and compositions
- * that share the same name, type, and parent path.
- */
-interface MergedContainer {
-    key: string;
-    ids: Set<string>;
-    name: string;
-    type: "Tab" | "Group";
-    sortOrder: number;
-    parentKey: string | null;
-}
-
-interface TabViewModel {
-    key: string;
-    name: string;
-    sortOrder: number;
-    groups: GroupViewModel[];
-    rootProperties: UmbPropertyTypeModel[];
-}
-
-interface GroupViewModel {
-    key: string;
-    name: string;
-    sortOrder: number;
-    properties: UmbPropertyTypeModel[];
-}
+const ROOT_TAB_KEY = "__root__";
+const ROOT_TAB_NAME = "Content";
 
 /**
  * CMS Mock Entity Editor.
  * Registered for document/media/member entity types.
- * Fetches content type structure and renders properties in tabs and groups
- * using `umb-property-type-based-property` within `umb-property-dataset`,
- * matching the document blueprint editor layout.
  *
- * Renders its own sticky header (name input + tabs) so the host modal
- * only needs to provide the outer chrome and footer actions.
+ * Fetches content type structure and renders properties in tabs and groups
+ * via a routed sub-view, mirroring the CMS block-workspace-view-edit layout.
+ *
+ * The outer editor hosts an `<umb-router-slot>` inside an `<umb-property-dataset>`:
+ * the property dataset provides `UMB_PROPERTY_DATASET_CONTEXT` + an invariant
+ * `UMB_VARIANT_CONTEXT`, and the router slot publishes `UMB_ROUTE_CONTEXT` so
+ * nested block-based property editors (grid, list, rte, single) can register
+ * their catalogue/workspace modals via `UmbModalRouteRegistrationController`.
+ *
+ * The modal-route for this editor is registered by the owning `uai-mock-entity`
+ * element, so the tab sub-paths emitted by this router slot stay scoped under
+ * that registered URL segment and are cleaned up when the modal closes.
+ *
+ * Renders its own sticky header (name input + tabs) so the host modal only
+ * needs to provide the outer chrome and footer actions.
  *
  * @fires change - Fires UmbChangeEvent when value changes.
  */
@@ -80,16 +69,19 @@ export class UaiCmsMockEntityEditorElement extends UmbLitElement {
     private _tabs: TabViewModel[] = [];
 
     @state()
-    private _rootProperties: UmbPropertyTypeModel[] = [];
-
-    @state()
     private _allProperties: UmbPropertyTypeModel[] = [];
 
     @state()
     private _propertyValues: UmbPropertyValueData[] = [];
 
     @state()
-    private _activeTabKey?: string;
+    private _routes: UmbRoute[] = [];
+
+    @state()
+    private _routerPath?: string;
+
+    @state()
+    private _activePath = "";
 
     #documentTypeRepo?: UmbDocumentTypeDetailRepository;
     #mediaTypeRepo?: UmbMediaTypeDetailRepository;
@@ -297,24 +289,56 @@ export class UaiCmsMockEntityEditorElement extends UmbLitElement {
             .sort((a, b) => a.sortOrder - b.sortOrder)
             .map(buildGroup);
 
-        if (standaloneGroups.length > 0) {
+        // Prepend a synthetic root tab for root-level properties and standalone groups
+        // (the CMS blueprint calls this the "Generic" tab). We always promote to a tab
+        // so everything renders through the router-slot path.
+        const hasRootContent = rootProps.length > 0 || standaloneGroups.length > 0;
+        if (hasRootContent) {
             tabViewModels.unshift({
-                key: "__standalone__",
-                name: "Content",
+                key: ROOT_TAB_KEY,
+                name: ROOT_TAB_NAME,
                 sortOrder: -1,
                 groups: standaloneGroups,
                 rootProperties: rootProps,
             });
-            this._rootProperties = [];
-        } else {
-            this._rootProperties = rootProps;
         }
 
         this._tabs = tabViewModels;
+        this.#createRoutes();
+    }
 
-        if (tabViewModels.length > 0 && !this._activeTabKey) {
-            this._activeTabKey = tabViewModels[0].key;
+    #createRoutes() {
+        if (this._tabs.length === 0) {
+            this._routes = [];
+            return;
         }
+
+        const routes: UmbRoute[] = this._tabs.map((tab) => ({
+            path: this.#pathForTab(tab),
+            component: () => import("./cms-mock-entity-editor-tab.element.js"),
+            setup: (component) => {
+                (component as UaiCmsMockEntityEditorTabElement).tab = tab;
+            },
+        }));
+
+        // Default route aliasing the first tab so the router lands on something on open.
+        routes.push({
+            ...routes[0],
+            unique: "emptyPathFor_" + routes[0].path,
+            path: "",
+        });
+
+        routes.push({
+            path: "**",
+            component: async () => (await import("@umbraco-cms/backoffice/router")).UmbRouteNotFoundElement,
+        });
+
+        this._routes = routes;
+    }
+
+    #pathForTab(tab: TabViewModel): string {
+        if (tab.key === ROOT_TAB_KEY) return "root";
+        return `tab/${encodeFolderName(tab.name)}`;
     }
 
     #getTypeFetcher() {
@@ -381,10 +405,6 @@ export class UaiCmsMockEntityEditorElement extends UmbLitElement {
         this.#emitValue();
     }
 
-    #onTabClick(tabKey: string) {
-        this._activeTabKey = tabKey;
-    }
-
     override render() {
         if (this._loading) {
             return html`<uui-loader-bar></uui-loader-bar>`;
@@ -393,6 +413,8 @@ export class UaiCmsMockEntityEditorElement extends UmbLitElement {
         if (this._allProperties.length === 0 && this.#initialized) {
             return html`<uui-label><em>No properties found for this content type.</em></uui-label>`;
         }
+
+        const showTabs = !!this._routerPath && this._tabs.length > 1;
 
         return html`
             <div id="header">
@@ -405,18 +427,14 @@ export class UaiCmsMockEntityEditorElement extends UmbLitElement {
                         label="Name"
                     ></uui-input>
                 </div>
-                ${this._tabs.length > 0
+                ${showTabs
                     ? html`
                         <div id="tabs-container">
                             <uui-tab-group>
-                                ${this._tabs.map(
-                                    (tab) => html`
-                                        <uui-tab
-                                            label=${tab.name}
-                                            ?active=${this._activeTabKey === tab.key}
-                                            @click=${() => this.#onTabClick(tab.key)}
-                                        >${tab.name}</uui-tab>
-                                    `,
+                                ${repeat(
+                                    this._tabs,
+                                    (tab) => tab.key,
+                                    (tab) => this.#renderTab(tab),
                                 )}
                             </uui-tab-group>
                         </div>`
@@ -425,59 +443,32 @@ export class UaiCmsMockEntityEditorElement extends UmbLitElement {
 
             <div id="body">
                 <umb-property-dataset .value=${this._propertyValues} @change=${this.#onPropertyDatasetChange}>
-                    ${this._tabs.length > 0
-                        ? this._tabs.map(
-                            (tab) => html`
-                                <div class="tab-content" ?hidden=${this._activeTabKey !== tab.key}>
-                                    ${this.#renderTabContent(tab)}
-                                </div>
-                            `,
-                        )
-                        : this.#renderUngroupedProperties()}
+                    <umb-router-slot
+                        .routes=${this._routes}
+                        @init=${(e: UmbRouterSlotInitEvent) => {
+                            this._routerPath = e.target.absoluteRouterPath;
+                        }}
+                        @change=${(e: UmbRouterSlotChangeEvent) => {
+                            this._activePath = e.target.absoluteActiveViewPath || "";
+                        }}
+                    ></umb-router-slot>
                 </umb-property-dataset>
             </div>
         `;
     }
 
-    #renderTabContent(tab: TabViewModel) {
+    #renderTab(tab: TabViewModel) {
+        const basePath = (this._routerPath ?? "") + "/";
+        const path = this.#pathForTab(tab);
+        const fullPath = basePath + path;
+        const active = fullPath === this._activePath;
         return html`
-            ${tab.rootProperties.length > 0
-                ? html`
-                    <uui-box>
-                        ${this.#renderProperties(tab.rootProperties)}
-                    </uui-box>`
-                : nothing}
-            ${repeat(
-                tab.groups,
-                (group) => group.key,
-                (group) => html`
-                    <uui-box .headline=${group.name}>
-                        ${this.#renderProperties(group.properties)}
-                    </uui-box>
-                `,
-            )}
+            <uui-tab
+                label=${tab.name}
+                .active=${active}
+                href=${fullPath}
+            >${tab.name}</uui-tab>
         `;
-    }
-
-    #renderUngroupedProperties() {
-        if (this._rootProperties.length === 0) return nothing;
-        return html`
-            <uui-box>
-                ${this.#renderProperties(this._rootProperties)}
-            </uui-box>
-        `;
-    }
-
-    #renderProperties(properties: UmbPropertyTypeModel[]) {
-        return repeat(
-            properties,
-            (prop) => prop.alias,
-            (prop) => html`
-                <umb-property-type-based-property
-                    .property=${prop}
-                ></umb-property-type-based-property>
-            `,
-        );
     }
 
     static override styles = css`
@@ -514,19 +505,7 @@ export class UaiCmsMockEntityEditorElement extends UmbLitElement {
         #body {
             flex: 1;
             overflow-y: auto;
-            padding: var(--uui-size-layout-1);
             background-color: var(--uui-color-background);
-        }
-
-        uui-box {
-            --uui-box-default-padding: 0 var(--uui-size-space-5);
-        }
-        uui-box + uui-box {
-            margin-top: var(--uui-size-layout-1);
-        }
-
-        .tab-content[hidden] {
-            display: none;
         }
     `;
 }

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/components/mock-entity/cms-mock-entity-editor.element.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/components/mock-entity/cms-mock-entity-editor.element.ts
@@ -332,9 +332,16 @@ export class UaiCmsMockEntityEditorElement extends UmbLitElement {
             path: "",
             pathMatch: "full",
             resolve: async () => {
-                if (this._routerPath) {
-                    history.replaceState({}, "", `${this._routerPath}/${firstTabPath}`);
-                }
+                // Guard: when the modal is closing, UmbRouteContext._internal_removeModalPath
+                // pushes the URL back to the outer workspace path. That triggers one last
+                // pass through our inner router-slot on this empty-path route — if we
+                // replaceState unconditionally, we'd yank the URL back into our modal
+                // segment and undo the modal-manager's cleanup (the user sees the URL
+                // clear and then reappear). Only redirect while the URL is still inside
+                // our modal's registered route.
+                if (!this._routerPath) return;
+                if (!window.location.pathname.startsWith(this._routerPath)) return;
+                history.replaceState({}, "", `${this._routerPath}/${firstTabPath}`);
             },
         });
 

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/components/mock-entity/cms-mock-entity-editor.element.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/components/mock-entity/cms-mock-entity-editor.element.ts
@@ -321,11 +321,21 @@ export class UaiCmsMockEntityEditorElement extends UmbLitElement {
             },
         }));
 
-        // Default route aliasing the first tab so the router lands on something on open.
+        // Default route: replaceState into the first tab's canonical path so the
+        // URL reflects the active tab and the tab pill picks up the active style.
+        // Mirrors document-workspace-editor.element.ts's default-route handling —
+        // without this, matching path "" keeps the URL at the parent route's base
+        // and absoluteActiveViewPath comes back without a tab segment, so
+        // href-based active-state comparison fails for the landed-on tab.
+        const firstTabPath = this.#pathForTab(this._tabs[0]);
         routes.push({
-            ...routes[0],
-            unique: "emptyPathFor_" + routes[0].path,
             path: "",
+            pathMatch: "full",
+            resolve: async () => {
+                if (this._routerPath) {
+                    history.replaceState({}, "", `${this._routerPath}/${firstTabPath}`);
+                }
+            },
         });
 
         routes.push({

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/components/mock-entity/mock-entity-editor-modal.token.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/components/mock-entity/mock-entity-editor-modal.token.ts
@@ -11,9 +11,18 @@ export interface UaiMockEntityEditorModalData {
     editorManifest?: ManifestTestMockEntityEditor;
 }
 
-export interface UaiMockEntityEditorModalValue {
-    mockEntityJson: string;
-}
+/**
+ * Submit value of the editor modal. Includes `| undefined` so the modal can be
+ * registered via UmbModalRouteRegistrationController (whose onSetup return type
+ * requires `value` only when the token's value type is non-undefined). The modal
+ * itself only ever reaches `submit()` after building a real value, so consumers
+ * only need to handle undefined on the route-setup callback path.
+ */
+export type UaiMockEntityEditorModalValue =
+    | {
+          mockEntityJson: string;
+      }
+    | undefined;
 
 export const UAI_MOCK_ENTITY_EDITOR_MODAL = new UmbModalToken<
     UaiMockEntityEditorModalData,

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/components/mock-entity/mock-entity.element.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/components/mock-entity/mock-entity.element.ts
@@ -3,6 +3,7 @@ import { UmbLitElement } from "@umbraco-cms/backoffice/lit-element";
 import { UmbChangeEvent } from "@umbraco-cms/backoffice/event";
 import { UMB_MODAL_MANAGER_CONTEXT } from "@umbraco-cms/backoffice/modal";
 import type { UmbModalManagerContext, UmbModalContext } from "@umbraco-cms/backoffice/modal";
+import { UmbModalRouteRegistrationController } from "@umbraco-cms/backoffice/router";
 import { umbExtensionsRegistry } from "@umbraco-cms/backoffice/extension-registry";
 import { UAI_ITEM_PICKER_MODAL } from "../../../core/modals/item-picker/item-picker-modal.token.js";
 import type { UaiPickableItemModel } from "../../../core/modals/item-picker/types.js";
@@ -10,6 +11,7 @@ import { UaiSelectedEvent } from "../../../core/events/selected.event.js";
 import { TestsService } from "../../../api/sdk.gen.js";
 import type { TestEntityTypeResponseModel, TestEntitySubTypeResponseModel } from "../../../api/types.gen.js";
 import { UAI_MOCK_ENTITY_EDITOR_MODAL } from "./mock-entity-editor-modal.token.js";
+import type { UaiMockEntityEditorModalData } from "./mock-entity-editor-modal.token.js";
 import {
     UAI_TEST_MOCK_ENTITY_EDITOR_EXTENSION_TYPE,
     type ManifestTestMockEntityEditor,
@@ -51,6 +53,69 @@ export class UaiMockEntityElement extends UmbLitElement {
     private _entityTypes: TestEntityTypeResponseModel[] = [];
 
     #entityTypesLoaded = false;
+
+    /**
+     * Route path for the editor modal, emitted by UmbModalRouteRegistrationController
+     * once the route is registered (ready shortly after construction).
+     */
+    #editorRoutePath?: string;
+
+    /**
+     * Pending modal data, captured when the user finishes the picker chain (or clicks
+     * Edit/Edit JSON) and handed to the route-registered modal via its onSetup callback.
+     * Cleared when the modal resolves or is cancelled.
+     */
+    #pendingEditorData?: UaiMockEntityEditorModalData;
+
+    /**
+     * In-flight flow metadata for the current editor invocation. Tracks which picker
+     * modals to close on submit and which entity type/sub-type to save the result
+     * against. Only lives between open-the-editor and submit/cancel.
+     */
+    #pendingEditorFlow?: {
+        parentModals: UmbModalContext[];
+        entityType: string;
+        subTypeAlias?: string;
+    };
+
+    constructor() {
+        super();
+
+        // Register the mock entity editor modal as a route under this element.
+        // Opening the editor means navigating to this route via history.pushState,
+        // mirroring how CMS workspaces open their block/workspace modals. This gives
+        // the inner cms-mock-entity-editor's <umb-router-slot> a clean URL segment
+        // to extend (for tab sub-paths) and ensures the URL is tidied up when the
+        // modal closes.
+        new UmbModalRouteRegistrationController(this, UAI_MOCK_ENTITY_EDITOR_MODAL)
+            .addAdditionalPath("mock-entity-editor")
+            .onSetup(() => {
+                // Guard against stray navigation (e.g. URL replayed without going
+                // through the picker chain): refuse to open without pending data.
+                if (!this.#pendingEditorData) return false;
+                return { data: this.#pendingEditorData };
+            })
+            .onSubmit((value) => {
+                const flow = this.#pendingEditorFlow;
+                if (!flow || !value) {
+                    this.#resetEditorFlow();
+                    return;
+                }
+                // Close picker chain and persist the resolved value, matching the
+                // previous `await onSubmit(); for (m of parentModals) m.reject()` behaviour.
+                for (const modal of flow.parentModals) modal.reject();
+                this.#saveValue(flow.entityType, flow.subTypeAlias, value.mockEntityJson);
+                this.#resetEditorFlow();
+            })
+            .onReject(() => {
+                // Editor cancelled: leave any picker modals open so the user can
+                // pick a different type, matching the previous try/catch behaviour.
+                this.#resetEditorFlow();
+            })
+            .observeRouteBuilder((routeBuilder) => {
+                this.#editorRoutePath = routeBuilder({});
+            });
+    }
 
     connectedCallback() {
         super.connectedCallback();
@@ -105,7 +170,7 @@ export class UaiMockEntityElement extends UmbLitElement {
             if (entityTypeInfo?.hasSubTypes) {
                 this.#openSubTypePicker(modalManager, typeModal, selectedType.value, editorManifest);
             } else {
-                this.#openMockEditor(modalManager, [typeModal], selectedType.value, undefined, undefined, undefined, editorManifest);
+                this.#openMockEditor([typeModal], selectedType.value, undefined, undefined, undefined, editorManifest);
             }
         });
     }
@@ -127,7 +192,6 @@ export class UaiMockEntityElement extends UmbLitElement {
         subTypeModal.addEventListener(UaiSelectedEvent.TYPE, async (e: Event) => {
             const selectedSubType = (e as UaiSelectedEvent).item as UaiPickableItemModel;
             this.#openMockEditor(
-                modalManager,
                 [typeModal, subTypeModal],
                 entityType,
                 selectedSubType.value,
@@ -138,8 +202,7 @@ export class UaiMockEntityElement extends UmbLitElement {
         });
     }
 
-    async #openMockEditor(
-        modalManager: UmbModalManagerContext,
+    #openMockEditor(
         parentModals: UmbModalContext[],
         entityType: string,
         subTypeAlias?: string,
@@ -147,26 +210,15 @@ export class UaiMockEntityElement extends UmbLitElement {
         subTypeName?: string,
         editorManifest?: ManifestTestMockEntityEditor,
     ) {
-        const editorModal = modalManager.open(this, UAI_MOCK_ENTITY_EDITOR_MODAL, {
-            data: {
-                entityType,
-                subTypeAlias,
-                subTypeUnique,
-                subTypeName,
-                editorManifest,
-            },
-        });
-
-        try {
-            const result = await editorModal.onSubmit();
-            // Close all parent modals
-            for (const modal of parentModals) {
-                modal.reject();
-            }
-            this.#saveValue(entityType, subTypeAlias, result.mockEntityJson);
-        } catch {
-            // Editor cancelled - parent modals stay open
-        }
+        this.#pendingEditorFlow = { parentModals, entityType, subTypeAlias };
+        this.#pendingEditorData = {
+            entityType,
+            subTypeAlias,
+            subTypeUnique,
+            subTypeName,
+            editorManifest,
+        };
+        this.#navigateToEditorRoute();
     }
 
     async #onEdit() {
@@ -182,9 +234,6 @@ export class UaiMockEntityElement extends UmbLitElement {
 
     async #openExistingEditor(editorManifest?: ManifestTestMockEntityEditor) {
         if (!this.value) return;
-
-        const modalManager = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
-        if (!modalManager) return;
 
         // Resolve sub-type info if needed
         let subTypeUnique: string | undefined;
@@ -202,29 +251,39 @@ export class UaiMockEntityElement extends UmbLitElement {
             }
         }
 
-        const modal = modalManager.open(this, UAI_MOCK_ENTITY_EDITOR_MODAL, {
-            data: {
-                entityType: this.value.entityType,
-                subTypeAlias: this.value.entitySubType ?? undefined,
-                subTypeUnique,
-                subTypeName,
-                existingValue: this.value.mockEntity
-                    ? JSON.stringify(this.value.mockEntity, null, 2)
-                    : undefined,
-                editorManifest,
-            },
-        });
+        this.#pendingEditorFlow = {
+            parentModals: [],
+            entityType: this.value.entityType,
+            subTypeAlias: this.value.entitySubType ?? undefined,
+        };
+        this.#pendingEditorData = {
+            entityType: this.value.entityType,
+            subTypeAlias: this.value.entitySubType ?? undefined,
+            subTypeUnique,
+            subTypeName,
+            existingValue: this.value.mockEntity
+                ? JSON.stringify(this.value.mockEntity, null, 2)
+                : undefined,
+            editorManifest,
+        };
+        this.#navigateToEditorRoute();
+    }
 
-        try {
-            const result = await modal.onSubmit();
-            this.#saveValue(
-                this.value.entityType,
-                this.value.entitySubType ?? undefined,
-                result.mockEntityJson,
-            );
-        } catch {
-            // User cancelled
+    #navigateToEditorRoute() {
+        if (!this.#editorRoutePath) {
+            // Registration runs synchronously in the constructor, but the route
+            // builder observable can fire on the next microtask. If this ever
+            // happens in practice, surface it loudly so we can investigate.
+            console.error("Mock entity editor route path not yet registered.");
+            this.#resetEditorFlow();
+            return;
         }
+        window.history.pushState({}, "", this.#editorRoutePath);
+    }
+
+    #resetEditorFlow() {
+        this.#pendingEditorData = undefined;
+        this.#pendingEditorFlow = undefined;
     }
 
     #onDelete() {

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/components/mock-entity/mock-entity.element.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/components/mock-entity/mock-entity.element.ts
@@ -70,7 +70,9 @@ export class UaiMockEntityElement extends UmbLitElement {
     /**
      * In-flight flow metadata for the current editor invocation. Tracks which picker
      * modals to close on submit and which entity type/sub-type to save the result
-     * against. Only lives between open-the-editor and submit/cancel.
+     * against. Only lives between open-the-editor and submit/cancel. URL cleanup
+     * on close is handled by UmbModalContext.reject/submit → UmbRouteContext
+     * _internal_removeModalPath, so we don't restore the URL ourselves.
      */
     #pendingEditorFlow?: {
         parentModals: UmbModalContext[];

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/components/mock-entity/types.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/components/mock-entity/types.ts
@@ -1,0 +1,29 @@
+import type { UmbPropertyTypeModel } from "@umbraco-cms/backoffice/content-type";
+
+/**
+ * A merged container that combines containers from the main type and compositions
+ * that share the same name, type, and parent path.
+ */
+export interface MergedContainer {
+    key: string;
+    ids: Set<string>;
+    name: string;
+    type: "Tab" | "Group";
+    sortOrder: number;
+    parentKey: string | null;
+}
+
+export interface GroupViewModel {
+    key: string;
+    name: string;
+    sortOrder: number;
+    properties: UmbPropertyTypeModel[];
+}
+
+export interface TabViewModel {
+    key: string;
+    name: string;
+    sortOrder: number;
+    groups: GroupViewModel[];
+    rootProperties: UmbPropertyTypeModel[];
+}


### PR DESCRIPTION
## Summary

- Route-register the mock entity editor modal via `UmbModalRouteRegistrationController` + `history.pushState`, giving the inner editor a URL-addressable route segment that mirrors how CMS block workspaces open
- Split CMS mock entity editor tabs into a routed sub-component (`cms-mock-entity-editor-tab`) rendered inside `<umb-router-slot>` within `<umb-property-dataset>`, publishing `UMB_ROUTE_CONTEXT`
- Block grid / block list / block rte / block single now register their catalogue/workspace modals correctly — previously "Add block" silently auto-inserted the first allowed type and edit links didn't open

## Test plan

- [ ] Open a test feature with a document-type entity context containing a block grid property
- [ ] Click Edit → verify editor modal opens with tabs highlighted and URL reflecting the active tab
- [ ] Verify block grid "Create new" opens the block catalogue modal (not silent first-block insertion)
- [ ] Select a block type → verify block workspace opens with editable properties
- [ ] Cancel the editor → verify URL resets to the parent workspace path
- [ ] Re-click Edit → verify the editor modal reopens successfully
- [ ] Repeat with block-list and block-rte properties to confirm generalisation

🤖 Generated with [Claude Code](https://claude.com/claude-code)