### PR TITLE
bring `install-demo-site.sln` into parity with `install-demo-site.ps1`

### DIFF
--- a/scripts/install-demo-site.sh
+++ b/scripts/install-demo-site.sh
@@ -68,6 +68,11 @@ fi
 # Step 1: Install Umbraco templates
 if [ "$SKIP_TEMPLATE_INSTALL" = false ]; then
     echo "Installing Umbraco templates..."
+    # Uninstall any existing version to avoid conflicts
+    echo "Removing any existing Umbraco.Templates installations..."
+    if dotnet new uninstall 2>&1 | grep -q "Umbraco\.Templates"; then
+        dotnet new uninstall Umbraco.Templates 2>/dev/null || true
+    fi
     dotnet new install Umbraco.Templates --force
 fi
 

--- a/scripts/install-demo-site.sh
+++ b/scripts/install-demo-site.sh
@@ -105,7 +105,7 @@ cp "$SCRIPT_DIR/templates/NamedPipeListenerComposer.cs" "demo/Umbraco.AI.DemoSit
 
 # Step 4: Create unified solution
 echo "Creating unified solution..."
-dotnet new sln -n "Umbraco.AI.local" --force --format sln
+dotnet new sln -n "Umbraco.AI.local" --force --format slnx
 
 # Helper function to add all projects from a product's src folder
 add_product_projects() {


### PR DESCRIPTION
At the moment, the `install-demo-site.sh` doesn't have feature parity with `install-demo-site.ps1`.

Updated it so that:

- Generates an `.slnx` formatted solution instead of `.sln` formatted solution
- Uninstalls existing `Umbraco.Templates`

It should now have the same outcome as the `.ps1` equivalent, and matches the documented result in `./README.md`