### PR TITLE
feat(chat, agent, core): Add With/Set Contexts and Guardrails on inline builders

### DIFF
--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Agents/AIAgentService.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Agents/AIAgentService.cs
@@ -13,6 +13,7 @@ using Umbraco.AI.AGUI.Events;
 using Umbraco.AI.AGUI.Models;
 using Umbraco.AI.AGUI.Streaming;
 using Umbraco.AI.Core.Chat;
+using Umbraco.AI.Core.Contexts;
 using Umbraco.AI.Core.Guardrails;
 using Umbraco.AI.Core.Models;
 using Umbraco.AI.Core.Profiles;
@@ -45,6 +46,7 @@ internal sealed class AIAgentService : IAIAgentService
     private readonly AIToolCollection _toolCollection;
     private readonly IAIProfileService _profileService;
     private readonly IAIGuardrailService _guardrailService;
+    private readonly IAIContextService _contextService;
     private readonly IAIChatClientFactory _chatClientFactory;
     private readonly AIAgentScopeValidator _scopeValidator;
     private readonly AIAgentSurfaceCollection _surfaceCollection;
@@ -60,6 +62,7 @@ internal sealed class AIAgentService : IAIAgentService
         AIToolCollection toolCollection,
         IAIProfileService profileService,
         IAIGuardrailService guardrailService,
+        IAIContextService contextService,
         IAIChatClientFactory chatClientFactory,
         AIAgentScopeValidator scopeValidator,
         AIAgentSurfaceCollection surfaceCollection,
@@ -75,6 +78,7 @@ internal sealed class AIAgentService : IAIAgentService
         _toolCollection = toolCollection;
         _profileService = profileService;
         _guardrailService = guardrailService;
+        _contextService = contextService;
         _chatClientFactory = chatClientFactory;
         _scopeValidator = scopeValidator;
         _surfaceCollection = surfaceCollection;
@@ -647,6 +651,27 @@ internal sealed class AIAgentService : IAIAgentService
                 await _guardrailService.GetGuardrailIdsByAliasesAsync(aliases, cancellationToken));
         }
 
+        // Resolve additional guardrail aliases to IDs if needed
+        if (builder.AdditionalGuardrailAliases is { Count: > 0 } additionalGuardrailAliases)
+        {
+            builder.SetResolvedAdditionalGuardrailIds(
+                await _guardrailService.GetGuardrailIdsByAliasesAsync(additionalGuardrailAliases, cancellationToken));
+        }
+
+        // Resolve context aliases to IDs if needed (replace)
+        if (builder.ContextAliases is { Count: > 0 } contextAliases)
+        {
+            builder.SetResolvedContextIds(
+                await _contextService.GetContextIdsByAliasesAsync(contextAliases, cancellationToken));
+        }
+
+        // Resolve additional context aliases to IDs if needed (additive)
+        if (builder.AdditionalContextAliases is { Count: > 0 } additionalContextAliases)
+        {
+            builder.SetResolvedAdditionalContextIds(
+                await _contextService.GetContextIdsByAliasesAsync(additionalContextAliases, cancellationToken));
+        }
+
         var agent = builder.Build();
         return (agent, builder);
     }
@@ -666,6 +691,20 @@ internal sealed class AIAgentService : IAIAgentService
         if (builder.ChatOptions is not null)
         {
             properties[CoreConstants.ContextKeys.ChatOptionsOverride] = builder.ChatOptions;
+        }
+
+        // SetGuardrails → replace: the override key suppresses both agent and profile guardrail
+        // resolvers; only the override list applies. Additive (WithGuardrails) lives on agent.GuardrailIds.
+        if (builder.GuardrailIds.Count > 0)
+        {
+            properties[CoreConstants.ContextKeys.GuardrailIdsOverride] = builder.GuardrailIds;
+        }
+
+        // SetContexts → replace: the override key suppresses both agent and profile context resolvers;
+        // only the override list applies. Additive (WithContexts) lives on AIStandardAgentConfig.ContextIds.
+        if (builder.ContextIds is not null)
+        {
+            properties[CoreConstants.ContextKeys.ContextIdsOverride] = builder.ContextIds;
         }
 
         // Merge any additional properties from the builder
@@ -858,7 +897,7 @@ internal sealed class AIAgentService : IAIAgentService
 
         if (options.ContextIdsOverride is not null)
         {
-            additionalProperties[Constants.ContextKeys.ContextIdsOverride] = options.ContextIdsOverride;
+            additionalProperties[CoreConstants.ContextKeys.ContextIdsOverride] = options.ContextIdsOverride;
         }
 
         if (options.GuardrailIdsOverride is not null)

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Constants.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Constants.cs
@@ -42,12 +42,6 @@ public static class Constants
         /// Identifies which UI surface the request originated from (e.g., "copilot", "workspace").
         /// </summary>
         public const string Surface = "Umbraco.AI.Agent.Surface";
-
-        /// <summary>
-        /// Key for context IDs override in runtime context.
-        /// When set, context resolvers use these IDs instead of the agent's configured <see cref="Agents.AIAgent.ContextIds"/>.
-        /// </summary>
-        public const string ContextIdsOverride = "Umbraco.AI.Agent.ContextIdsOverride";
     }
 
     /// <summary>

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Context/AgentContextResolver.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Context/AgentContextResolver.cs
@@ -3,6 +3,7 @@ using Umbraco.AI.Agent.Extensions;
 using Umbraco.AI.Core.Contexts;
 using Umbraco.AI.Core.Contexts.Resolvers;
 using Umbraco.AI.Core.RuntimeContext;
+using CoreConstants = Umbraco.AI.Core.Constants;
 
 namespace Umbraco.AI.Agent.Core.Context;
 
@@ -10,7 +11,7 @@ namespace Umbraco.AI.Agent.Core.Context;
 /// Resolves context from agent-level context assignments.
 /// </summary>
 /// <remarks>
-/// This resolver reads the agent ID from <see cref="Constants.MetadataKeys.AgentId"/> in the request properties,
+/// This resolver reads the agent ID from <see cref="Constants.ContextKeys.AgentId"/> in the request properties,
 /// then resolves any context IDs configured on the agent.
 /// </remarks>
 internal sealed class AgentContextResolver : IAIContextResolver
@@ -38,6 +39,13 @@ internal sealed class AgentContextResolver : IAIContextResolver
     /// <inheritdoc />
     public async Task<AIContextResolverResult> ResolveAsync(CancellationToken cancellationToken = default)
     {
+        // A full override (execution options or builder SetContexts) suppresses this resolver; the
+        // ProfileContextResolver surfaces the override ID set so it's emitted once.
+        if (_runtimeContextAccessor.Context?.GetValue<IReadOnlyList<Guid>>(CoreConstants.ContextKeys.ContextIdsOverride) is not null)
+        {
+            return AIContextResolverResult.Empty;
+        }
+
         var agentId = _runtimeContextAccessor.Context?.GetValue<Guid>(Constants.ContextKeys.AgentId);
         if (!agentId.HasValue)
         {
@@ -45,19 +53,6 @@ internal sealed class AgentContextResolver : IAIContextResolver
         }
 
         var agent = await _agentService.GetAgentAsync(agentId.Value, cancellationToken);
-
-
-        // Check for context IDs override (set by execution options for test scenarios)
-        var contextIdsOverride = _runtimeContextAccessor.Context?.GetValue<IReadOnlyList<Guid>>(Constants.ContextKeys.ContextIdsOverride);
-        if (contextIdsOverride is not null)
-        {
-            if (contextIdsOverride.Count == 0)
-            {
-                return AIContextResolverResult.Empty;
-            }
-
-            return await ResolveContextIdsAsync(contextIdsOverride, agent?.Name, cancellationToken);
-        }
 
         if (agent is null)
         {

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Guardrails/AgentGuardrailResolver.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Guardrails/AgentGuardrailResolver.cs
@@ -2,6 +2,7 @@ using Umbraco.AI.Agent.Core.Agents;
 using Umbraco.AI.Core.Guardrails;
 using Umbraco.AI.Core.Guardrails.Resolvers;
 using Umbraco.AI.Core.RuntimeContext;
+using CoreConstants = Umbraco.AI.Core.Constants;
 
 namespace Umbraco.AI.Agent.Core.Guardrails;
 
@@ -32,6 +33,12 @@ internal sealed class AgentGuardrailResolver : IAIGuardrailResolver
     /// <inheritdoc />
     public async Task<AIGuardrailResolverResult> ResolveAsync(CancellationToken cancellationToken = default)
     {
+        // Override suppresses source-level guardrails entirely.
+        if (_runtimeContextAccessor.Context?.GetValue<IReadOnlyList<Guid>>(CoreConstants.ContextKeys.GuardrailIdsOverride) is not null)
+        {
+            return AIGuardrailResolverResult.Empty;
+        }
+
         var agentId = _runtimeContextAccessor.Context?.GetValue<Guid>(Constants.ContextKeys.AgentId);
         if (!agentId.HasValue)
         {
@@ -45,25 +52,6 @@ internal sealed class AgentGuardrailResolver : IAIGuardrailResolver
         }
 
         var guardrails = await _guardrailService.GetGuardrailsByIdsAsync(agent.GuardrailIds, cancellationToken);
-
-        var allRules = new List<AIGuardrailRule>();
-        var resolvedIds = new List<Guid>();
-
-        foreach (var guardrail in guardrails)
-        {
-            resolvedIds.Add(guardrail.Id);
-            foreach (var rule in guardrail.Rules.OrderBy(r => r.SortOrder))
-            {
-                rule.GuardrailName = guardrail.Name;
-                allRules.Add(rule);
-            }
-        }
-
-        return new AIGuardrailResolverResult
-        {
-            Rules = allRules,
-            GuardrailIds = resolvedIds,
-            Source = agent.Name
-        };
+        return AIGuardrailResolverResult.FromGuardrails(guardrails, source: agent.Name);
     }
 }

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/InlineAgents/AIInlineAgentBuilder.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/InlineAgents/AIInlineAgentBuilder.cs
@@ -1,6 +1,8 @@
 using System.Text.Json;
 using Microsoft.Extensions.AI;
 using Umbraco.AI.Agent.Core.Agents;
+using Umbraco.AI.Core.Contexts;
+using Umbraco.AI.Core.Guardrails;
 using Umbraco.AI.Core.RuntimeContext;
 using Umbraco.AI.Core.Utilities;
 
@@ -26,8 +28,9 @@ namespace Umbraco.AI.Agent.Core.InlineAgents;
 ///     .WithInstructions("Summarize the provided content concisely.")
 ///     .WithToolScopes("content-read")
 ///     .WithProfile("my-chat-profile")
-///     .WithGuardrails("safety-check", "pii-filter"),
+///     .WithGuardrails("safety-check", "pii-filter"), // additive on top of the profile's guardrails
 ///     messages, cancellationToken);
+/// // Use SetGuardrails / SetContexts to replace the profile's configured values.
 /// </code>
 /// <para>
 /// <strong>Orchestrated agent example:</strong>
@@ -55,8 +58,8 @@ public sealed class AIInlineAgentBuilder
     private string? _workflowId;
     private JsonElement? _workflowSettings;
     private IEnumerable<AIRequestContextItem>? _contextItems;
-    private IReadOnlyList<Guid> _guardrailIds = [];
-    private IReadOnlyList<string>? _guardrailAliases;
+    private readonly AIContextBuilderState _aiContexts = new();
+    private readonly AIGuardrailBuilderState _aiGuardrails = new();
     private IReadOnlyDictionary<string, object?>? _additionalProperties;
     private ChatOptions? _chatOptions;
     private JsonElement? _outputSchema;
@@ -195,26 +198,81 @@ public sealed class AIInlineAgentBuilder
     }
 
     /// <summary>
-    /// Sets guardrails for safety and compliance checks by ID.
+    /// Adds stored AI context entries on top of the profile's configured contexts (additive). Use
+    /// <see cref="SetContexts(Guid[])"/> to fully replace.
     /// </summary>
-    /// <param name="guardrailIds">The guardrail IDs to apply.</param>
-    /// <returns>The builder for chaining.</returns>
-    public AIInlineAgentBuilder WithGuardrails(params Guid[] guardrailIds)
+    public AIInlineAgentBuilder WithContexts(params Guid[] contextIds)
     {
-        _guardrailIds = guardrailIds;
-        _guardrailAliases = null;
+        _aiContexts.With(contextIds);
         return this;
     }
 
     /// <summary>
-    /// Sets guardrails for safety and compliance checks by alias.
+    /// Adds stored AI context entries by alias on top of the profile's configured contexts (additive).
+    /// Aliases are resolved to IDs by the service layer.
     /// </summary>
-    /// <param name="guardrailAliases">The guardrail aliases to apply.</param>
-    /// <returns>The builder for chaining.</returns>
+    public AIInlineAgentBuilder WithContexts(params string[] contextAliases)
+    {
+        _aiContexts.WithByAlias(contextAliases);
+        return this;
+    }
+
+    /// <summary>
+    /// Replaces the profile's configured contexts with this set (replace). Pass an empty array to
+    /// explicitly use no contexts.
+    /// </summary>
+    public AIInlineAgentBuilder SetContexts(params Guid[] contextIds)
+    {
+        _aiContexts.Set(contextIds);
+        return this;
+    }
+
+    /// <summary>
+    /// Replaces the profile's configured contexts with this set by alias (replace). Aliases are resolved
+    /// to IDs by the service layer.
+    /// </summary>
+    public AIInlineAgentBuilder SetContexts(params string[] contextAliases)
+    {
+        _aiContexts.SetByAlias(contextAliases);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds guardrails on top of the profile's configured guardrails (additive). Use
+    /// <see cref="SetGuardrails(Guid[])"/> to fully replace.
+    /// </summary>
+    public AIInlineAgentBuilder WithGuardrails(params Guid[] guardrailIds)
+    {
+        _aiGuardrails.With(guardrailIds);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds guardrails by alias on top of the profile's configured guardrails (additive). Aliases are
+    /// resolved to IDs by the service layer.
+    /// </summary>
     public AIInlineAgentBuilder WithGuardrails(params string[] guardrailAliases)
     {
-        _guardrailAliases = guardrailAliases;
-        _guardrailIds = [];
+        _aiGuardrails.WithByAlias(guardrailAliases);
+        return this;
+    }
+
+    /// <summary>
+    /// Replaces the profile's configured guardrails with this set (replace).
+    /// </summary>
+    public AIInlineAgentBuilder SetGuardrails(params Guid[] guardrailIds)
+    {
+        _aiGuardrails.Set(guardrailIds);
+        return this;
+    }
+
+    /// <summary>
+    /// Replaces the profile's configured guardrails with this set by alias (replace). Aliases are
+    /// resolved to IDs by the service layer.
+    /// </summary>
+    public AIInlineAgentBuilder SetGuardrails(params string[] guardrailAliases)
+    {
+        _aiGuardrails.SetByAlias(guardrailAliases);
         return this;
     }
 
@@ -257,10 +315,15 @@ public sealed class AIInlineAgentBuilder
     /// </summary>
     internal string? ProfileAlias => _profileAlias;
 
-    /// <summary>
-    /// Gets the guardrail aliases configured on this builder, if any.
-    /// </summary>
-    internal IReadOnlyList<string>? GuardrailAliases => _guardrailAliases;
+    internal IReadOnlyList<Guid> GuardrailIds => _aiGuardrails.Ids;
+    internal IReadOnlyList<string>? GuardrailAliases => _aiGuardrails.Aliases;
+    internal IReadOnlyList<Guid> AdditionalGuardrailIds => _aiGuardrails.AdditionalIds;
+    internal IReadOnlyList<string>? AdditionalGuardrailAliases => _aiGuardrails.AdditionalAliases;
+
+    internal IReadOnlyList<Guid>? ContextIds => _aiContexts.Ids;
+    internal IReadOnlyList<string>? ContextAliases => _aiContexts.Aliases;
+    internal IReadOnlyList<Guid> AdditionalContextIds => _aiContexts.AdditionalIds;
+    internal IReadOnlyList<string>? AdditionalContextAliases => _aiContexts.AdditionalAliases;
 
     /// <summary>
     /// Gets whether all tools should be included.
@@ -294,10 +357,24 @@ public sealed class AIInlineAgentBuilder
     internal void SetResolvedProfileId(Guid profileId) => _profileId = profileId;
 
     /// <summary>
-    /// Sets resolved guardrail IDs from alias lookup. Used by the service layer
-    /// to resolve aliases before building the agent entity.
+    /// Sets resolved guardrail IDs from alias lookup (replace mode). Used by the service layer.
     /// </summary>
-    internal void SetResolvedGuardrailIds(IReadOnlyList<Guid> guardrailIds) => _guardrailIds = guardrailIds;
+    internal void SetResolvedGuardrailIds(IReadOnlyList<Guid> guardrailIds) => _aiGuardrails.SetResolvedIds(guardrailIds);
+
+    /// <summary>
+    /// Sets resolved additional guardrail IDs from alias lookup (additive mode). Used by the service layer.
+    /// </summary>
+    internal void SetResolvedAdditionalGuardrailIds(IReadOnlyList<Guid> guardrailIds) => _aiGuardrails.SetResolvedAdditionalIds(guardrailIds);
+
+    /// <summary>
+    /// Sets resolved context IDs from alias lookup (replace mode). Used by the service layer.
+    /// </summary>
+    internal void SetResolvedContextIds(IReadOnlyList<Guid> contextIds) => _aiContexts.SetResolvedIds(contextIds);
+
+    /// <summary>
+    /// Sets resolved additional context IDs from alias lookup (additive mode). Used by the service layer.
+    /// </summary>
+    internal void SetResolvedAdditionalContextIds(IReadOnlyList<Guid> contextIds) => _aiContexts.SetResolvedAdditionalIds(contextIds);
 
     /// <summary>
     /// Builds a transient <see cref="AIAgent"/> entity from the builder configuration.
@@ -320,6 +397,9 @@ public sealed class AIInlineAgentBuilder
 
         var isOrchestrated = _workflowId is not null;
 
+        // Additive lists (WithGuardrails / WithContexts) are written onto the agent entity so they flow
+        // through the agent-level resolvers (additive-with-profile). Replace lists (SetGuardrails /
+        // SetContexts) are emitted as runtime-context override keys by BuildAgentProperties.
         var agent = new AIAgent
         {
             Alias = _alias,
@@ -327,7 +407,7 @@ public sealed class AIInlineAgentBuilder
             Description = _description,
             AgentType = isOrchestrated ? AIAgentType.Orchestrated : AIAgentType.Standard,
             ProfileId = _profileId,
-            GuardrailIds = _guardrailIds,
+            GuardrailIds = _aiGuardrails.AdditionalIds,
             IsActive = true,
             SurfaceIds = [],
         };
@@ -350,6 +430,7 @@ public sealed class AIInlineAgentBuilder
                 Instructions = _instructions,
                 AllowedToolIds = _toolIds,
                 AllowedToolScopeIds = _toolScopeIds,
+                ContextIds = _aiContexts.AdditionalIds,
                 OutputSchema = _outputSchema,
             };
         }

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/Agents/AIAgentServiceTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/Agents/AIAgentServiceTests.cs
@@ -36,6 +36,8 @@ public class AIAgentServiceTests
             null!, // IAGUIMessageConverter
             _toolCollection,
             null!, // IAIProfileService
+            null!, // IAIGuardrailService
+            null!, // IAIContextService
             null!, // IAIChatClientFactory
             null!, // AIAgentScopeValidator
             null!, // AIAgentSurfaceCollection

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/Context/AgentContextResolverTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/Context/AgentContextResolverTests.cs
@@ -1,0 +1,63 @@
+using Moq;
+using Shouldly;
+using Umbraco.AI.Agent.Core.Agents;
+using Umbraco.AI.Agent.Core.Context;
+using Umbraco.AI.Core.Contexts;
+using Umbraco.AI.Core.RuntimeContext;
+using Xunit;
+using AgentConstants = Umbraco.AI.Agent.Core.Constants;
+using CoreConstants = Umbraco.AI.Core.Constants;
+
+namespace Umbraco.AI.Agent.Tests.Unit.Context;
+
+/// <summary>
+/// Verifies that AgentContextResolver suppresses itself when a full context override is set on the
+/// runtime context (e.g., via AIInlineAgentBuilder.SetContexts or an execution-options override) —
+/// the ProfileContextResolver surfaces the override set, so the agent resolver must stay silent.
+/// </summary>
+public class AgentContextResolverTests
+{
+    private readonly Mock<IAIContextService> _contextServiceMock = new();
+    private readonly Mock<IAIAgentService> _agentServiceMock = new();
+    private readonly Mock<IAIRuntimeContextAccessor> _runtimeContextAccessorMock = new();
+
+    [Fact]
+    public async Task ResolveAsync_OverridePresent_ReturnsEmpty()
+    {
+        var agentId = Guid.NewGuid();
+        var overrideId = Guid.NewGuid();
+
+        var runtimeContext = new AIRuntimeContext([]);
+        runtimeContext.SetValue(AgentConstants.ContextKeys.AgentId, agentId);
+        runtimeContext.SetValue(CoreConstants.ContextKeys.ContextIdsOverride, (IReadOnlyList<Guid>)[overrideId]);
+        _runtimeContextAccessorMock.Setup(x => x.Context).Returns(runtimeContext);
+
+        var resolver = new AgentContextResolver(
+            _runtimeContextAccessorMock.Object, _contextServiceMock.Object, _agentServiceMock.Object);
+
+        var result = await resolver.ResolveAsync();
+
+        result.Resources.ShouldBeEmpty();
+        result.Sources.ShouldBeEmpty();
+        _agentServiceMock.Verify(
+            x => x.GetAgentAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _contextServiceMock.Verify(
+            x => x.GetContextAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_NoAgentId_ReturnsEmpty()
+    {
+        _runtimeContextAccessorMock.Setup(x => x.Context).Returns(new AIRuntimeContext([]));
+
+        var resolver = new AgentContextResolver(
+            _runtimeContextAccessorMock.Object, _contextServiceMock.Object, _agentServiceMock.Object);
+
+        var result = await resolver.ResolveAsync();
+
+        result.Resources.ShouldBeEmpty();
+        result.Sources.ShouldBeEmpty();
+    }
+}

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/Guardrails/AgentGuardrailResolverTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/Guardrails/AgentGuardrailResolverTests.cs
@@ -1,0 +1,61 @@
+using Moq;
+using Shouldly;
+using Umbraco.AI.Agent.Core.Agents;
+using Umbraco.AI.Agent.Core.Guardrails;
+using Umbraco.AI.Core.Guardrails;
+using Umbraco.AI.Core.RuntimeContext;
+using Xunit;
+using AgentConstants = Umbraco.AI.Agent.Core.Constants;
+using CoreConstants = Umbraco.AI.Core.Constants;
+
+namespace Umbraco.AI.Agent.Tests.Unit.Guardrails;
+
+/// <summary>
+/// Verifies that AgentGuardrailResolver suppresses itself when a full guardrail override is set
+/// on the runtime context (e.g., via AIInlineAgentBuilder.SetGuardrails or an execution-options override).
+/// Mirrors the Core ProfileGuardrailResolver suppression test so the profile/agent/prompt axis is covered.
+/// </summary>
+public class AgentGuardrailResolverTests
+{
+    private readonly Mock<IAIGuardrailService> _guardrailServiceMock = new();
+    private readonly Mock<IAIAgentService> _agentServiceMock = new();
+    private readonly Mock<IAIRuntimeContextAccessor> _runtimeContextAccessorMock = new();
+
+    [Fact]
+    public async Task ResolveAsync_OverridePresent_ReturnsEmpty()
+    {
+        var agentId = Guid.NewGuid();
+        var overrideId = Guid.NewGuid();
+
+        var runtimeContext = new AIRuntimeContext([]);
+        runtimeContext.SetValue(AgentConstants.ContextKeys.AgentId, agentId);
+        runtimeContext.SetValue(CoreConstants.ContextKeys.GuardrailIdsOverride, (IReadOnlyList<Guid>)[overrideId]);
+        _runtimeContextAccessorMock.Setup(x => x.Context).Returns(runtimeContext);
+
+        var resolver = new AgentGuardrailResolver(
+            _runtimeContextAccessorMock.Object, _guardrailServiceMock.Object, _agentServiceMock.Object);
+
+        var result = await resolver.ResolveAsync();
+
+        result.GuardrailIds.ShouldBeEmpty();
+        _agentServiceMock.Verify(
+            x => x.GetAgentAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _guardrailServiceMock.Verify(
+            x => x.GetGuardrailsByIdsAsync(It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_NoAgentId_ReturnsEmpty()
+    {
+        _runtimeContextAccessorMock.Setup(x => x.Context).Returns(new AIRuntimeContext([]));
+
+        var resolver = new AgentGuardrailResolver(
+            _runtimeContextAccessorMock.Object, _guardrailServiceMock.Object, _agentServiceMock.Object);
+
+        var result = await resolver.ResolveAsync();
+
+        result.GuardrailIds.ShouldBeEmpty();
+    }
+}

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/InlineAgents/AIInlineAgentBuilderTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/InlineAgents/AIInlineAgentBuilderTests.cs
@@ -245,4 +245,81 @@ public class AIInlineAgentBuilderTests
         // Assert
         builder.ChatOptions.ShouldBeNull();
     }
+
+    [Fact]
+    public void Build_WithContexts_ById_WritesToConfigContextIds_Additive()
+    {
+        // Arrange
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        var builder = new AIInlineAgentBuilder();
+        builder.WithAlias("test-agent").WithContexts(a, b);
+
+        // Act
+        var agent = builder.Build();
+
+        // Assert — WithContexts is additive: contexts flow via agent.Config.ContextIds so
+        // AgentContextResolver emits them alongside the profile's contexts.
+        var config = (AIStandardAgentConfig)agent.Config!;
+        config.ContextIds.ShouldBe([a, b]);
+    }
+
+    [Fact]
+    public void WithContexts_ByAlias_ExposesAdditionalAliases()
+    {
+        // Arrange
+        var builder = new AIInlineAgentBuilder();
+        builder.WithAlias("test-agent").WithContexts("brand", "guidelines");
+
+        // Assert
+        builder.AdditionalContextAliases.ShouldBe(["brand", "guidelines"]);
+        builder.ContextAliases.ShouldBeNull();
+    }
+
+    [Fact]
+    public void WithContexts_ByAlias_ThenSetResolved_PopulatesConfig()
+    {
+        // Arrange
+        var resolvedId = Guid.NewGuid();
+        var builder = new AIInlineAgentBuilder();
+        builder.WithAlias("test-agent").WithContexts("brand");
+
+        // Act
+        builder.SetResolvedAdditionalContextIds([resolvedId]);
+        var agent = builder.Build();
+
+        // Assert
+        var config = (AIStandardAgentConfig)agent.Config!;
+        config.ContextIds.ShouldBe([resolvedId]);
+    }
+
+    [Fact]
+    public void SetContexts_ById_ExposesReplaceContextIds()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var builder = new AIInlineAgentBuilder();
+        builder.WithAlias("test-agent").SetContexts(id);
+
+        // Assert — SetContexts is replace: carried on the builder and emitted as a runtime override
+        // key; does not touch agent.Config.ContextIds.
+        builder.ContextIds.ShouldBe([id]);
+        var agent = builder.Build();
+        ((AIStandardAgentConfig)agent.Config!).ContextIds.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Build_WithoutContexts_HasEmptyContextIds()
+    {
+        // Arrange
+        var builder = new AIInlineAgentBuilder();
+        builder.WithAlias("test-agent");
+
+        // Act
+        var agent = builder.Build();
+
+        // Assert
+        var config = (AIStandardAgentConfig)agent.Config!;
+        config.ContextIds.ShouldBeEmpty();
+    }
 }

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Constants.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Constants.cs
@@ -14,16 +14,10 @@ public static class Constants
         /// Key for prompt ID in metadata collections.
         /// </summary>
         public const string PromptId = "Umbraco.AI.PromptId";
-        
+
         /// <summary>
         /// Key for prompt alias in metadata collections.
         /// </summary>
         public const string PromptAlias = "Umbraco.AI.PromptAlias";
-
-        /// <summary>
-        /// Key for context IDs override in runtime context.
-        /// When set, context resolvers use these IDs instead of the prompt's configured <see cref="Prompts.AIPrompt.ContextIds"/>.
-        /// </summary>
-        public const string ContextIdsOverride = "Umbraco.AI.Prompt.ContextIdsOverride";
     }
-} 
+}

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Context/PromptContextResolver.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Context/PromptContextResolver.cs
@@ -2,6 +2,7 @@ using Umbraco.AI.Core.Contexts;
 using Umbraco.AI.Core.Contexts.Resolvers;
 using Umbraco.AI.Core.RuntimeContext;
 using Umbraco.AI.Prompt.Core.Prompts;
+using CoreConstants = Umbraco.AI.Core.Constants;
 
 namespace Umbraco.AI.Prompt.Core.Context;
 
@@ -37,6 +38,13 @@ internal sealed class PromptContextResolver : IAIContextResolver
     /// <inheritdoc />
     public async Task<AIContextResolverResult> ResolveAsync(CancellationToken cancellationToken = default)
     {
+        // A full override (execution options or builder SetContexts) suppresses this resolver; the
+        // ProfileContextResolver surfaces the override ID set so it's emitted once.
+        if (_runtimeContextAccessor.Context?.GetValue<IReadOnlyList<Guid>>(CoreConstants.ContextKeys.ContextIdsOverride) is not null)
+        {
+            return AIContextResolverResult.Empty;
+        }
+
         var promptId = _runtimeContextAccessor.Context?.GetValue<Guid>(Constants.MetadataKeys.PromptId);
         if (!promptId.HasValue)
         {
@@ -44,18 +52,6 @@ internal sealed class PromptContextResolver : IAIContextResolver
         }
 
         var prompt = await _promptService.GetPromptAsync(promptId.Value, cancellationToken);
-
-        // Check for context IDs override (set by execution options for test scenarios)
-        var contextIdsOverride = _runtimeContextAccessor.Context?.GetValue<IReadOnlyList<Guid>>(Constants.MetadataKeys.ContextIdsOverride);
-        if (contextIdsOverride is not null)
-        {
-            if (contextIdsOverride.Count == 0)
-            {
-                return AIContextResolverResult.Empty;
-            }
-
-            return await ResolveContextIdsAsync(contextIdsOverride, prompt?.Name, cancellationToken);
-        }
 
         if (prompt is null || prompt.ContextIds.Count == 0)
         {

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Guardrails/PromptGuardrailResolver.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Guardrails/PromptGuardrailResolver.cs
@@ -2,6 +2,7 @@ using Umbraco.AI.Core.Guardrails;
 using Umbraco.AI.Core.Guardrails.Resolvers;
 using Umbraco.AI.Core.RuntimeContext;
 using Umbraco.AI.Prompt.Core.Prompts;
+using CoreConstants = Umbraco.AI.Core.Constants;
 
 namespace Umbraco.AI.Prompt.Core.Guardrails;
 
@@ -31,6 +32,12 @@ internal sealed class PromptGuardrailResolver : IAIGuardrailResolver
     /// <inheritdoc />
     public async Task<AIGuardrailResolverResult> ResolveAsync(CancellationToken cancellationToken = default)
     {
+        // Override suppresses source-level guardrails entirely.
+        if (_runtimeContextAccessor.Context?.GetValue<IReadOnlyList<Guid>>(CoreConstants.ContextKeys.GuardrailIdsOverride) is not null)
+        {
+            return AIGuardrailResolverResult.Empty;
+        }
+
         var promptId = _runtimeContextAccessor.Context?.GetValue<Guid>(Constants.MetadataKeys.PromptId);
         if (!promptId.HasValue)
         {
@@ -44,25 +51,6 @@ internal sealed class PromptGuardrailResolver : IAIGuardrailResolver
         }
 
         var guardrails = await _guardrailService.GetGuardrailsByIdsAsync(prompt.GuardrailIds, cancellationToken);
-
-        var allRules = new List<AIGuardrailRule>();
-        var resolvedIds = new List<Guid>();
-
-        foreach (var guardrail in guardrails)
-        {
-            resolvedIds.Add(guardrail.Id);
-            foreach (var rule in guardrail.Rules.OrderBy(r => r.SortOrder))
-            {
-                rule.GuardrailName = guardrail.Name;
-                allRules.Add(rule);
-            }
-        }
-
-        return new AIGuardrailResolverResult
-        {
-            Rules = allRules,
-            GuardrailIds = resolvedIds,
-            Source = prompt.Name
-        };
+        return AIGuardrailResolverResult.FromGuardrails(guardrails, source: prompt.Name);
     }
 }

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptService.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptService.cs
@@ -263,10 +263,11 @@ internal sealed class AIPromptService : IAIPromptService
         runtimeContext.SetValue(CoreConstants.ContextKeys.FeatureAlias, prompt.Alias);
         runtimeContext.SetValue(CoreConstants.ContextKeys.FeatureVersion, prompt.Version);
 
-        // Set context IDs override in runtime context for PromptContextResolver to pick up
+        // Set context IDs override in runtime context — full replace (all context resolvers suppress
+        // themselves when this core key is set; ProfileContextResolver then surfaces the override set).
         if (options.ContextIdsOverride is not null)
         {
-            runtimeContext.SetValue(Constants.MetadataKeys.ContextIdsOverride, options.ContextIdsOverride);
+            runtimeContext.SetValue(CoreConstants.ContextKeys.ContextIdsOverride, options.ContextIdsOverride);
         }
 
         // Set guardrail IDs override in runtime context for guardrail resolvers to pick up

--- a/Umbraco.AI.Prompt/tests/Umbraco.AI.Prompt.Tests.Unit/Context/PromptContextResolverTests.cs
+++ b/Umbraco.AI.Prompt/tests/Umbraco.AI.Prompt.Tests.Unit/Context/PromptContextResolverTests.cs
@@ -1,0 +1,63 @@
+using Moq;
+using Shouldly;
+using Umbraco.AI.Core.Contexts;
+using Umbraco.AI.Core.RuntimeContext;
+using Umbraco.AI.Prompt.Core.Context;
+using Umbraco.AI.Prompt.Core.Prompts;
+using Xunit;
+using CoreConstants = Umbraco.AI.Core.Constants;
+using PromptConstants = Umbraco.AI.Prompt.Core.Constants;
+
+namespace Umbraco.AI.Prompt.Tests.Unit.Context;
+
+/// <summary>
+/// Verifies that PromptContextResolver suppresses itself when a full context override is set on the
+/// runtime context — the ProfileContextResolver surfaces the override set, so the prompt resolver
+/// must stay silent.
+/// </summary>
+public class PromptContextResolverTests
+{
+    private readonly Mock<IAIContextService> _contextServiceMock = new();
+    private readonly Mock<IAIPromptService> _promptServiceMock = new();
+    private readonly Mock<IAIRuntimeContextAccessor> _runtimeContextAccessorMock = new();
+
+    [Fact]
+    public async Task ResolveAsync_OverridePresent_ReturnsEmpty()
+    {
+        var promptId = Guid.NewGuid();
+        var overrideId = Guid.NewGuid();
+
+        var runtimeContext = new AIRuntimeContext([]);
+        runtimeContext.SetValue(PromptConstants.MetadataKeys.PromptId, promptId);
+        runtimeContext.SetValue(CoreConstants.ContextKeys.ContextIdsOverride, (IReadOnlyList<Guid>)[overrideId]);
+        _runtimeContextAccessorMock.Setup(x => x.Context).Returns(runtimeContext);
+
+        var resolver = new PromptContextResolver(
+            _runtimeContextAccessorMock.Object, _contextServiceMock.Object, _promptServiceMock.Object);
+
+        var result = await resolver.ResolveAsync();
+
+        result.Resources.ShouldBeEmpty();
+        result.Sources.ShouldBeEmpty();
+        _promptServiceMock.Verify(
+            x => x.GetPromptAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _contextServiceMock.Verify(
+            x => x.GetContextAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_NoPromptId_ReturnsEmpty()
+    {
+        _runtimeContextAccessorMock.Setup(x => x.Context).Returns(new AIRuntimeContext([]));
+
+        var resolver = new PromptContextResolver(
+            _runtimeContextAccessorMock.Object, _contextServiceMock.Object, _promptServiceMock.Object);
+
+        var result = await resolver.ResolveAsync();
+
+        result.Resources.ShouldBeEmpty();
+        result.Sources.ShouldBeEmpty();
+    }
+}

--- a/Umbraco.AI.Prompt/tests/Umbraco.AI.Prompt.Tests.Unit/Guardrails/PromptGuardrailResolverTests.cs
+++ b/Umbraco.AI.Prompt/tests/Umbraco.AI.Prompt.Tests.Unit/Guardrails/PromptGuardrailResolverTests.cs
@@ -1,0 +1,61 @@
+using Moq;
+using Shouldly;
+using Umbraco.AI.Core.Guardrails;
+using Umbraco.AI.Core.RuntimeContext;
+using Umbraco.AI.Prompt.Core.Guardrails;
+using Umbraco.AI.Prompt.Core.Prompts;
+using Xunit;
+using CoreConstants = Umbraco.AI.Core.Constants;
+using PromptConstants = Umbraco.AI.Prompt.Core.Constants;
+
+namespace Umbraco.AI.Prompt.Tests.Unit.Guardrails;
+
+/// <summary>
+/// Verifies that PromptGuardrailResolver suppresses itself when a full guardrail override is set on
+/// the runtime context. Mirrors the Core ProfileGuardrailResolver suppression test so the
+/// profile/agent/prompt axis is covered end to end.
+/// </summary>
+public class PromptGuardrailResolverTests
+{
+    private readonly Mock<IAIGuardrailService> _guardrailServiceMock = new();
+    private readonly Mock<IAIPromptService> _promptServiceMock = new();
+    private readonly Mock<IAIRuntimeContextAccessor> _runtimeContextAccessorMock = new();
+
+    [Fact]
+    public async Task ResolveAsync_OverridePresent_ReturnsEmpty()
+    {
+        var promptId = Guid.NewGuid();
+        var overrideId = Guid.NewGuid();
+
+        var runtimeContext = new AIRuntimeContext([]);
+        runtimeContext.SetValue(PromptConstants.MetadataKeys.PromptId, promptId);
+        runtimeContext.SetValue(CoreConstants.ContextKeys.GuardrailIdsOverride, (IReadOnlyList<Guid>)[overrideId]);
+        _runtimeContextAccessorMock.Setup(x => x.Context).Returns(runtimeContext);
+
+        var resolver = new PromptGuardrailResolver(
+            _runtimeContextAccessorMock.Object, _guardrailServiceMock.Object, _promptServiceMock.Object);
+
+        var result = await resolver.ResolveAsync();
+
+        result.GuardrailIds.ShouldBeEmpty();
+        _promptServiceMock.Verify(
+            x => x.GetPromptAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _guardrailServiceMock.Verify(
+            x => x.GetGuardrailsByIdsAsync(It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_NoPromptId_ReturnsEmpty()
+    {
+        _runtimeContextAccessorMock.Setup(x => x.Context).Returns(new AIRuntimeContext([]));
+
+        var resolver = new PromptGuardrailResolver(
+            _runtimeContextAccessorMock.Object, _guardrailServiceMock.Object, _promptServiceMock.Object);
+
+        var result = await resolver.ResolveAsync();
+
+        result.GuardrailIds.ShouldBeEmpty();
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Chat/AIChatService.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Chat/AIChatService.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Options;
+using Umbraco.AI.Core.Contexts;
 using Umbraco.AI.Core.Guardrails;
 using Umbraco.AI.Core.InlineChat;
 using Umbraco.AI.Core.Models;
@@ -18,6 +19,7 @@ internal sealed class AIChatService : IAIChatService
     private readonly IAIChatClientFactory _clientFactory;
     private readonly IAIProfileService _profileService;
     private readonly IAIGuardrailService _guardrailService;
+    private readonly IAIContextService _contextService;
     private readonly AIOptions _options;
     private readonly IEventAggregator _eventAggregator;
     private readonly IAIRuntimeContextAccessor _contextAccessor;
@@ -30,6 +32,7 @@ internal sealed class AIChatService : IAIChatService
         IAIChatClientFactory clientFactory,
         IAIProfileService profileService,
         IAIGuardrailService guardrailService,
+        IAIContextService contextService,
         IOptionsMonitor<AIOptions> options,
         IEventAggregator eventAggregator,
         IAIRuntimeContextAccessor contextAccessor,
@@ -41,6 +44,7 @@ internal sealed class AIChatService : IAIChatService
         _clientFactory = clientFactory;
         _profileService = profileService;
         _guardrailService = guardrailService;
+        _contextService = contextService;
         _options = options.CurrentValue;
         _eventAggregator = eventAggregator;
         _contextAccessor = contextAccessor;
@@ -335,9 +339,25 @@ internal sealed class AIChatService : IAIChatService
             builder.SetResolvedGuardrailIds(
                 await _guardrailService.GetGuardrailIdsByAliasesAsync(aliases, cancellationToken));
         }
+
+        if (builder.AdditionalGuardrailAliases is { Count: > 0 } additionalGuardrailAliases)
+        {
+            builder.SetResolvedAdditionalGuardrailIds(
+                await _guardrailService.GetGuardrailIdsByAliasesAsync(additionalGuardrailAliases, cancellationToken));
+        }
+
+        if (builder.ContextAliases is { Count: > 0 } contextAliases)
+        {
+            builder.SetResolvedContextIds(
+                await _contextService.GetContextIdsByAliasesAsync(contextAliases, cancellationToken));
+        }
+
+        if (builder.AdditionalContextAliases is { Count: > 0 } additionalContextAliases)
+        {
+            builder.SetResolvedAdditionalContextIds(
+                await _contextService.GetContextIdsByAliasesAsync(additionalContextAliases, cancellationToken));
+        }
     }
-
-
 
     private static ChatOptions MergeOptions(AIProfile profile, ChatOptions? callerOptions)
     {

--- a/Umbraco.AI/src/Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.cs
@@ -224,10 +224,13 @@ public static partial class UmbracoBuilderExtensions
         builder.AIGuardrailEvaluators()
             .Add(() => builder.TypeLoader.GetTypesWithAttribute<IAIGuardrailEvaluator, AIGuardrailEvaluatorAttribute>(cache: true));
 
-        // Guardrail resolution - pluggable resolver system
+        // Guardrail resolution - pluggable resolver system.
+        // Order: override first (only runs if set; source resolvers suppress themselves when override is set),
+        // then source resolvers (profile/agent/prompt), then additional (always additive on top).
         builder.AIGuardrailResolvers()
             .Append<GuardrailIdsOverrideResolver>()
-            .Append<ProfileGuardrailResolver>();
+            .Append<ProfileGuardrailResolver>()
+            .Append<AdditionalGuardrailIdsResolver>();
         services.AddSingleton<IAIGuardrailResolutionService, AIGuardrailResolutionService>();
 
         // Entity adapter infrastructure

--- a/Umbraco.AI/src/Umbraco.AI.Core/Constants.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Constants.cs
@@ -187,11 +187,19 @@ public static class Constants
 
         /// <summary>
         /// Key for guardrail IDs override in runtime context.
-        /// When set, the guardrail resolution system uses these IDs instead of (or in addition to)
-        /// the guardrails configured on the profile, prompt, or agent.
-        /// Used by the test execution system to override guardrails for testing scenarios.
+        /// When set, the guardrail resolution system uses only these IDs, suppressing guardrails
+        /// configured on the profile, prompt, or agent.
+        /// Used by the inline chat/agent builders and by the test execution system.
         /// </summary>
         public const string GuardrailIdsOverride = "Umbraco.AI.GuardrailIdsOverride";
+
+        /// <summary>
+        /// Key for additional guardrail IDs in runtime context.
+        /// When set, these IDs are resolved and appended to guardrails configured on the profile, prompt,
+        /// or agent (order: sources first, then additional, deduplicated). Used by the inline chat/agent
+        /// builders to extend rather than replace the default guardrails.
+        /// </summary>
+        public const string AdditionalGuardrailIds = "Umbraco.AI.AdditionalGuardrailIds";
 
         /// <summary>
         /// Key for chat options override in runtime context.
@@ -200,5 +208,21 @@ public static class Constants
         /// Used by inline agent and inline chat builders to pass ChatOptions through the middleware pipeline.
         /// </summary>
         public const string ChatOptionsOverride = "Umbraco.AI.ChatOptionsOverride";
+
+        /// <summary>
+        /// Key for context IDs override in runtime context.
+        /// When set, <see cref="Contexts.Resolvers.ProfileContextResolver"/> uses these IDs instead of
+        /// the context IDs configured on the profile. Used by the inline chat builder to attach specific
+        /// <see cref="Models.AIContext"/> entries per-call.
+        /// </summary>
+        public const string ContextIdsOverride = "Umbraco.AI.ContextIdsOverride";
+
+        /// <summary>
+        /// Key for additional context IDs in runtime context.
+        /// When set, <see cref="Contexts.Resolvers.ProfileContextResolver"/> appends these IDs to the ones
+        /// configured on the profile (order: profile contexts first, then additional). Used by the inline
+        /// chat builder to extend rather than replace the profile's configured contexts.
+        /// </summary>
+        public const string AdditionalContextIds = "Umbraco.AI.AdditionalContextIds";
     }
 }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Contexts/AIContextBuilderState.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Contexts/AIContextBuilderState.cs
@@ -1,0 +1,85 @@
+using Umbraco.AI.Core.RuntimeContext;
+
+namespace Umbraco.AI.Core.Contexts;
+
+/// <summary>
+/// Shared context-selection state for the inline builders. Unlike guardrails, the replace-mode list is
+/// nullable so that <c>SetContexts(Array.Empty&lt;Guid&gt;())</c> can signal "explicitly use no contexts"
+/// (empty override) distinct from "not set".
+/// </summary>
+internal sealed class AIContextBuilderState
+{
+    private IReadOnlyList<Guid>? _ids;
+    private IReadOnlyList<string>? _aliases;
+    private IReadOnlyList<Guid> _additionalIds = [];
+    private IReadOnlyList<string>? _additionalAliases;
+
+    public IReadOnlyList<Guid>? Ids => _ids;
+    public IReadOnlyList<string>? Aliases => _aliases;
+    public IReadOnlyList<Guid> AdditionalIds => _additionalIds;
+    public IReadOnlyList<string>? AdditionalAliases => _additionalAliases;
+
+    public void Set(Guid[] ids)
+    {
+        _ids = ids;
+        _aliases = null;
+    }
+
+    public void SetByAlias(string[] aliases)
+    {
+        _aliases = aliases;
+        _ids = null;
+    }
+
+    public void With(Guid[] ids)
+    {
+        _additionalIds = ids;
+        _additionalAliases = null;
+    }
+
+    public void WithByAlias(string[] aliases)
+    {
+        _additionalAliases = aliases;
+        _additionalIds = [];
+    }
+
+    public void SetResolvedIds(IReadOnlyList<Guid> ids) => _ids = ids;
+
+    public void SetResolvedAdditionalIds(IReadOnlyList<Guid> ids) => _additionalIds = ids;
+
+    /// <summary>
+    /// Writes the replace (override) and additive lists onto the runtime context under the core context
+    /// override / additional keys. Override is emitted whenever <see cref="Set"/> has been called — even
+    /// with an empty array — so that the override can explicitly suppress profile contexts.
+    /// </summary>
+    public void WriteToContext(AIRuntimeContext context)
+    {
+        if (_ids is not null)
+        {
+            context.SetValue(Constants.ContextKeys.ContextIdsOverride, _ids);
+        }
+
+        if (_additionalIds.Count > 0)
+        {
+            context.SetValue(Constants.ContextKeys.AdditionalContextIds, _additionalIds);
+        }
+    }
+
+    /// <summary>
+    /// Writes the replace (override) and additive lists into an additional-properties dictionary
+    /// (used by the agent service, which emits them when creating the MAF agent instead of populating
+    /// a runtime context directly).
+    /// </summary>
+    public void WriteTo(IDictionary<string, object?> properties)
+    {
+        if (_ids is not null)
+        {
+            properties[Constants.ContextKeys.ContextIdsOverride] = _ids;
+        }
+
+        if (_additionalIds.Count > 0)
+        {
+            properties[Constants.ContextKeys.AdditionalContextIds] = _additionalIds;
+        }
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Contexts/Resolvers/ProfileContextResolver.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Contexts/Resolvers/ProfileContextResolver.cs
@@ -8,7 +8,10 @@ namespace Umbraco.AI.Core.Contexts.Resolvers;
 /// </summary>
 /// <remarks>
 /// This resolver reads the profile ID from <see cref="Constants.ContextKeys.ProfileId"/> in the request properties,
-/// then resolves any context IDs configured on the profile's chat settings.
+/// then resolves any context IDs configured on the profile's chat settings. It also honors
+/// <see cref="Constants.ContextKeys.ContextIdsOverride"/> set by the inline chat builder (via
+/// <see cref="InlineChat.AIChatBuilder.WithContexts(Guid[])"/>), using the override list in place of
+/// the profile's configured context IDs.
 /// </remarks>
 internal sealed class ProfileContextResolver : IAIContextResolver
 {
@@ -35,19 +38,60 @@ internal sealed class ProfileContextResolver : IAIContextResolver
     /// <inheritdoc />
     public async Task<AIContextResolverResult> ResolveAsync(CancellationToken cancellationToken = default)
     {
+        var contextIdsOverride = _runtimeContextAccessor.Context?.GetValue<IReadOnlyList<Guid>>(Constants.ContextKeys.ContextIdsOverride);
+        var additionalContextIds = _runtimeContextAccessor.Context?.GetValue<IReadOnlyList<Guid>>(Constants.ContextKeys.AdditionalContextIds);
+
+        // Short-circuit: when override is set we don't need the profile's configured contexts,
+        // and when neither override nor additional is set we need a profile to source any contexts.
         var profileId = _runtimeContextAccessor.Context?.GetValue<Guid>(Constants.ContextKeys.ProfileId);
         if (!profileId.HasValue)
         {
             return AIContextResolverResult.Empty;
         }
 
-        var profile = await _profileService.GetProfileAsync(profileId.Value, cancellationToken);
-        if (profile?.Settings is not AIChatProfileSettings chatSettings || chatSettings.ContextIds.Count == 0)
+        IReadOnlyList<Guid> baseIds;
+        string? entityName;
+
+        if (contextIdsOverride is not null)
+        {
+            // Override replaces the profile's configured contexts; skip fetching the profile for its ContextIds.
+            baseIds = contextIdsOverride;
+            entityName = null;
+        }
+        else
+        {
+            var profile = await _profileService.GetProfileAsync(profileId.Value, cancellationToken);
+            baseIds = profile?.Settings is AIChatProfileSettings chatSettings ? chatSettings.ContextIds : [];
+            entityName = profile?.Name;
+        }
+
+        var combined = Combine(baseIds, additionalContextIds);
+        if (combined.Count == 0)
         {
             return AIContextResolverResult.Empty;
         }
 
-        return await ResolveContextIdsAsync(chatSettings.ContextIds, profile.Name, cancellationToken);
+        return await ResolveContextIdsAsync(combined, entityName, cancellationToken);
+    }
+
+    private static IReadOnlyList<Guid> Combine(IReadOnlyList<Guid> primary, IReadOnlyList<Guid>? additional)
+    {
+        if (additional is null || additional.Count == 0)
+        {
+            return primary;
+        }
+
+        var combined = new List<Guid>(primary.Count + additional.Count);
+        combined.AddRange(primary);
+        foreach (var id in additional)
+        {
+            if (!combined.Contains(id))
+            {
+                combined.Add(id);
+            }
+        }
+
+        return combined;
     }
 
     private async Task<AIContextResolverResult> ResolveContextIdsAsync(

--- a/Umbraco.AI/src/Umbraco.AI.Core/Embeddings/AIEmbeddingBuilder.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Embeddings/AIEmbeddingBuilder.cs
@@ -16,7 +16,7 @@ namespace Umbraco.AI.Core.Embeddings;
 /// var embeddings = await embeddingService.GenerateEmbeddingsAsync(emb => emb
 ///     .WithAlias("content-search")
 ///     .WithProfile("ada-embedding")
-///     .WithGuardrails(guardrailId),
+///     .WithGuardrails(guardrailId),   // additive on top of the profile's guardrails
 ///     values, cancellationToken);
 /// </code>
 /// </remarks>
@@ -33,8 +33,7 @@ public sealed class AIEmbeddingBuilder
     private string? _profileAlias;
     private EmbeddingGenerationOptions? _embeddingOptions;
     private IEnumerable<AIRequestContextItem>? _contextItems;
-    private IReadOnlyList<Guid> _guardrailIds = [];
-    private IReadOnlyList<string>? _guardrailAliases;
+    private readonly Guardrails.AIGuardrailBuilderState _aiGuardrails = new();
     private IReadOnlyDictionary<string, object?>? _additionalProperties;
     private bool _isPassThrough;
 
@@ -122,26 +121,41 @@ public sealed class AIEmbeddingBuilder
     }
 
     /// <summary>
-    /// Sets guardrails for safety and compliance checks by ID.
+    /// Adds guardrails on top of the profile's configured guardrails (additive). Use
+    /// <see cref="SetGuardrails(Guid[])"/> to fully replace.
     /// </summary>
-    /// <param name="guardrailIds">The guardrail IDs to apply.</param>
-    /// <returns>The builder for chaining.</returns>
     public AIEmbeddingBuilder WithGuardrails(params Guid[] guardrailIds)
     {
-        _guardrailIds = guardrailIds;
-        _guardrailAliases = null;
+        _aiGuardrails.With(guardrailIds);
         return this;
     }
 
     /// <summary>
-    /// Sets guardrails for safety and compliance checks by alias.
+    /// Adds guardrails by alias on top of the profile's configured guardrails (additive). Aliases are
+    /// resolved to IDs by the service layer.
     /// </summary>
-    /// <param name="guardrailAliases">The guardrail aliases to apply.</param>
-    /// <returns>The builder for chaining.</returns>
     public AIEmbeddingBuilder WithGuardrails(params string[] guardrailAliases)
     {
-        _guardrailAliases = guardrailAliases;
-        _guardrailIds = [];
+        _aiGuardrails.WithByAlias(guardrailAliases);
+        return this;
+    }
+
+    /// <summary>
+    /// Replaces the profile's configured guardrails with this set (replace).
+    /// </summary>
+    public AIEmbeddingBuilder SetGuardrails(params Guid[] guardrailIds)
+    {
+        _aiGuardrails.Set(guardrailIds);
+        return this;
+    }
+
+    /// <summary>
+    /// Replaces the profile's configured guardrails with this set by alias (replace). Aliases are resolved
+    /// to IDs by the service layer.
+    /// </summary>
+    public AIEmbeddingBuilder SetGuardrails(params string[] guardrailAliases)
+    {
+        _aiGuardrails.SetByAlias(guardrailAliases);
         return this;
     }
 
@@ -175,12 +189,15 @@ public sealed class AIEmbeddingBuilder
     internal string? ProfileAlias => _profileAlias;
     internal EmbeddingGenerationOptions? EmbeddingOptions => _embeddingOptions;
     internal IEnumerable<AIRequestContextItem>? ContextItems => _contextItems;
-    internal IReadOnlyList<Guid> GuardrailIds => _guardrailIds;
-    internal IReadOnlyList<string>? GuardrailAliases => _guardrailAliases;
+    internal IReadOnlyList<Guid> GuardrailIds => _aiGuardrails.Ids;
+    internal IReadOnlyList<string>? GuardrailAliases => _aiGuardrails.Aliases;
+    internal IReadOnlyList<Guid> AdditionalGuardrailIds => _aiGuardrails.AdditionalIds;
+    internal IReadOnlyList<string>? AdditionalGuardrailAliases => _aiGuardrails.AdditionalAliases;
     internal IReadOnlyDictionary<string, object?>? AdditionalProperties => _additionalProperties;
     internal bool IsPassThrough => _isPassThrough;
 
-    internal void SetResolvedGuardrailIds(IReadOnlyList<Guid> guardrailIds) => _guardrailIds = guardrailIds;
+    internal void SetResolvedGuardrailIds(IReadOnlyList<Guid> guardrailIds) => _aiGuardrails.SetResolvedIds(guardrailIds);
+    internal void SetResolvedAdditionalGuardrailIds(IReadOnlyList<Guid> guardrailIds) => _aiGuardrails.SetResolvedAdditionalIds(guardrailIds);
 
     internal void Validate()
     {
@@ -199,10 +216,7 @@ public sealed class AIEmbeddingBuilder
             context.SetValue(Constants.ContextKeys.FeatureAlias, Alias);
         }
 
-        if (_guardrailIds.Count > 0)
-        {
-            context.SetValue(Constants.ContextKeys.GuardrailIdsOverride, _guardrailIds);
-        }
+        _aiGuardrails.WriteToContext(context);
 
         if (_additionalProperties is not null)
         {

--- a/Umbraco.AI/src/Umbraco.AI.Core/Embeddings/AIEmbeddingService.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Embeddings/AIEmbeddingService.cs
@@ -230,6 +230,12 @@ internal sealed class AIEmbeddingService : IAIEmbeddingService
             builder.SetResolvedGuardrailIds(
                 await _guardrailService.GetGuardrailIdsByAliasesAsync(aliases, cancellationToken));
         }
+
+        if (builder.AdditionalGuardrailAliases is { Count: > 0 } additionalAliases)
+        {
+            builder.SetResolvedAdditionalGuardrailIds(
+                await _guardrailService.GetGuardrailIdsByAliasesAsync(additionalAliases, cancellationToken));
+        }
     }
 
     private static EmbeddingGenerationOptions? MergeOptions(AIProfile profile, EmbeddingGenerationOptions? callerOptions)

--- a/Umbraco.AI/src/Umbraco.AI.Core/Extensions/AIContextServiceAliasExtensions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Extensions/AIContextServiceAliasExtensions.cs
@@ -1,0 +1,38 @@
+using Umbraco.AI.Core.Contexts;
+
+namespace Umbraco.AI.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="IAIContextService"/> to support alias-based lookups.
+/// </summary>
+public static class AIContextServiceAliasExtensions
+{
+    /// <summary>
+    /// Resolves a list of context aliases to their corresponding IDs.
+    /// </summary>
+    /// <param name="service">The context service.</param>
+    /// <param name="aliases">The context aliases to resolve.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The resolved context IDs in the same order as the input aliases.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when a context alias is not found.</exception>
+    public static async Task<IReadOnlyList<Guid>> GetContextIdsByAliasesAsync(
+        this IAIContextService service,
+        IReadOnlyList<string> aliases,
+        CancellationToken cancellationToken = default)
+    {
+        var resolvedIds = new List<Guid>(aliases.Count);
+
+        foreach (var alias in aliases)
+        {
+            var context = await service.GetContextByAliasAsync(alias, cancellationToken);
+            if (context is null)
+            {
+                throw new InvalidOperationException($"AI context with alias '{alias}' not found.");
+            }
+
+            resolvedIds.Add(context.Id);
+        }
+
+        return resolvedIds;
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/AIGuardrailBuilderState.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/AIGuardrailBuilderState.cs
@@ -1,0 +1,85 @@
+using Umbraco.AI.Core.RuntimeContext;
+
+namespace Umbraco.AI.Core.Guardrails;
+
+/// <summary>
+/// Shared guardrail-selection state for the inline builders (chat / agent / speech-to-text / embedding).
+/// Holds the replace-mode and additive-mode lists (IDs and aliases) and knows how to emit the matching
+/// runtime-context keys so each builder exposes the same <c>WithGuardrails</c> / <c>SetGuardrails</c>
+/// semantics without duplicating the field pairs and logic.
+/// </summary>
+internal sealed class AIGuardrailBuilderState
+{
+    private IReadOnlyList<Guid> _ids = [];
+    private IReadOnlyList<string>? _aliases;
+    private IReadOnlyList<Guid> _additionalIds = [];
+    private IReadOnlyList<string>? _additionalAliases;
+
+    public IReadOnlyList<Guid> Ids => _ids;
+    public IReadOnlyList<string>? Aliases => _aliases;
+    public IReadOnlyList<Guid> AdditionalIds => _additionalIds;
+    public IReadOnlyList<string>? AdditionalAliases => _additionalAliases;
+
+    public void Set(Guid[] ids)
+    {
+        _ids = ids;
+        _aliases = null;
+    }
+
+    public void SetByAlias(string[] aliases)
+    {
+        _aliases = aliases;
+        _ids = [];
+    }
+
+    public void With(Guid[] ids)
+    {
+        _additionalIds = ids;
+        _additionalAliases = null;
+    }
+
+    public void WithByAlias(string[] aliases)
+    {
+        _additionalAliases = aliases;
+        _additionalIds = [];
+    }
+
+    public void SetResolvedIds(IReadOnlyList<Guid> ids) => _ids = ids;
+
+    public void SetResolvedAdditionalIds(IReadOnlyList<Guid> ids) => _additionalIds = ids;
+
+    /// <summary>
+    /// Writes the replace (override) and additive lists onto the runtime context under the core guardrail
+    /// override / additional keys. Empty lists are skipped so source resolvers behave normally.
+    /// </summary>
+    public void WriteToContext(AIRuntimeContext context)
+    {
+        if (_ids.Count > 0)
+        {
+            context.SetValue(Constants.ContextKeys.GuardrailIdsOverride, _ids);
+        }
+
+        if (_additionalIds.Count > 0)
+        {
+            context.SetValue(Constants.ContextKeys.AdditionalGuardrailIds, _additionalIds);
+        }
+    }
+
+    /// <summary>
+    /// Writes the replace (override) and additive lists into an additional-properties dictionary
+    /// (used by the agent service, which emits them when creating the MAF agent instead of populating
+    /// a runtime context directly).
+    /// </summary>
+    public void WriteTo(IDictionary<string, object?> properties)
+    {
+        if (_ids.Count > 0)
+        {
+            properties[Constants.ContextKeys.GuardrailIdsOverride] = _ids;
+        }
+
+        if (_additionalIds.Count > 0)
+        {
+            properties[Constants.ContextKeys.AdditionalGuardrailIds] = _additionalIds;
+        }
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/AIGuardrailRule.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/AIGuardrailRule.cs
@@ -48,6 +48,13 @@ public sealed class AIGuardrailRule
     public string? GuardrailName { get; set; }
 
     /// <summary>
+    /// The ID of the parent guardrail this rule belongs to. Populated during resolution so the
+    /// aggregator can dedupe rules whose guardrail was already contributed by an earlier resolver.
+    /// Distinct from <see cref="Id"/>, which is the rule's own identifier.
+    /// </summary>
+    public Guid? GuardrailId { get; set; }
+
+    /// <summary>
     /// Controls evaluation order within the guardrail.
     /// </summary>
     public int SortOrder { get; set; }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Resolvers/AIGuardrailResolutionService.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Resolvers/AIGuardrailResolutionService.cs
@@ -23,19 +23,16 @@ internal sealed class AIGuardrailResolutionService : IAIGuardrailResolutionServi
         {
             var result = await resolver.ResolveAsync(cancellationToken);
 
-            // Deduplicate by guardrail ID (later resolvers don't duplicate earlier ones)
-            foreach (var guardrailId in result.GuardrailIds)
+            // Group rules by parent guardrail so we can skip duplicates at rule granularity — a resolver
+            // may return rules whose guardrail was already contributed by an earlier resolver.
+            foreach (var group in result.Rules.GroupBy(r => r.GuardrailId))
             {
-                if (!seenGuardrailIds.Add(guardrailId))
+                if (group.Key is Guid guardrailId && !seenGuardrailIds.Add(guardrailId))
                 {
                     continue;
                 }
-            }
 
-            // Add rules from guardrails we haven't seen before
-            foreach (var rule in result.Rules)
-            {
-                allRules.Add(rule);
+                allRules.AddRange(group);
             }
         }
 

--- a/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Resolvers/AIGuardrailResolverResult.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Resolvers/AIGuardrailResolverResult.cs
@@ -24,4 +24,34 @@ public sealed class AIGuardrailResolverResult
     /// Returns an empty result (no guardrails resolved).
     /// </summary>
     public static AIGuardrailResolverResult Empty => new();
+
+    /// <summary>
+    /// Projects a set of resolved guardrails into a result, flattening their rules (ordered by
+    /// <see cref="AIGuardrailRule.SortOrder"/>) and stamping each rule with its parent guardrail name.
+    /// </summary>
+    /// <param name="guardrails">The guardrails to project.</param>
+    /// <param name="source">The source name for debugging/tracking.</param>
+    public static AIGuardrailResolverResult FromGuardrails(IEnumerable<AIGuardrail> guardrails, string? source)
+    {
+        var allRules = new List<AIGuardrailRule>();
+        var resolvedIds = new List<Guid>();
+
+        foreach (var guardrail in guardrails)
+        {
+            resolvedIds.Add(guardrail.Id);
+            foreach (var rule in guardrail.Rules.OrderBy(r => r.SortOrder))
+            {
+                rule.GuardrailId = guardrail.Id;
+                rule.GuardrailName = guardrail.Name;
+                allRules.Add(rule);
+            }
+        }
+
+        return new AIGuardrailResolverResult
+        {
+            Rules = allRules,
+            GuardrailIds = resolvedIds,
+            Source = source,
+        };
+    }
 }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Resolvers/AdditionalGuardrailIdsResolver.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Resolvers/AdditionalGuardrailIdsResolver.cs
@@ -3,24 +3,22 @@ using Umbraco.AI.Core.RuntimeContext;
 namespace Umbraco.AI.Core.Guardrails.Resolvers;
 
 /// <summary>
-/// Resolves guardrails from an explicit override in the runtime context.
+/// Resolves additional guardrails appended by the caller via the builder's <c>WithGuardrails</c> API.
 /// </summary>
 /// <remarks>
 /// <para>
-/// This resolver reads <see cref="Constants.ContextKeys.GuardrailIdsOverride"/> from the runtime context.
-/// When present, it resolves the specified guardrails. Other resolvers still run and their results
-/// are deduplicated by the resolution service.
-/// </para>
-/// <para>
-/// This resolver is registered first in the pipeline so its guardrail IDs take priority during deduplication.
+/// This resolver reads <see cref="Constants.ContextKeys.AdditionalGuardrailIds"/> from the runtime context
+/// and adds the specified guardrails to whatever the source resolvers (profile/agent/prompt) produced. If a
+/// full <see cref="Constants.ContextKeys.GuardrailIdsOverride"/> is also set, the additional IDs are still
+/// applied on top of the override.
 /// </para>
 /// </remarks>
-internal sealed class GuardrailIdsOverrideResolver : IAIGuardrailResolver
+internal sealed class AdditionalGuardrailIdsResolver : IAIGuardrailResolver
 {
     private readonly IAIRuntimeContextAccessor _runtimeContextAccessor;
     private readonly IAIGuardrailService _guardrailService;
 
-    public GuardrailIdsOverrideResolver(
+    public AdditionalGuardrailIdsResolver(
         IAIRuntimeContextAccessor runtimeContextAccessor,
         IAIGuardrailService guardrailService)
     {
@@ -31,13 +29,13 @@ internal sealed class GuardrailIdsOverrideResolver : IAIGuardrailResolver
     /// <inheritdoc />
     public async Task<AIGuardrailResolverResult> ResolveAsync(CancellationToken cancellationToken = default)
     {
-        var guardrailIds = _runtimeContextAccessor.Context?.GetValue<IReadOnlyList<Guid>>(Constants.ContextKeys.GuardrailIdsOverride);
+        var guardrailIds = _runtimeContextAccessor.Context?.GetValue<IReadOnlyList<Guid>>(Constants.ContextKeys.AdditionalGuardrailIds);
         if (guardrailIds is null || guardrailIds.Count == 0)
         {
             return AIGuardrailResolverResult.Empty;
         }
 
         var guardrails = await _guardrailService.GetGuardrailsByIdsAsync(guardrailIds, cancellationToken);
-        return AIGuardrailResolverResult.FromGuardrails(guardrails, source: "Override");
+        return AIGuardrailResolverResult.FromGuardrails(guardrails, source: "Additional");
     }
 }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Resolvers/ProfileGuardrailResolver.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Resolvers/ProfileGuardrailResolver.cs
@@ -29,6 +29,12 @@ internal sealed class ProfileGuardrailResolver : IAIGuardrailResolver
     /// <inheritdoc />
     public async Task<AIGuardrailResolverResult> ResolveAsync(CancellationToken cancellationToken = default)
     {
+        // Override suppresses source-level guardrails entirely.
+        if (_runtimeContextAccessor.Context?.GetValue<IReadOnlyList<Guid>>(Constants.ContextKeys.GuardrailIdsOverride) is not null)
+        {
+            return AIGuardrailResolverResult.Empty;
+        }
+
         var profileId = _runtimeContextAccessor.Context?.GetValue<Guid>(Constants.ContextKeys.ProfileId);
         if (!profileId.HasValue)
         {
@@ -42,25 +48,6 @@ internal sealed class ProfileGuardrailResolver : IAIGuardrailResolver
         }
 
         var guardrails = await _guardrailService.GetGuardrailsByIdsAsync(chatSettings.GuardrailIds, cancellationToken);
-
-        var allRules = new List<AIGuardrailRule>();
-        var resolvedIds = new List<Guid>();
-
-        foreach (var guardrail in guardrails)
-        {
-            resolvedIds.Add(guardrail.Id);
-            foreach (var rule in guardrail.Rules.OrderBy(r => r.SortOrder))
-            {
-                rule.GuardrailName = guardrail.Name;
-                allRules.Add(rule);
-            }
-        }
-
-        return new AIGuardrailResolverResult
-        {
-            Rules = allRules,
-            GuardrailIds = resolvedIds,
-            Source = profile.Name
-        };
+        return AIGuardrailResolverResult.FromGuardrails(guardrails, source: profile.Name);
     }
 }

--- a/Umbraco.AI/src/Umbraco.AI.Core/InlineChat/AIChatBuilder.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/InlineChat/AIChatBuilder.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.AI;
 using Umbraco.AI.Core.Chat;
+using Umbraco.AI.Core.Contexts;
+using Umbraco.AI.Core.Guardrails;
 using Umbraco.AI.Core.RuntimeContext;
 using Umbraco.AI.Core.Utilities;
 
@@ -22,8 +24,10 @@ namespace Umbraco.AI.Core.InlineChat;
 ///     .WithAlias("my-summarizer")
 ///     .WithProfile(profileId)
 ///     .WithChatOptions(new ChatOptions { Temperature = 0.3f })
-///     .WithGuardrails(guardrailId),
+///     .WithGuardrails(guardrailId)   // additive on top of the profile's guardrails
+///     .WithContexts(contextId),      // additive on top of the profile's contexts
 ///     messages, cancellationToken);
+/// // Use SetGuardrails / SetContexts to replace the profile's configured values.
 /// </code>
 /// </remarks>
 public sealed class AIChatBuilder
@@ -40,8 +44,8 @@ public sealed class AIChatBuilder
     private ChatOptions? _chatOptions;
     private AIOutputSchema? _outputSchema;
     private IEnumerable<AIRequestContextItem>? _contextItems;
-    private IReadOnlyList<Guid> _guardrailIds = [];
-    private IReadOnlyList<string>? _guardrailAliases;
+    private readonly AIContextBuilderState _aiContexts = new();
+    private readonly AIGuardrailBuilderState _aiGuardrails = new();
     private IReadOnlyDictionary<string, object?>? _additionalProperties;
     private bool _isPassThrough;
     private readonly List<string> _toolIds = [];
@@ -146,26 +150,81 @@ public sealed class AIChatBuilder
     }
 
     /// <summary>
-    /// Sets guardrails for safety and compliance checks by ID.
+    /// Adds stored <see cref="Models.AIContext"/> entries on top of the profile's configured contexts
+    /// (additive). Use <see cref="SetContexts(Guid[])"/> to fully replace.
     /// </summary>
-    /// <param name="guardrailIds">The guardrail IDs to apply.</param>
-    /// <returns>The builder for chaining.</returns>
-    public AIChatBuilder WithGuardrails(params Guid[] guardrailIds)
+    public AIChatBuilder WithContexts(params Guid[] contextIds)
     {
-        _guardrailIds = guardrailIds;
-        _guardrailAliases = null;
+        _aiContexts.With(contextIds);
         return this;
     }
 
     /// <summary>
-    /// Sets guardrails for safety and compliance checks by alias.
+    /// Adds stored <see cref="Models.AIContext"/> entries by alias on top of the profile's configured
+    /// contexts (additive). Aliases are resolved to IDs by the service layer.
     /// </summary>
-    /// <param name="guardrailAliases">The guardrail aliases to apply.</param>
-    /// <returns>The builder for chaining.</returns>
+    public AIChatBuilder WithContexts(params string[] contextAliases)
+    {
+        _aiContexts.WithByAlias(contextAliases);
+        return this;
+    }
+
+    /// <summary>
+    /// Replaces the profile's configured contexts with this set (replace). Pass an empty array to
+    /// explicitly use no contexts.
+    /// </summary>
+    public AIChatBuilder SetContexts(params Guid[] contextIds)
+    {
+        _aiContexts.Set(contextIds);
+        return this;
+    }
+
+    /// <summary>
+    /// Replaces the profile's configured contexts with this set by alias (replace). Aliases are resolved
+    /// to IDs by the service layer.
+    /// </summary>
+    public AIChatBuilder SetContexts(params string[] contextAliases)
+    {
+        _aiContexts.SetByAlias(contextAliases);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds guardrails on top of the profile's configured guardrails (additive). Use
+    /// <see cref="SetGuardrails(Guid[])"/> to fully replace.
+    /// </summary>
+    public AIChatBuilder WithGuardrails(params Guid[] guardrailIds)
+    {
+        _aiGuardrails.With(guardrailIds);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds guardrails by alias on top of the profile's configured guardrails (additive). Aliases are
+    /// resolved to IDs by the service layer.
+    /// </summary>
     public AIChatBuilder WithGuardrails(params string[] guardrailAliases)
     {
-        _guardrailAliases = guardrailAliases;
-        _guardrailIds = [];
+        _aiGuardrails.WithByAlias(guardrailAliases);
+        return this;
+    }
+
+    /// <summary>
+    /// Replaces the profile's configured guardrails with this set (replace).
+    /// </summary>
+    public AIChatBuilder SetGuardrails(params Guid[] guardrailIds)
+    {
+        _aiGuardrails.Set(guardrailIds);
+        return this;
+    }
+
+    /// <summary>
+    /// Replaces the profile's configured guardrails with this set by alias (replace). Aliases are resolved
+    /// to IDs by the service layer.
+    /// </summary>
+    public AIChatBuilder SetGuardrails(params string[] guardrailAliases)
+    {
+        _aiGuardrails.SetByAlias(guardrailAliases);
         return this;
     }
 
@@ -259,15 +318,15 @@ public sealed class AIChatBuilder
     /// </summary>
     internal IEnumerable<AIRequestContextItem>? ContextItems => _contextItems;
 
-    /// <summary>
-    /// Gets the guardrail IDs configured on this builder.
-    /// </summary>
-    internal IReadOnlyList<Guid> GuardrailIds => _guardrailIds;
+    internal IReadOnlyList<Guid>? ContextIds => _aiContexts.Ids;
+    internal IReadOnlyList<string>? ContextAliases => _aiContexts.Aliases;
+    internal IReadOnlyList<Guid> AdditionalContextIds => _aiContexts.AdditionalIds;
+    internal IReadOnlyList<string>? AdditionalContextAliases => _aiContexts.AdditionalAliases;
 
-    /// <summary>
-    /// Gets the guardrail aliases configured on this builder, if any.
-    /// </summary>
-    internal IReadOnlyList<string>? GuardrailAliases => _guardrailAliases;
+    internal IReadOnlyList<Guid> GuardrailIds => _aiGuardrails.Ids;
+    internal IReadOnlyList<string>? GuardrailAliases => _aiGuardrails.Aliases;
+    internal IReadOnlyList<Guid> AdditionalGuardrailIds => _aiGuardrails.AdditionalIds;
+    internal IReadOnlyList<string>? AdditionalGuardrailAliases => _aiGuardrails.AdditionalAliases;
 
     /// <summary>
     /// Gets the additional properties configured on this builder.
@@ -285,10 +344,24 @@ public sealed class AIChatBuilder
     internal bool IsPassThrough => _isPassThrough;
 
     /// <summary>
-    /// Sets resolved guardrail IDs from alias lookup. Used by the service layer
-    /// to resolve aliases before execution.
+    /// Sets resolved guardrail IDs from alias lookup (replace mode). Used by the service layer.
     /// </summary>
-    internal void SetResolvedGuardrailIds(IReadOnlyList<Guid> guardrailIds) => _guardrailIds = guardrailIds;
+    internal void SetResolvedGuardrailIds(IReadOnlyList<Guid> guardrailIds) => _aiGuardrails.SetResolvedIds(guardrailIds);
+
+    /// <summary>
+    /// Sets resolved additional guardrail IDs from alias lookup (additive mode). Used by the service layer.
+    /// </summary>
+    internal void SetResolvedAdditionalGuardrailIds(IReadOnlyList<Guid> guardrailIds) => _aiGuardrails.SetResolvedAdditionalIds(guardrailIds);
+
+    /// <summary>
+    /// Sets resolved context IDs from alias lookup (replace mode). Used by the service layer.
+    /// </summary>
+    internal void SetResolvedContextIds(IReadOnlyList<Guid> contextIds) => _aiContexts.SetResolvedIds(contextIds);
+
+    /// <summary>
+    /// Sets resolved additional context IDs from alias lookup (additive mode). Used by the service layer.
+    /// </summary>
+    internal void SetResolvedAdditionalContextIds(IReadOnlyList<Guid> contextIds) => _aiContexts.SetResolvedAdditionalIds(contextIds);
 
     /// <summary>
     /// Validates the builder configuration.
@@ -319,10 +392,8 @@ public sealed class AIChatBuilder
             context.SetValue(Constants.ContextKeys.FeatureAlias, Alias);
         }
 
-        if (_guardrailIds.Count > 0)
-        {
-            context.SetValue(Constants.ContextKeys.GuardrailIdsOverride, _guardrailIds);
-        }
+        _aiGuardrails.WriteToContext(context);
+        _aiContexts.WriteToContext(context);
 
         if (_chatOptions is not null)
         {

--- a/Umbraco.AI/src/Umbraco.AI.Core/SpeechToText/AISpeechToTextBuilder.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/SpeechToText/AISpeechToTextBuilder.cs
@@ -22,7 +22,7 @@ namespace Umbraco.AI.Core.SpeechToText;
 /// var response = await speechToTextService.TranscribeAsync(stt => stt
 ///     .WithAlias("voice-notes")
 ///     .WithProfile("whisper-profile")
-///     .WithGuardrails("content-filter"),
+///     .WithGuardrails("content-filter"),   // additive on top of the profile's guardrails
 ///     audioStream, cancellationToken);
 /// </code>
 /// </remarks>
@@ -39,8 +39,7 @@ public sealed class AISpeechToTextBuilder
     private string? _profileAlias;
     private SpeechToTextOptions? _speechToTextOptions;
     private IEnumerable<AIRequestContextItem>? _contextItems;
-    private IReadOnlyList<Guid> _guardrailIds = [];
-    private IReadOnlyList<string>? _guardrailAliases;
+    private readonly Guardrails.AIGuardrailBuilderState _aiGuardrails = new();
     private IReadOnlyDictionary<string, object?>? _additionalProperties;
     private bool _isPassThrough;
 
@@ -132,26 +131,41 @@ public sealed class AISpeechToTextBuilder
     }
 
     /// <summary>
-    /// Sets guardrails for safety and compliance checks by ID.
+    /// Adds guardrails on top of the profile's configured guardrails (additive). Use
+    /// <see cref="SetGuardrails(Guid[])"/> to fully replace.
     /// </summary>
-    /// <param name="guardrailIds">The guardrail IDs to apply.</param>
-    /// <returns>The builder for chaining.</returns>
     public AISpeechToTextBuilder WithGuardrails(params Guid[] guardrailIds)
     {
-        _guardrailIds = guardrailIds;
-        _guardrailAliases = null;
+        _aiGuardrails.With(guardrailIds);
         return this;
     }
 
     /// <summary>
-    /// Sets guardrails for safety and compliance checks by alias.
+    /// Adds guardrails by alias on top of the profile's configured guardrails (additive). Aliases are
+    /// resolved to IDs by the service layer.
     /// </summary>
-    /// <param name="guardrailAliases">The guardrail aliases to apply.</param>
-    /// <returns>The builder for chaining.</returns>
     public AISpeechToTextBuilder WithGuardrails(params string[] guardrailAliases)
     {
-        _guardrailAliases = guardrailAliases;
-        _guardrailIds = [];
+        _aiGuardrails.WithByAlias(guardrailAliases);
+        return this;
+    }
+
+    /// <summary>
+    /// Replaces the profile's configured guardrails with this set (replace).
+    /// </summary>
+    public AISpeechToTextBuilder SetGuardrails(params Guid[] guardrailIds)
+    {
+        _aiGuardrails.Set(guardrailIds);
+        return this;
+    }
+
+    /// <summary>
+    /// Replaces the profile's configured guardrails with this set by alias (replace). Aliases are resolved
+    /// to IDs by the service layer.
+    /// </summary>
+    public AISpeechToTextBuilder SetGuardrails(params string[] guardrailAliases)
+    {
+        _aiGuardrails.SetByAlias(guardrailAliases);
         return this;
     }
 
@@ -227,15 +241,10 @@ public sealed class AISpeechToTextBuilder
     /// </summary>
     internal IEnumerable<AIRequestContextItem>? ContextItems => _contextItems;
 
-    /// <summary>
-    /// Gets the guardrail IDs configured on this builder.
-    /// </summary>
-    internal IReadOnlyList<Guid> GuardrailIds => _guardrailIds;
-
-    /// <summary>
-    /// Gets the guardrail aliases configured on this builder, if any.
-    /// </summary>
-    internal IReadOnlyList<string>? GuardrailAliases => _guardrailAliases;
+    internal IReadOnlyList<Guid> GuardrailIds => _aiGuardrails.Ids;
+    internal IReadOnlyList<string>? GuardrailAliases => _aiGuardrails.Aliases;
+    internal IReadOnlyList<Guid> AdditionalGuardrailIds => _aiGuardrails.AdditionalIds;
+    internal IReadOnlyList<string>? AdditionalGuardrailAliases => _aiGuardrails.AdditionalAliases;
 
     /// <summary>
     /// Gets the additional properties configured on this builder.
@@ -251,7 +260,12 @@ public sealed class AISpeechToTextBuilder
     /// Sets resolved guardrail IDs from alias lookup. Used by the service layer
     /// to resolve aliases before execution.
     /// </summary>
-    internal void SetResolvedGuardrailIds(IReadOnlyList<Guid> guardrailIds) => _guardrailIds = guardrailIds;
+    internal void SetResolvedGuardrailIds(IReadOnlyList<Guid> guardrailIds) => _aiGuardrails.SetResolvedIds(guardrailIds);
+
+    /// <summary>
+    /// Sets resolved additional guardrail IDs from alias lookup (additive mode).
+    /// </summary>
+    internal void SetResolvedAdditionalGuardrailIds(IReadOnlyList<Guid> guardrailIds) => _aiGuardrails.SetResolvedAdditionalIds(guardrailIds);
 
     /// <summary>
     /// Validates the builder configuration.
@@ -282,10 +296,7 @@ public sealed class AISpeechToTextBuilder
             context.SetValue(Constants.ContextKeys.FeatureAlias, Alias);
         }
 
-        if (_guardrailIds.Count > 0)
-        {
-            context.SetValue(Constants.ContextKeys.GuardrailIdsOverride, _guardrailIds);
-        }
+        _aiGuardrails.WriteToContext(context);
 
         if (_additionalProperties is not null)
         {

--- a/Umbraco.AI/src/Umbraco.AI.Core/SpeechToText/AISpeechToTextService.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/SpeechToText/AISpeechToTextService.cs
@@ -304,6 +304,12 @@ internal sealed class AISpeechToTextService : IAISpeechToTextService
             builder.SetResolvedGuardrailIds(
                 await _guardrailService.GetGuardrailIdsByAliasesAsync(aliases, cancellationToken));
         }
+
+        if (builder.AdditionalGuardrailAliases is { Count: > 0 } additionalAliases)
+        {
+            builder.SetResolvedAdditionalGuardrailIds(
+                await _guardrailService.GetGuardrailIdsByAliasesAsync(additionalAliases, cancellationToken));
+        }
     }
 
     private static SpeechToTextOptions? MergeOptions(AIProfile profile, SpeechToTextOptions? callerOptions)

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/AITestRunner.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/AITestRunner.cs
@@ -1,3 +1,4 @@
+using Umbraco.AI.Core.Utilities;
 
 namespace Umbraco.AI.Core.Tests;
 
@@ -45,8 +46,11 @@ internal sealed class AITestRunner : IAITestRunner
         var effectiveBatchId = batchId ?? Guid.NewGuid();
 
         // 1. Execute default configuration runs
+        // Only treat ContextIds as an override when something was actually requested:
+        // a caller-supplied list, or a non-empty test-level list. An empty list would otherwise
+        // reach the resolvers as "replace profile contexts with nothing" and suppress them.
         var effectiveProfile = profileIdOverride ?? test.ProfileId;
-        var effectiveContextIds = contextIdsOverride?.ToList() ?? test.ContextIds.ToList();
+        var effectiveContextIds = (IReadOnlyList<Guid>?)contextIdsOverride?.ToList() ?? test.ContextIds.NullIfEmpty();
 
         var defaultRuns = await ExecuteRunsAsync(
             test,
@@ -68,7 +72,9 @@ internal sealed class AITestRunner : IAITestRunner
         foreach (var variation in test.Variations)
         {
             var varProfile = variation.ProfileId ?? test.ProfileId;
-            var varContextIds = variation.ContextIds ?? test.ContextIds;
+            // variation.ContextIds is nullable: null = no variation-level override, list = explicit override
+            // (including []). When falling back to the test's stored ContextIds, treat empty as "no override".
+            var varContextIds = (IReadOnlyList<Guid>?)variation.ContextIds?.ToList() ?? test.ContextIds.NullIfEmpty();
             var varRunCount = variation.RunCount ?? test.RunCount;
 
             // Deep merge feature config if variation provides overrides
@@ -81,7 +87,7 @@ internal sealed class AITestRunner : IAITestRunner
                 testFeature,
                 varRunCount,
                 varProfile,
-                varContextIds.ToList(),
+                varContextIds,
                 guardrailIdsOverride,
                 effectiveBatchId,
                 executionId,
@@ -153,7 +159,7 @@ internal sealed class AITestRunner : IAITestRunner
         IAITestFeature testFeature,
         int runCount,
         Guid? profileId,
-        IReadOnlyList<Guid> contextIds,
+        IReadOnlyList<Guid>? contextIds,
         IEnumerable<Guid>? guardrailIdsOverride,
         Guid batchId,
         Guid executionId,
@@ -226,7 +232,7 @@ internal sealed class AITestRunner : IAITestRunner
         IAITestFeature testFeature,
         int runNumber,
         Guid? profileId,
-        IReadOnlyList<Guid> contextIds,
+        IReadOnlyList<Guid>? contextIds,
         IEnumerable<Guid>? guardrailIdsOverride,
         Guid batchId,
         Guid executionId,
@@ -236,7 +242,7 @@ internal sealed class AITestRunner : IAITestRunner
     {
         var startTime = DateTime.UtcNow;
 
-        // Create test run
+        // Create test run — store [] on the run when no override was applied, matching the existing shape
         var testRun = new AITestRun
         {
             Id = Guid.NewGuid(),
@@ -244,7 +250,7 @@ internal sealed class AITestRunner : IAITestRunner
             TestVersion = test.Version,
             RunNumber = runNumber,
             ProfileId = profileId,
-            ContextIds = contextIds.ToList(),
+            ContextIds = contextIds?.ToList() ?? [],
             ExecutedAt = startTime,
             Status = AITestRunStatus.Running,
             BatchId = batchId,
@@ -255,12 +261,12 @@ internal sealed class AITestRunner : IAITestRunner
 
         try
         {
-            // Execute the test feature
+            // Pass the nullable slot to the feature so null ("no override") stays null all the way to the resolver.
             var transcript = await testFeature.ExecuteAsync(
                 test,
                 runNumber,
                 testRun.ProfileId,
-                testRun.ContextIds,
+                contextIds,
                 guardrailIdsOverride,
                 cancellationToken);
 

--- a/Umbraco.AI/src/Umbraco.AI.Core/Utilities/CollectionExtensions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Utilities/CollectionExtensions.cs
@@ -1,0 +1,17 @@
+namespace Umbraco.AI.Core.Utilities;
+
+/// <summary>
+/// General-purpose collection helpers.
+/// </summary>
+public static class CollectionExtensions
+{
+    /// <summary>
+    /// Returns the source unchanged when it has items, or <c>null</c> when it is <c>null</c> or empty.
+    /// </summary>
+    /// <remarks>
+    /// Useful when flowing a stored list into a slot that treats <c>null</c> as "not set" and any
+    /// non-null list (including an empty one) as an explicit override.
+    /// </remarks>
+    public static IReadOnlyList<T>? NullIfEmpty<T>(this IReadOnlyList<T>? source)
+        => source is { Count: > 0 } ? source : null;
+}

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/workspace/test/views/test-details-workspace-view.element.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/workspace/test/views/test-details-workspace-view.element.ts
@@ -143,7 +143,7 @@ export class UmbracoAITestDetailsWorkspaceViewElement extends UmbFormControlMixi
                     </div>
                 </umb-property-layout>
 
-                <umb-property-layout label="Contexts" description="Knowledge contexts to include in test execution (optional)">
+                <umb-property-layout label="Contexts" description="Override the target's contexts for this test run (optional - leave empty to use the target's own contexts)">
                     <div slot="editor">
                         <uai-context-picker
                             multiple

--- a/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/Guardrail/Mapping/GuardrailMapDefinition.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/Guardrail/Mapping/GuardrailMapDefinition.cs
@@ -65,7 +65,7 @@ public class GuardrailMapDefinition : IMapDefinition
         target.Rules = source.Rules.Select(r => context.Map<AIGuardrailRule>(r)!).ToList();
     }
 
-    // Umbraco.Code.MapAll -EvaluatorId -GuardrailName
+    // Umbraco.Code.MapAll -EvaluatorId -GuardrailName -GuardrailId
     private static void MapRuleFromModel(GuardrailRuleModel source, AIGuardrailRule target, MapperContext context)
     {
         target.Id = source.Id;

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Contexts/Resolvers/ProfileContextResolverTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Contexts/Resolvers/ProfileContextResolverTests.cs
@@ -1,0 +1,148 @@
+using Umbraco.AI.Core;
+using Umbraco.AI.Core.Contexts;
+using Umbraco.AI.Core.Contexts.Resolvers;
+using Umbraco.AI.Core.Profiles;
+using Umbraco.AI.Core.RuntimeContext;
+using Umbraco.AI.Tests.Common.Builders;
+
+namespace Umbraco.AI.Tests.Unit.Contexts.Resolvers;
+
+public class ProfileContextResolverTests
+{
+    private readonly Mock<IAIContextService> _contextServiceMock = new();
+    private readonly Mock<IAIProfileService> _profileServiceMock = new();
+    private readonly Mock<IAIRuntimeContextAccessor> _runtimeContextAccessorMock = new();
+
+    private ProfileContextResolver CreateResolver() =>
+        new(_runtimeContextAccessorMock.Object, _contextServiceMock.Object, _profileServiceMock.Object);
+
+    [Fact]
+    public async Task ResolveAsync_NoProfileId_ReturnsEmpty()
+    {
+        _runtimeContextAccessorMock.Setup(x => x.Context).Returns(new AIRuntimeContext([]));
+
+        var result = await CreateResolver().ResolveAsync();
+
+        result.Resources.ShouldBeEmpty();
+        result.Sources.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ProfileContextIds_Resolved()
+    {
+        var profileId = Guid.NewGuid();
+        var contextId = Guid.NewGuid();
+        var profile = new AIProfileBuilder()
+            .WithId(profileId)
+            .WithSettings(new AIChatProfileSettings { ContextIds = [contextId] })
+            .Build();
+
+        var runtimeContext = new AIRuntimeContext([]);
+        runtimeContext.SetValue(Constants.ContextKeys.ProfileId, profileId);
+        _runtimeContextAccessorMock.Setup(x => x.Context).Returns(runtimeContext);
+        _profileServiceMock.Setup(x => x.GetProfileAsync(profileId, It.IsAny<CancellationToken>())).ReturnsAsync(profile);
+        _contextServiceMock.Setup(x => x.GetContextAsync(contextId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AIContextBuilder().WithId(contextId).WithName("profile-ctx").Build());
+
+        var result = await CreateResolver().ResolveAsync();
+
+        result.Sources.ShouldContain(s => s.EntityName == profile.Name && s.ContextName == "profile-ctx");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_OverrideTakesPrecedenceOverProfile()
+    {
+        var profileId = Guid.NewGuid();
+        var profileContextId = Guid.NewGuid();
+        var overrideContextId = Guid.NewGuid();
+        var profile = new AIProfileBuilder()
+            .WithId(profileId)
+            .WithSettings(new AIChatProfileSettings { ContextIds = [profileContextId] })
+            .Build();
+
+        var runtimeContext = new AIRuntimeContext([]);
+        runtimeContext.SetValue(Constants.ContextKeys.ProfileId, profileId);
+        runtimeContext.SetValue(Constants.ContextKeys.ContextIdsOverride, (IReadOnlyList<Guid>)[overrideContextId]);
+        _runtimeContextAccessorMock.Setup(x => x.Context).Returns(runtimeContext);
+        _profileServiceMock.Setup(x => x.GetProfileAsync(profileId, It.IsAny<CancellationToken>())).ReturnsAsync(profile);
+        _contextServiceMock.Setup(x => x.GetContextAsync(overrideContextId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AIContextBuilder().WithId(overrideContextId).WithName("override-ctx").Build());
+
+        var result = await CreateResolver().ResolveAsync();
+
+        result.Sources.ShouldContain(s => s.ContextName == "override-ctx");
+        _contextServiceMock.Verify(x => x.GetContextAsync(profileContextId, It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_EmptyOverride_ReturnsEmpty()
+    {
+        var profileId = Guid.NewGuid();
+        var profileContextId = Guid.NewGuid();
+        var profile = new AIProfileBuilder()
+            .WithId(profileId)
+            .WithSettings(new AIChatProfileSettings { ContextIds = [profileContextId] })
+            .Build();
+
+        var runtimeContext = new AIRuntimeContext([]);
+        runtimeContext.SetValue(Constants.ContextKeys.ProfileId, profileId);
+        runtimeContext.SetValue(Constants.ContextKeys.ContextIdsOverride, (IReadOnlyList<Guid>)[]);
+        _runtimeContextAccessorMock.Setup(x => x.Context).Returns(runtimeContext);
+        _profileServiceMock.Setup(x => x.GetProfileAsync(profileId, It.IsAny<CancellationToken>())).ReturnsAsync(profile);
+
+        var result = await CreateResolver().ResolveAsync();
+
+        result.Resources.ShouldBeEmpty();
+        _contextServiceMock.Verify(x => x.GetContextAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_AdditionalContextIds_AppendedToProfile()
+    {
+        var profileId = Guid.NewGuid();
+        var profileContextId = Guid.NewGuid();
+        var extraContextId = Guid.NewGuid();
+        var profile = new AIProfileBuilder()
+            .WithId(profileId)
+            .WithSettings(new AIChatProfileSettings { ContextIds = [profileContextId] })
+            .Build();
+
+        var runtimeContext = new AIRuntimeContext([]);
+        runtimeContext.SetValue(Constants.ContextKeys.ProfileId, profileId);
+        runtimeContext.SetValue(Constants.ContextKeys.AdditionalContextIds, (IReadOnlyList<Guid>)[extraContextId]);
+        _runtimeContextAccessorMock.Setup(x => x.Context).Returns(runtimeContext);
+        _profileServiceMock.Setup(x => x.GetProfileAsync(profileId, It.IsAny<CancellationToken>())).ReturnsAsync(profile);
+        _contextServiceMock.Setup(x => x.GetContextAsync(profileContextId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AIContextBuilder().WithId(profileContextId).WithName("profile-ctx").Build());
+        _contextServiceMock.Setup(x => x.GetContextAsync(extraContextId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AIContextBuilder().WithId(extraContextId).WithName("extra-ctx").Build());
+
+        var result = await CreateResolver().ResolveAsync();
+
+        result.Sources.Select(s => s.ContextName).ShouldBe(["profile-ctx", "extra-ctx"]);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_AdditionalDeduplicatedAgainstProfile()
+    {
+        var profileId = Guid.NewGuid();
+        var sharedId = Guid.NewGuid();
+        var profile = new AIProfileBuilder()
+            .WithId(profileId)
+            .WithSettings(new AIChatProfileSettings { ContextIds = [sharedId] })
+            .Build();
+
+        var runtimeContext = new AIRuntimeContext([]);
+        runtimeContext.SetValue(Constants.ContextKeys.ProfileId, profileId);
+        runtimeContext.SetValue(Constants.ContextKeys.AdditionalContextIds, (IReadOnlyList<Guid>)[sharedId]);
+        _runtimeContextAccessorMock.Setup(x => x.Context).Returns(runtimeContext);
+        _profileServiceMock.Setup(x => x.GetProfileAsync(profileId, It.IsAny<CancellationToken>())).ReturnsAsync(profile);
+        _contextServiceMock.Setup(x => x.GetContextAsync(sharedId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AIContextBuilder().WithId(sharedId).WithName("shared-ctx").Build());
+
+        var result = await CreateResolver().ResolveAsync();
+
+        result.Sources.Count.ShouldBe(1);
+        _contextServiceMock.Verify(x => x.GetContextAsync(sharedId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Guardrails/Resolvers/GuardrailResolverOverrideTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Guardrails/Resolvers/GuardrailResolverOverrideTests.cs
@@ -1,0 +1,104 @@
+using Umbraco.AI.Core;
+using Umbraco.AI.Core.Guardrails;
+using Umbraco.AI.Core.Guardrails.Resolvers;
+using Umbraco.AI.Core.Profiles;
+using Umbraco.AI.Core.RuntimeContext;
+using Umbraco.AI.Tests.Common.Builders;
+
+namespace Umbraco.AI.Tests.Unit.Guardrails.Resolvers;
+
+/// <summary>
+/// Verifies that WithGuardrails truly replaces profile-level guardrails (override suppresses profile resolver)
+/// and AppendGuardrails truly appends (additional resolver runs on top).
+/// </summary>
+public class GuardrailResolverOverrideTests
+{
+    private readonly Mock<IAIGuardrailService> _guardrailServiceMock = new();
+    private readonly Mock<IAIProfileService> _profileServiceMock = new();
+    private readonly Mock<IAIRuntimeContextAccessor> _runtimeContextAccessorMock = new();
+
+    [Fact]
+    public async Task ProfileResolver_OverridePresent_ReturnsEmpty()
+    {
+        var profileId = Guid.NewGuid();
+        var profileGuardrailId = Guid.NewGuid();
+        var overrideId = Guid.NewGuid();
+        var profile = new AIProfileBuilder()
+            .WithId(profileId)
+            .WithSettings(new AIChatProfileSettings { GuardrailIds = [profileGuardrailId] })
+            .Build();
+
+        var runtimeContext = new AIRuntimeContext([]);
+        runtimeContext.SetValue(Constants.ContextKeys.ProfileId, profileId);
+        runtimeContext.SetValue(Constants.ContextKeys.GuardrailIdsOverride, (IReadOnlyList<Guid>)[overrideId]);
+        _runtimeContextAccessorMock.Setup(x => x.Context).Returns(runtimeContext);
+        _profileServiceMock.Setup(x => x.GetProfileAsync(profileId, It.IsAny<CancellationToken>())).ReturnsAsync(profile);
+
+        var resolver = new ProfileGuardrailResolver(
+            _runtimeContextAccessorMock.Object, _guardrailServiceMock.Object, _profileServiceMock.Object);
+
+        var result = await resolver.ResolveAsync();
+
+        result.GuardrailIds.ShouldBeEmpty();
+        _guardrailServiceMock.Verify(
+            x => x.GetGuardrailsByIdsAsync(It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ProfileResolver_NoOverride_ReturnsProfileGuardrails()
+    {
+        var profileId = Guid.NewGuid();
+        var profileGuardrailId = Guid.NewGuid();
+        var profile = new AIProfileBuilder()
+            .WithId(profileId)
+            .WithSettings(new AIChatProfileSettings { GuardrailIds = [profileGuardrailId] })
+            .Build();
+
+        var runtimeContext = new AIRuntimeContext([]);
+        runtimeContext.SetValue(Constants.ContextKeys.ProfileId, profileId);
+        _runtimeContextAccessorMock.Setup(x => x.Context).Returns(runtimeContext);
+        _profileServiceMock.Setup(x => x.GetProfileAsync(profileId, It.IsAny<CancellationToken>())).ReturnsAsync(profile);
+        _guardrailServiceMock
+            .Setup(x => x.GetGuardrailsByIdsAsync(It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new AIGuardrailBuilder().WithId(profileGuardrailId).Build()]);
+
+        var resolver = new ProfileGuardrailResolver(
+            _runtimeContextAccessorMock.Object, _guardrailServiceMock.Object, _profileServiceMock.Object);
+
+        var result = await resolver.ResolveAsync();
+
+        result.GuardrailIds.ShouldBe([profileGuardrailId]);
+    }
+
+    [Fact]
+    public async Task AdditionalResolver_AdditionalKeyPresent_ReturnsIds()
+    {
+        var additionalId = Guid.NewGuid();
+        var runtimeContext = new AIRuntimeContext([]);
+        runtimeContext.SetValue(Constants.ContextKeys.AdditionalGuardrailIds, (IReadOnlyList<Guid>)[additionalId]);
+        _runtimeContextAccessorMock.Setup(x => x.Context).Returns(runtimeContext);
+        _guardrailServiceMock
+            .Setup(x => x.GetGuardrailsByIdsAsync(It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new AIGuardrailBuilder().WithId(additionalId).Build()]);
+
+        var resolver = new AdditionalGuardrailIdsResolver(_runtimeContextAccessorMock.Object, _guardrailServiceMock.Object);
+
+        var result = await resolver.ResolveAsync();
+
+        result.GuardrailIds.ShouldBe([additionalId]);
+        result.Source.ShouldBe("Additional");
+    }
+
+    [Fact]
+    public async Task AdditionalResolver_NotSet_ReturnsEmpty()
+    {
+        _runtimeContextAccessorMock.Setup(x => x.Context).Returns(new AIRuntimeContext([]));
+
+        var resolver = new AdditionalGuardrailIdsResolver(_runtimeContextAccessorMock.Object, _guardrailServiceMock.Object);
+
+        var result = await resolver.ResolveAsync();
+
+        result.GuardrailIds.ShouldBeEmpty();
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/InlineChat/AIInlineChatBuilderTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/InlineChat/AIInlineChatBuilderTests.cs
@@ -128,7 +128,7 @@ public class AIChatBuilderTests
     }
 
     [Fact]
-    public void WithGuardrails_SetsGuardrailIds()
+    public void WithGuardrails_StoresAdditionalIds()
     {
         // Arrange
         var guardrailId = Guid.NewGuid();
@@ -136,7 +136,7 @@ public class AIChatBuilderTests
         builder.WithGuardrails(guardrailId);
 
         // Assert
-        builder.GuardrailIds.ShouldContain(guardrailId);
+        builder.AdditionalGuardrailIds.ShouldContain(guardrailId);
     }
 
     [Fact]
@@ -181,5 +181,222 @@ public class AIChatBuilderTests
 
         // Assert
         builder.AdditionalProperties.ShouldBe(properties);
+    }
+
+    [Fact]
+    public void WithContexts_ById_StoresAdditionalIds()
+    {
+        // Arrange
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        var builder = new AIChatBuilder();
+
+        // Act
+        builder.WithContexts(a, b);
+
+        // Assert
+        builder.AdditionalContextIds.ShouldBe([a, b]);
+        builder.AdditionalContextAliases.ShouldBeNull();
+        builder.ContextIds.ShouldBeNull();
+    }
+
+    [Fact]
+    public void WithContexts_ByAlias_StoresAdditionalAliases()
+    {
+        // Arrange
+        var builder = new AIChatBuilder();
+
+        // Act
+        builder.WithContexts("brand", "guidelines");
+
+        // Assert
+        builder.AdditionalContextAliases.ShouldBe(["brand", "guidelines"]);
+        builder.AdditionalContextIds.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void SetContexts_ById_StoresReplaceContextIds()
+    {
+        // Arrange
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        var builder = new AIChatBuilder();
+
+        // Act
+        builder.SetContexts(a, b);
+
+        // Assert
+        builder.ContextIds.ShouldBe([a, b]);
+        builder.ContextAliases.ShouldBeNull();
+    }
+
+    [Fact]
+    public void SetContexts_EmptyArray_SignalsExplicitNoContexts()
+    {
+        // Arrange
+        var builder = new AIChatBuilder();
+
+        // Act
+        builder.SetContexts(Array.Empty<Guid>());
+
+        // Assert
+        builder.ContextIds.ShouldNotBeNull();
+        builder.ContextIds!.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void SetContexts_ByAlias_ThenById_ClearsAliases()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var builder = new AIChatBuilder();
+        builder.SetContexts("alias-one");
+
+        // Act
+        builder.SetContexts(id);
+
+        // Assert
+        builder.ContextIds.ShouldBe([id]);
+        builder.ContextAliases.ShouldBeNull();
+    }
+
+    [Fact]
+    public void PopulateContext_SetContexts_WritesOverrideKey()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var builder = new AIChatBuilder();
+        builder.WithAlias("test").SetContexts(id);
+        var runtimeContext = new AIRuntimeContext([]);
+
+        // Act
+        builder.PopulateContext(runtimeContext, setFeatureMetadata: true);
+
+        // Assert
+        runtimeContext.GetValue<IReadOnlyList<Guid>>(Core.Constants.ContextKeys.ContextIdsOverride)
+            .ShouldBe([id]);
+        runtimeContext.GetValue<IReadOnlyList<Guid>>(Core.Constants.ContextKeys.AdditionalContextIds).ShouldBeNull();
+    }
+
+    [Fact]
+    public void PopulateContext_WithContexts_WritesAdditionalKey()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var builder = new AIChatBuilder();
+        builder.WithAlias("test").WithContexts(id);
+        var runtimeContext = new AIRuntimeContext([]);
+
+        // Act
+        builder.PopulateContext(runtimeContext, setFeatureMetadata: true);
+
+        // Assert
+        runtimeContext.GetValue<IReadOnlyList<Guid>>(Core.Constants.ContextKeys.AdditionalContextIds)
+            .ShouldBe([id]);
+        runtimeContext.GetValue<IReadOnlyList<Guid>>(Core.Constants.ContextKeys.ContextIdsOverride).ShouldBeNull();
+    }
+
+    [Fact]
+    public void PopulateContext_SetAndWithContexts_WritesBothKeys()
+    {
+        // Arrange
+        var replaceId = Guid.NewGuid();
+        var additionalId = Guid.NewGuid();
+        var builder = new AIChatBuilder();
+        builder.WithAlias("test").SetContexts(replaceId).WithContexts(additionalId);
+        var runtimeContext = new AIRuntimeContext([]);
+
+        // Act
+        builder.PopulateContext(runtimeContext, setFeatureMetadata: true);
+
+        // Assert — both keys emitted; resolver combines them.
+        runtimeContext.GetValue<IReadOnlyList<Guid>>(Core.Constants.ContextKeys.ContextIdsOverride)
+            .ShouldBe([replaceId]);
+        runtimeContext.GetValue<IReadOnlyList<Guid>>(Core.Constants.ContextKeys.AdditionalContextIds)
+            .ShouldBe([additionalId]);
+    }
+
+    [Fact]
+    public void WithGuardrails_ById_StoresAdditionalIds()
+    {
+        var id = Guid.NewGuid();
+        var builder = new AIChatBuilder();
+
+        builder.WithGuardrails(id);
+
+        builder.AdditionalGuardrailIds.ShouldBe([id]);
+        builder.AdditionalGuardrailAliases.ShouldBeNull();
+    }
+
+    [Fact]
+    public void WithGuardrails_ByAlias_StoresAdditionalAliases()
+    {
+        var builder = new AIChatBuilder();
+
+        builder.WithGuardrails("safety");
+
+        builder.AdditionalGuardrailAliases.ShouldBe(["safety"]);
+        builder.AdditionalGuardrailIds.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void SetGuardrails_ById_StoresReplaceGuardrailIds()
+    {
+        var id = Guid.NewGuid();
+        var builder = new AIChatBuilder();
+
+        builder.SetGuardrails(id);
+
+        builder.GuardrailIds.ShouldBe([id]);
+        builder.GuardrailAliases.ShouldBeNull();
+    }
+
+    [Fact]
+    public void PopulateContext_WithGuardrails_WritesAdditionalKey()
+    {
+        var id = Guid.NewGuid();
+        var builder = new AIChatBuilder();
+        builder.WithAlias("test").WithGuardrails(id);
+        var runtimeContext = new AIRuntimeContext([]);
+
+        builder.PopulateContext(runtimeContext, setFeatureMetadata: true);
+
+        runtimeContext.GetValue<IReadOnlyList<Guid>>(Core.Constants.ContextKeys.AdditionalGuardrailIds)
+            .ShouldBe([id]);
+        runtimeContext.GetValue<IReadOnlyList<Guid>>(Core.Constants.ContextKeys.GuardrailIdsOverride)
+            .ShouldBeNull();
+    }
+
+    [Fact]
+    public void PopulateContext_SetGuardrails_WritesOverrideKey()
+    {
+        var id = Guid.NewGuid();
+        var builder = new AIChatBuilder();
+        builder.WithAlias("test").SetGuardrails(id);
+        var runtimeContext = new AIRuntimeContext([]);
+
+        builder.PopulateContext(runtimeContext, setFeatureMetadata: true);
+
+        runtimeContext.GetValue<IReadOnlyList<Guid>>(Core.Constants.ContextKeys.GuardrailIdsOverride)
+            .ShouldBe([id]);
+        runtimeContext.GetValue<IReadOnlyList<Guid>>(Core.Constants.ContextKeys.AdditionalGuardrailIds)
+            .ShouldBeNull();
+    }
+
+    [Fact]
+    public void PopulateContext_SetAndWithGuardrails_WritesBothKeys()
+    {
+        var replaceId = Guid.NewGuid();
+        var additionalId = Guid.NewGuid();
+        var builder = new AIChatBuilder();
+        builder.WithAlias("test").SetGuardrails(replaceId).WithGuardrails(additionalId);
+        var runtimeContext = new AIRuntimeContext([]);
+
+        builder.PopulateContext(runtimeContext, setFeatureMetadata: true);
+
+        runtimeContext.GetValue<IReadOnlyList<Guid>>(Core.Constants.ContextKeys.GuardrailIdsOverride)
+            .ShouldBe([replaceId]);
+        runtimeContext.GetValue<IReadOnlyList<Guid>>(Core.Constants.ContextKeys.AdditionalGuardrailIds)
+            .ShouldBe([additionalId]);
     }
 }

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Services/AIChatServiceTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Services/AIChatServiceTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Options;
 using Umbraco.AI.Core.Chat;
+using Umbraco.AI.Core.Contexts;
 using Umbraco.AI.Core.Guardrails;
 using Umbraco.AI.Core.Models;
 using Umbraco.AI.Core.Profiles;
@@ -72,6 +73,7 @@ public class AIChatServiceTests
             _clientFactoryMock.Object,
             _profileServiceMock.Object,
             new Mock<IAIGuardrailService>().Object,
+            new Mock<IAIContextService>().Object,
             _optionsMock.Object,
             _eventAggregatorMock.Object,
             _contextAccessorMock.Object,
@@ -694,6 +696,7 @@ public class AIChatServiceTests
             _clientFactoryMock.Object,
             _profileServiceMock.Object,
             new Mock<IAIGuardrailService>().Object,
+            new Mock<IAIContextService>().Object,
             _optionsMock.Object,
             _eventAggregatorMock.Object,
             _contextAccessorMock.Object,

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/SpeechToText/AISpeechToTextBuilderTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/SpeechToText/AISpeechToTextBuilderTests.cs
@@ -173,28 +173,35 @@ public class AISpeechToTextBuilderTests
     }
 
     [Fact]
-    public void WithGuardrails_ById_SetsGuardrailIds()
+    public void WithGuardrails_ById_StoresAdditionalIds()
     {
-        // Arrange
         var guardrailId = Guid.NewGuid();
         var builder = new AISpeechToTextBuilder();
         builder.WithGuardrails(guardrailId);
 
-        // Assert
-        builder.GuardrailIds.ShouldContain(guardrailId);
-        builder.GuardrailAliases.ShouldBeNull();
+        builder.AdditionalGuardrailIds.ShouldContain(guardrailId);
+        builder.AdditionalGuardrailAliases.ShouldBeNull();
     }
 
     [Fact]
-    public void WithGuardrails_ByAlias_SetsGuardrailAliases()
+    public void WithGuardrails_ByAlias_StoresAdditionalAliases()
     {
-        // Arrange
         var builder = new AISpeechToTextBuilder();
         builder.WithGuardrails("content-filter");
 
-        // Assert
-        builder.GuardrailAliases.ShouldContain("content-filter");
-        builder.GuardrailIds.ShouldBeEmpty();
+        builder.AdditionalGuardrailAliases.ShouldContain("content-filter");
+        builder.AdditionalGuardrailIds.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void SetGuardrails_ById_StoresReplaceIds()
+    {
+        var guardrailId = Guid.NewGuid();
+        var builder = new AISpeechToTextBuilder();
+        builder.SetGuardrails(guardrailId);
+
+        builder.GuardrailIds.ShouldContain(guardrailId);
+        builder.GuardrailAliases.ShouldBeNull();
     }
 
     [Fact]

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tests/AITestRunnerTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tests/AITestRunnerTests.cs
@@ -1,0 +1,140 @@
+using System.Text.Json;
+using Umbraco.AI.Core.EditableModels;
+using Umbraco.AI.Core.Tests;
+
+namespace Umbraco.AI.Tests.Unit.Tests;
+
+/// <summary>
+/// Verifies <see cref="AITestRunner"/> preserves the null-vs-empty distinction when flowing stored
+/// test <see cref="AITest.ContextIds"/> into the feature's <c>contextIdsOverride</c> slot.
+/// Regression test: an empty stored list used to reach the resolvers as "replace profile contexts
+/// with nothing" and suppress them, so a test with only a profile override lost the override
+/// profile's contexts.
+/// </summary>
+public class AITestRunnerTests
+{
+    private readonly Mock<IAITestRunRepository> _runRepositoryMock = new();
+    private readonly Mock<IAITestTranscriptRepository> _transcriptRepositoryMock = new();
+
+    private AITestRunner CreateRunner(RecordingTestFeature feature)
+    {
+        var features = new AITestFeatureCollection(() => [feature]);
+        var graders = new AITestGraderCollection(() => []);
+        return new AITestRunner(
+            _runRepositoryMock.Object,
+            _transcriptRepositoryMock.Object,
+            features,
+            graders);
+    }
+
+    private static AITest BuildTest(IReadOnlyList<Guid> contextIds, params AITestVariation[] variations) => new()
+    {
+        Id = Guid.NewGuid(),
+        Alias = "t",
+        Name = "t",
+        TestFeatureId = "recording",
+        TestTargetId = Guid.NewGuid(),
+        ContextIds = contextIds,
+        Variations = variations,
+        RunCount = 1,
+    };
+
+    [Fact]
+    public async Task ExecuteTestAsync_NoOverrideAndEmptyStoredContexts_PassesNullToFeature()
+    {
+        var feature = new RecordingTestFeature();
+        var runner = CreateRunner(feature);
+
+        await runner.ExecuteTestAsync(BuildTest([]));
+
+        feature.ReceivedContextIdsOverride.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteTestAsync_NoOverrideAndPopulatedStoredContexts_PassesStoredListToFeature()
+    {
+        var stored = Guid.NewGuid();
+        var feature = new RecordingTestFeature();
+        var runner = CreateRunner(feature);
+
+        await runner.ExecuteTestAsync(BuildTest([stored]));
+
+        feature.ReceivedContextIdsOverride.ShouldNotBeNull();
+        feature.ReceivedContextIdsOverride!.ShouldBe([stored]);
+    }
+
+    [Fact]
+    public async Task ExecuteTestAsync_CallerOverridePresent_PassesCallerListToFeatureEvenIfEmpty()
+    {
+        // An explicit empty caller override means "explicit zero contexts" (mirrors builder SetContexts([])),
+        // and should reach the feature so the resolvers receive the override signal.
+        var feature = new RecordingTestFeature();
+        var runner = CreateRunner(feature);
+
+        await runner.ExecuteTestAsync(BuildTest([Guid.NewGuid()]), contextIdsOverride: []);
+
+        feature.ReceivedContextIdsOverride.ShouldNotBeNull();
+        feature.ReceivedContextIdsOverride!.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ExecuteTestAsync_VariationWithNoContextIds_FallsBackToNullWhenTestStoredEmpty()
+    {
+        var feature = new RecordingTestFeature();
+        var runner = CreateRunner(feature);
+
+        var variation = new AITestVariation { Id = Guid.NewGuid(), Name = "v", ContextIds = null };
+        await runner.ExecuteTestAsync(BuildTest([], variation));
+
+        // Two runs captured: default + variation, both should have null (no override)
+        feature.AllReceivedContextIdsOverrides.Count.ShouldBe(2);
+        feature.AllReceivedContextIdsOverrides.ShouldAllBe(x => x == null);
+    }
+
+    [Fact]
+    public async Task ExecuteTestAsync_VariationWithExplicitEmptyContextIds_PassesEmptyOverride()
+    {
+        var feature = new RecordingTestFeature();
+        var runner = CreateRunner(feature);
+
+        var variation = new AITestVariation { Id = Guid.NewGuid(), Name = "v", ContextIds = [] };
+        await runner.ExecuteTestAsync(BuildTest([Guid.NewGuid()], variation));
+
+        // Default run uses test's stored list; variation run uses the explicit [] override.
+        feature.AllReceivedContextIdsOverrides.Count.ShouldBe(2);
+        feature.AllReceivedContextIdsOverrides[1].ShouldNotBeNull();
+        feature.AllReceivedContextIdsOverrides[1]!.ShouldBeEmpty();
+    }
+
+    private sealed class RecordingTestFeature : IAITestFeature
+    {
+        public string Id => "recording";
+        public string Name => "Recording";
+        public string Description => "Captures the overrides it received for assertions";
+        public string Category => "test";
+        public Type? ConfigType => null;
+        public AIEditableModelSchema? GetConfigSchema() => null;
+        public string ExtractOutputValue(AITestTranscript transcript) => string.Empty;
+
+        public List<IReadOnlyList<Guid>?> AllReceivedContextIdsOverrides { get; } = [];
+        public IReadOnlyList<Guid>? ReceivedContextIdsOverride => AllReceivedContextIdsOverrides.Count > 0
+            ? AllReceivedContextIdsOverrides[0]
+            : null;
+
+        public Task<AITestTranscript> ExecuteAsync(
+            AITest test,
+            int runNumber,
+            Guid? profileIdOverride,
+            IEnumerable<Guid>? contextIdsOverride,
+            IEnumerable<Guid>? guardrailIdsOverride,
+            CancellationToken cancellationToken)
+        {
+            AllReceivedContextIdsOverrides.Add(contextIdsOverride?.ToList());
+            return Task.FromResult(new AITestTranscript
+            {
+                RunId = Guid.Empty,
+                FinalOutput = JsonDocument.Parse("{}").RootElement,
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `WithContexts`/`SetContexts` and `WithGuardrails`/`SetGuardrails` to the four inline builders (chat, agent, speech-to-text, embedding). `With*` layers on top of the profile/agent defaults (additive); `Set*` fully replaces them. Unifies the override mechanism into one core runtime-context key so `Override` semantics are consistent whether the caller is a builder or the test-execution feature.

## Changes

- **Builder API** — `WithContexts` / `WithGuardrails` (additive) and `SetContexts` / `SetGuardrails` (replace) across `AIChatBuilder`, `AIInlineAgentBuilder`, `AISpeechToTextBuilder`, `AIEmbeddingBuilder`. Each method has `Guid[]` and `string[]` overloads; aliases are resolved by the service layer.
- **Unified override key** — deleted the per-scope `Umbraco.AI.Agent.ContextIdsOverride` and `Umbraco.AI.Prompt.ContextIdsOverride` constants. Single core key `Umbraco.AI.ContextIdsOverride` drives full replace; all three context resolvers (profile/agent/prompt) suppress themselves when it's set. Guardrails already used a single key; the source resolvers now suppress when it's set (previously override was effectively additive due to the aggregator).
- **New `AdditionalGuardrailIdsResolver`** — runs alongside the source resolvers when `AdditionalGuardrailIds` is set, so `WithGuardrails` stacks on top.
- **Shared builder state** — `AIGuardrailBuilderState` and `AIContextBuilderState` hold the replace/additive slots and emit the runtime keys; each builder delegates via one-line wrappers.
- **Rule-level dedup** — `AIGuardrailRule` now carries its parent `GuardrailId`. `AIGuardrailResolutionService` groups incoming rules by `GuardrailId` and skips whole groups already contributed, replacing the previous all-or-nothing resolver dedup.
- **Test-runner regression fix** — `AITestRunner` used to fall back from a null caller override to `test.ContextIds.ToList()`, producing an empty list when the test had no stored contexts. Under the unified override semantics, an empty list meant "replace profile contexts with nothing" and suppressed them. The runner now preserves the null-vs-empty distinction via a new `CollectionExtensions.NullIfEmpty` helper, so profile-only overrides pick up the override profile's contexts as expected. Explicit empty caller overrides still flow through as `[]` to mirror builder `SetContexts([])` semantics.
- **UI copy** — Test details "Contexts" description now says "Override the target's contexts..." rather than "include", matching the replace semantics and the variation modal wording.
- **Minor** — `ProfileContextResolver` short-circuits the profile fetch when a full override is set; duplicate context-alias resolution helper extracted into `AIContextServiceAliasExtensions` (mirroring the guardrail alias extension); `FromGuardrails` factory on `AIGuardrailResolverResult` collapses five 12-line loops into one call.

## Test plan

- [x] Core unit tests (714 passing, +5 for `AITestRunner` regression coverage)
- [x] Agent unit tests (139 passing, +4 for `AgentContextResolver` / `AgentGuardrailResolver` override suppression)
- [x] Prompt unit tests (55 passing, +4 for `PromptContextResolver` / `PromptGuardrailResolver` override suppression)
- [x] `WithContexts(extraId)` additive on profile — covered by `ProfileContextResolverTests.ResolveAsync_AdditionalContextIds_AppendedToProfile` + builder `PopulateContext_WithContexts_WritesAdditionalKey` tests
- [x] `ContextIdsOverride = [X]` yields exactly `[X]` — covered by `ProfileContextResolverTests.ResolveAsync_OverrideTakesPrecedenceOverProfile` + builder `PopulateContext_SetContexts_WritesOverrideKey` + new `AITestRunnerTests` (guards the empty-list regression). Manually verified in backoffice.
- [x] `SetGuardrails(X)` suppresses profile/agent/prompt guardrails — covered by existing `GuardrailResolverOverrideTests` (profile) + new Agent/Prompt resolver override-suppression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)