### PR TITLE
fix(core): Show progress on test run button in collection view

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/collection/views/table/test-run-inline-button.element.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/collection/views/table/test-run-inline-button.element.ts
@@ -1,0 +1,65 @@
+import { html, customElement, state, property } from "@umbraco-cms/backoffice/external/lit";
+import type { UUIButtonState } from "@umbraco-cms/backoffice/external/uui";
+import { UmbLitElement } from "@umbraco-cms/backoffice/lit-element";
+import { UaiTestRunEntityAction } from "../../../entity-actions/test-run.action.js";
+import { UAI_TEST_ENTITY_TYPE } from "../../../constants.js";
+
+/**
+ * Inline Run button rendered per-row in the test collection table.
+ * Mirrors the Run button on the test workspace editor by exposing
+ * waiting/success/failed progress state via UUIButtonState.
+ */
+@customElement("uai-test-run-inline-button")
+export class UaiTestRunInlineButtonElement extends UmbLitElement {
+    @property({ type: String })
+    unique?: string;
+
+    @state()
+    private _state?: UUIButtonState;
+
+    async #onClick(event: Event) {
+        event.stopPropagation();
+        event.preventDefault();
+        if (!this.unique) return;
+
+        this._state = "waiting";
+
+        try {
+            const action = new UaiTestRunEntityAction(this, {
+                unique: this.unique,
+                entityType: UAI_TEST_ENTITY_TYPE,
+                meta: undefined as never,
+            });
+            await action.execute();
+            this._state = "success";
+        } catch {
+            this._state = "failed";
+        }
+
+        setTimeout(() => {
+            this._state = undefined;
+        }, 2000);
+    }
+
+    render() {
+        return html`
+            <uui-button
+                compact
+                look="secondary"
+                label="Run"
+                .state=${this._state}
+                @click=${this.#onClick}
+            >
+                <uui-icon name="icon-play"></uui-icon>
+            </uui-button>
+        `;
+    }
+}
+
+export default UaiTestRunInlineButtonElement;
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "uai-test-run-inline-button": UaiTestRunInlineButtonElement;
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/collection/views/table/test-run-inline-button.element.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/collection/views/table/test-run-inline-button.element.ts
@@ -45,7 +45,8 @@ export class UaiTestRunInlineButtonElement extends UmbLitElement {
         return html`
             <uui-button
                 compact
-                look="secondary"
+                look="default"
+                color="default"
                 label="Run"
                 .state=${this._state}
                 @click=${this.#onClick}

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/collection/views/table/test-table-collection-view.element.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/collection/views/table/test-table-collection-view.element.ts
@@ -15,6 +15,7 @@ import { formatDateTime } from "../../../../core/index.js";
 import type { UaiTestItemModel } from "../../../types.js";
 import { UAI_TEST_ICON } from "../../../constants.js";
 import { UAI_EDIT_TEST_WORKSPACE_PATH_PATTERN } from "../../../workspace/paths.js";
+import "./test-run-inline-button.element.js";
 
 /**
  * Table view for the Test collection.
@@ -100,9 +101,12 @@ export class UaiTestTableCollectionViewElement extends UmbLitElement {
                 },
                 {
                     columnAlias: "entityActions",
-                    value: html`<umb-entity-actions-table-column-view
-                        .value=${{ entityType: item.entityType, unique: item.unique }}
-                    ></umb-entity-actions-table-column-view>`,
+                    value: html`<div class="row-actions">
+                        <uai-test-run-inline-button .unique=${item.unique}></uai-test-run-inline-button>
+                        <umb-entity-actions-table-column-view
+                            .value=${{ entityType: item.entityType, unique: item.unique }}
+                        ></umb-entity-actions-table-column-view>
+                    </div>`,
                 },
             ],
         }));
@@ -131,7 +135,21 @@ export class UaiTestTableCollectionViewElement extends UmbLitElement {
         ></umb-table>`;
     }
 
-    static styles = [UmbTextStyles, css`uui-tag { white-space: nowrap; }`];
+    static styles = [
+        UmbTextStyles,
+        css`
+            uui-tag {
+                white-space: nowrap;
+            }
+
+            .row-actions {
+                display: inline-flex;
+                align-items: center;
+                gap: var(--uui-size-space-2);
+                justify-content: flex-end;
+            }
+        `,
+    ];
 }
 
 export default UaiTestTableCollectionViewElement;

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/entity-actions/manifests.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/entity-actions/manifests.ts
@@ -18,19 +18,6 @@ export const testEntityActionManifests: Array<UmbExtensionManifest> = [
 	{
 		type: "entityAction",
 		kind: "default",
-		alias: "UmbracoAI.EntityAction.Test.Run",
-		name: "Run Test Entity Action",
-		weight: 1100,
-		api: () => import("./test-run.action.js"),
-		forEntityTypes: [UAI_TEST_ENTITY_TYPE],
-		meta: {
-			icon: "icon-play",
-			label: "Run",
-		},
-	},
-	{
-		type: "entityAction",
-		kind: "default",
 		alias: "UmbracoAI.EntityAction.Test.Delete",
 		name: "Delete Test Entity Action",
 		weight: 100,


### PR DESCRIPTION
## Summary
- Adds an inline Run button per row in the test collection table, exposing waiting/success/failed state via `UUIButtonState` so users see feedback while a test is running (mirrors the Run button on the test workspace editor).
- Button uses `look="default"` + `color="default"` to match the adjacent 3-dot row-actions button (transparent background, subtle hover).
- Removes the duplicate Run entry from the entity actions dropdown now that the action lives as a dedicated inline button.

Closes #131

## Test plan
- [x] Open the Tests dashboard
- [x] Click Run on a row — spinner shows while executing, then a success/failure checkmark for ~2s before resetting
- [x] Confirm the 3-dot dropdown no longer contains Run
- [x] Confirm the inline Run button blends with the 3-dot button (no grey fill, subtle hover)
- [x] Confirm Run button on the test editor workspace still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)