### PR TITLE
fix(core): Handle Umbraco slider {from,to} shape in double config fields

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Evaluators/LLMGuardrailEvaluator.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Evaluators/LLMGuardrailEvaluator.cs
@@ -1,8 +1,10 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.AI;
 using Umbraco.AI.Core.Chat;
 using Umbraco.AI.Core.EditableModels;
 using Umbraco.AI.Core.RuntimeContext;
+using Umbraco.AI.Core.Serialization;
 
 namespace Umbraco.AI.Core.Guardrails.Evaluators;
 
@@ -41,8 +43,9 @@ public class LLMGuardrailEvaluatorConfig
         Label = "Safety Threshold",
         Description = "Content is flagged if the safety score is below this threshold (0-1)",
         EditorUiAlias = "Umb.PropertyEditorUi.Slider",
-        EditorConfig = "[{\"alias\":\"minValue\",\"value\":0},{\"alias\":\"maxValue\",\"value\":1},{\"alias\":\"step\",\"value\":0.1}]",
+        EditorConfig = "[{\"alias\":\"minVal\",\"value\":0},{\"alias\":\"maxVal\",\"value\":1},{\"alias\":\"step\",\"value\":0.1},{\"alias\":\"initVal1\",\"value\":0.7}]",
         SortOrder = 3)]
+    [JsonConverter(typeof(SliderDoubleJsonConverter))]
     public double SafetyThreshold { get; set; } = 0.7;
 }
 

--- a/Umbraco.AI/src/Umbraco.AI.Core/Serialization/SliderDoubleJsonConverter.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Serialization/SliderDoubleJsonConverter.cs
@@ -1,0 +1,58 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Umbraco.AI.Core.Serialization;
+
+/// <summary>
+/// JSON converter for <see cref="double"/> properties bound to the Umbraco backoffice slider
+/// (<c>Umb.PropertyEditorUi.Slider</c>), which serialises its value as <c>{ "from": n, "to": n }</c>.
+/// Reads the <c>from</c> field when the value is an object, otherwise falls back to standard
+/// number / string-number parsing.
+/// </summary>
+public sealed class SliderDoubleJsonConverter : JsonConverter<double>
+{
+    /// <inheritdoc />
+    public override double Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.Number:
+                return reader.GetDouble();
+
+            case JsonTokenType.String:
+                var s = reader.GetString();
+                if (double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed))
+                {
+                    return parsed;
+                }
+                throw new JsonException($"Cannot convert string '{s}' to double.");
+
+            case JsonTokenType.StartObject:
+                using (var doc = JsonDocument.ParseValue(ref reader))
+                {
+                    if (doc.RootElement.TryGetProperty("from", out var fromElement))
+                    {
+                        return fromElement.ValueKind switch
+                        {
+                            JsonValueKind.Number => fromElement.GetDouble(),
+                            JsonValueKind.String when double.TryParse(
+                                fromElement.GetString(),
+                                NumberStyles.Float,
+                                CultureInfo.InvariantCulture,
+                                out var fromString) => fromString,
+                            _ => throw new JsonException("Slider 'from' value is not a number.")
+                        };
+                    }
+                    throw new JsonException("Object value has no 'from' property to convert to double.");
+                }
+
+            default:
+                throw new JsonException($"Unexpected token {reader.TokenType} when reading double.");
+        }
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, double value, JsonSerializerOptions options)
+        => writer.WriteNumberValue(value);
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/LLMJudgeGrader.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/LLMJudgeGrader.cs
@@ -1,7 +1,9 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.AI;
 using Umbraco.AI.Core.Chat;
 using Umbraco.AI.Core.EditableModels;
+using Umbraco.AI.Core.Serialization;
 
 namespace Umbraco.AI.Core.Tests.Graders;
 
@@ -38,8 +40,9 @@ public class LLMJudgeGraderConfig
         Label = "Pass Threshold",
         Description = "Minimum score to pass (0-1)",
         EditorUiAlias = "Umb.PropertyEditorUi.Slider",
-        EditorConfig = "[{\"alias\":\"minValue\",\"value\":0},{\"alias\":\"maxValue\",\"value\":1},{\"alias\":\"step\",\"value\":0.1}]",
+        EditorConfig = "[{\"alias\":\"minVal\",\"value\":0},{\"alias\":\"maxVal\",\"value\":1},{\"alias\":\"step\",\"value\":0.1},{\"alias\":\"initVal1\",\"value\":0.7}]",
         SortOrder = 3)]
+    [JsonConverter(typeof(SliderDoubleJsonConverter))]
     public double PassThreshold { get; set; } = 0.7;
 }
 

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Serialization/SliderDoubleJsonConverterTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Serialization/SliderDoubleJsonConverterTests.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Umbraco.AI.Core.Serialization;
+
+namespace Umbraco.AI.Tests.Unit.Serialization;
+
+public class SliderDoubleJsonConverterTests
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private sealed class Container
+    {
+        [JsonConverter(typeof(SliderDoubleJsonConverter))]
+        public double Value { get; set; }
+    }
+
+    [Fact]
+    public void Read_PlainNumber_ReturnsValue()
+    {
+        var result = JsonSerializer.Deserialize<Container>("""{"value":0.7}""", Options);
+
+        result.ShouldNotBeNull();
+        result!.Value.ShouldBe(0.7);
+    }
+
+    [Fact]
+    public void Read_StringNumber_ReturnsValue()
+    {
+        var result = JsonSerializer.Deserialize<Container>("""{"value":"0.42"}""", Options);
+
+        result.ShouldNotBeNull();
+        result!.Value.ShouldBe(0.42);
+    }
+
+    [Fact]
+    public void Read_SliderObject_ReturnsFromValue()
+    {
+        var result = JsonSerializer.Deserialize<Container>("""{"value":{"from":0.7,"to":0.7}}""", Options);
+
+        result.ShouldNotBeNull();
+        result!.Value.ShouldBe(0.7);
+    }
+
+    [Fact]
+    public void Read_SliderObject_RangeReturnsLowerBound()
+    {
+        var result = JsonSerializer.Deserialize<Container>("""{"value":{"from":0.3,"to":0.9}}""", Options);
+
+        result.ShouldNotBeNull();
+        result!.Value.ShouldBe(0.3);
+    }
+
+    [Fact]
+    public void Read_ObjectWithoutFrom_Throws()
+    {
+        Should.Throw<JsonException>(() =>
+            JsonSerializer.Deserialize<Container>("""{"value":{"to":0.5}}""", Options));
+    }
+
+    [Fact]
+    public void Read_BooleanValue_Throws()
+    {
+        Should.Throw<JsonException>(() =>
+            JsonSerializer.Deserialize<Container>("""{"value":true}""", Options));
+    }
+
+    [Fact]
+    public void Write_EmitsPlainNumber()
+    {
+        var json = JsonSerializer.Serialize(new Container { Value = 0.7 }, Options);
+
+        json.ShouldBe("""{"value":0.7}""");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #146 — saving an LLM Safety Judge guardrail rule produces *"The JSON value could not be converted to System.Double. Path: \$.safetyThreshold"* when the guardrail is later evaluated.

**Root cause:** `Umb.PropertyEditorUi.Slider` serialises its value as `{ "from": n, "to": n }`, not a plain number. The C# property `SafetyThreshold` is typed as `double`, so System.Text.Json fails on deserialization. The `Contains` and `Regex` evaluators don't hit this because they bind to text editors. The same latent bug exists on `LLMJudgeGraderConfig.PassThreshold`.

**Fix:**
- Added `SliderDoubleJsonConverter` that accepts a JSON number, a numeric string, or the slider `{from, to}` object (extracting `from`).
- Applied via `[JsonConverter(...)]` to `SafetyThreshold` and `PassThreshold`.
- Corrected the slider's `EditorConfig` aliases — the property editor reads `minVal`/`maxVal`, not `minValue`/`maxValue`, so the slider previously fell back to a 0–100 range instead of 0–1. Added `initVal1=0.7` so the slider initialises at the C# default.

## Test plan

- [x] New unit tests in `SliderDoubleJsonConverterTests` (7 cases: number / string-number / slider object / range / missing `from` / non-numeric / write)
- [x] Existing guardrail + grader + editable-model tests still green (72 tests)
- [ ] Manual verification: create LLM Safety Judge guardrail, attach to Backoffice Copilot agent, send a message — no deserialization error

🤖 Generated with [Claude Code](https://claude.com/claude-code)