### PR TITLE
fix(prompt): Extract display value from prompt result options for grading

### DIFF
--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Tests/PromptTestFeature.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Tests/PromptTestFeature.cs
@@ -32,6 +32,39 @@ public class PromptTestFeature : AITestFeatureBase<PromptTestFeatureConfig>
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// For prompts with a result type of Single Option / Multiple Options, the underlying
+    /// chat response is a structured-output JSON envelope (e.g. <c>{"value": "..."}</c>).
+    /// The unwrapped text lives on <c>resultOptions[].displayValue</c>. Graders should
+    /// evaluate the unwrapped text, not the JSON envelope, so prefer that when present.
+    /// </remarks>
+    public override string ExtractOutputValue(AITestTranscript transcript)
+    {
+        var output = transcript.FinalOutput;
+
+        if (output.ValueKind == JsonValueKind.Object
+            && output.TryGetProperty("resultOptions", out var resultOptions)
+            && resultOptions.ValueKind == JsonValueKind.Array
+            && resultOptions.GetArrayLength() > 0)
+        {
+            var displayValues = resultOptions.EnumerateArray()
+                .Where(o => o.ValueKind == JsonValueKind.Object
+                    && o.TryGetProperty("displayValue", out _))
+                .Select(o => o.GetProperty("displayValue").GetString() ?? string.Empty)
+                .ToList();
+
+            if (displayValues.Count > 0)
+            {
+                return displayValues.Count == 1
+                    ? displayValues[0]
+                    : string.Join(Environment.NewLine, displayValues);
+            }
+        }
+
+        return base.ExtractOutputValue(transcript);
+    }
+
+    /// <inheritdoc />
     public override async Task<AITestTranscript> ExecuteAsync(
         AITest test,
         int runNumber,

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Tests/PromptTestFeature.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Tests/PromptTestFeature.cs
@@ -40,23 +40,21 @@ public class PromptTestFeature : AITestFeatureBase<PromptTestFeatureConfig>
     /// </remarks>
     public override string ExtractOutputValue(AITestTranscript transcript)
     {
-        var output = transcript.FinalOutput;
+        var envelope = transcript.FinalOutput.ValueKind == JsonValueKind.Object
+            ? transcript.FinalOutput.Deserialize<FinalOutputEnvelope>(AIConstants.DefaultJsonSerializerOptions)
+            : null;
 
-        if (output.ValueKind == JsonValueKind.Object
-            && output.TryGetProperty("resultOptions", out var resultOptions)
-            && resultOptions.ValueKind == JsonValueKind.Array
-            && resultOptions.GetArrayLength() > 0)
+        if (envelope?.ResultOptions is { Count: > 0 } options)
         {
-            var displayValues = resultOptions.EnumerateArray()
-                .Where(o => o.ValueKind == JsonValueKind.Object
-                    && o.TryGetProperty("displayValue", out _))
-                .Select(o => o.GetProperty("displayValue").GetString() ?? string.Empty)
+            var displayValues = options
+                .Select(o => o.DisplayValue)
+                .Where(v => v is not null)
                 .ToList();
 
             if (displayValues.Count > 0)
             {
                 return displayValues.Count == 1
-                    ? displayValues[0]
+                    ? displayValues[0]!
                     : string.Join(Environment.NewLine, displayValues);
             }
         }
@@ -128,11 +126,9 @@ public class PromptTestFeature : AITestFeatureBase<PromptTestFeatureConfig>
                     new { role = "system", content = "Prompt execution failed" },
                     new { role = "error", content = ex.Message }
                 }, AIConstants.DefaultJsonSerializerOptions),
-                FinalOutput = JsonSerializer.SerializeToElement(new
-                {
-                    error = ex.Message,
-                    stackTrace = ex.StackTrace
-                }, AIConstants.DefaultJsonSerializerOptions),
+                FinalOutput = JsonSerializer.SerializeToElement(
+                    new FinalOutputEnvelope { Error = ex.Message, StackTrace = ex.StackTrace },
+                    AIConstants.DefaultJsonSerializerOptions),
                 Timing = JsonSerializer.SerializeToElement(new
                 {
                     totalMs = stopwatch.ElapsedMilliseconds,
@@ -168,17 +164,45 @@ public class PromptTestFeature : AITestFeatureBase<PromptTestFeatureConfig>
                 totalMs = stopwatch.ElapsedMilliseconds,
                 status = "success"
             }, AIConstants.DefaultJsonSerializerOptions),
-            FinalOutput = JsonSerializer.SerializeToElement(new
-            {
-                content = result.Content,
-                usage = result.Usage != null ? new
+            FinalOutput = JsonSerializer.SerializeToElement(
+                new FinalOutputEnvelope
                 {
-                    inputTokens = result.Usage.InputTokenCount,
-                    outputTokens = result.Usage.OutputTokenCount,
-                    totalTokens = result.Usage.TotalTokenCount
-                } : null,
-                resultOptions = result.ResultOptions
-            }, AIConstants.DefaultJsonSerializerOptions)
+                    Content = result.Content,
+                    Usage = result.Usage is null ? null : new FinalOutputUsage
+                    {
+                        InputTokens = result.Usage.InputTokenCount,
+                        OutputTokens = result.Usage.OutputTokenCount,
+                        TotalTokens = result.Usage.TotalTokenCount
+                    },
+                    ResultOptions = result.ResultOptions
+                },
+                AIConstants.DefaultJsonSerializerOptions)
         };
+    }
+
+    /// <summary>
+    /// Schema of the <see cref="AITestTranscript.FinalOutput"/> JSON for prompt tests.
+    /// Defined as a single type so write-time and read-time stay in sync.
+    /// </summary>
+    internal sealed class FinalOutputEnvelope
+    {
+        public string? Content { get; init; }
+
+        public FinalOutputUsage? Usage { get; init; }
+
+        public IReadOnlyList<AIPromptExecutionResult.AIPromptResultOption>? ResultOptions { get; init; }
+
+        public string? Error { get; init; }
+
+        public string? StackTrace { get; init; }
+    }
+
+    internal sealed class FinalOutputUsage
+    {
+        public long? InputTokens { get; init; }
+
+        public long? OutputTokens { get; init; }
+
+        public long? TotalTokens { get; init; }
     }
 }

--- a/Umbraco.AI.Prompt/tests/Umbraco.AI.Prompt.Tests.Unit/Tests/PromptTestFeatureTests.cs
+++ b/Umbraco.AI.Prompt/tests/Umbraco.AI.Prompt.Tests.Unit/Tests/PromptTestFeatureTests.cs
@@ -1,0 +1,95 @@
+using System.Text.Json;
+using Moq;
+using Shouldly;
+using Umbraco.AI.Core.EditableModels;
+using Umbraco.AI.Core.Tests;
+using Umbraco.AI.Prompt.Core.Prompts;
+using Umbraco.AI.Prompt.Core.Tests;
+using Xunit;
+
+namespace Umbraco.AI.Prompt.Tests.Unit.Tests;
+
+/// <summary>
+/// Regression tests for <see cref="PromptTestFeature.ExtractOutputValue"/>.
+/// For prompts with a result type of Single Option / Multiple Options, the underlying chat
+/// response is a structured-output JSON envelope (e.g. <c>{"value":"..."}</c>); the unwrapped
+/// text lives on <c>resultOptions[].displayValue</c>. Graders must evaluate the unwrapped text,
+/// not the JSON envelope (issue #142).
+/// </summary>
+public class PromptTestFeatureTests
+{
+    private readonly PromptTestFeature _feature = new(
+        Mock.Of<IAIPromptService>(),
+        new AITestContextResolver(),
+        Mock.Of<IAIEditableModelSchemaBuilder>());
+
+    [Fact]
+    public void ExtractOutputValue_SingleOption_ReturnsDisplayValue()
+    {
+        var transcript = BuildTranscript(new
+        {
+            content = "{\"value\":\"Hello world\"}",
+            resultOptions = new[]
+            {
+                new { label = "Result", displayValue = "Hello world" }
+            }
+        });
+
+        _feature.ExtractOutputValue(transcript).ShouldBe("Hello world");
+    }
+
+    [Fact]
+    public void ExtractOutputValue_MultipleOptions_ReturnsJoinedDisplayValues()
+    {
+        var transcript = BuildTranscript(new
+        {
+            content = "{\"options\":[...]}",
+            resultOptions = new[]
+            {
+                new { label = "A", displayValue = "First" },
+                new { label = "B", displayValue = "Second" }
+            }
+        });
+
+        _feature.ExtractOutputValue(transcript)
+            .ShouldBe("First" + Environment.NewLine + "Second");
+    }
+
+    [Fact]
+    public void ExtractOutputValue_NoResultOptions_FallsBackToContent()
+    {
+        var transcript = BuildTranscript(new
+        {
+            content = "Plain text response",
+            resultOptions = Array.Empty<object>()
+        });
+
+        _feature.ExtractOutputValue(transcript).ShouldBe("Plain text response");
+    }
+
+    [Fact]
+    public void ExtractOutputValue_MissingResultOptions_FallsBackToContent()
+    {
+        var transcript = BuildTranscript(new { content = "Plain text response" });
+
+        _feature.ExtractOutputValue(transcript).ShouldBe("Plain text response");
+    }
+
+    [Fact]
+    public void ExtractOutputValue_ErrorTranscript_ReturnsRawObjectText()
+    {
+        // Error transcripts don't have a "content" property — base behaviour should kick in.
+        var transcript = BuildTranscript(new { error = "boom", stackTrace = "..." });
+
+        _feature.ExtractOutputValue(transcript)
+            .ShouldContain("\"error\"");
+    }
+
+    private static AITestTranscript BuildTranscript(object finalOutput) => new()
+    {
+        RunId = Guid.NewGuid(),
+        FinalOutput = JsonSerializer.SerializeToElement(
+            finalOutput,
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase })
+    };
+}


### PR DESCRIPTION
## Summary

- Fixes #142 — prompt test graders evaluated the raw structured-output JSON envelope (`{"value":"..."}`) instead of the unwrapped text, causing the Regex grader to fail length checks and the LLM Judge to throw `The JSON value could not be converted to System.Double` when scoring.
- `PromptTestFeature` now overrides `ExtractOutputValue` to prefer `resultOptions[].displayValue` from the transcript's `FinalOutput`, joining multi-option responses with newlines and falling back to `content` when no options are present (preserves `OptionCount == 0` and error transcripts).
- Adds `PromptTestFeatureTests` covering single option, multiple options, no options, missing `resultOptions`, and error-shape transcripts.

## Test plan

- [x] `dotnet test Umbraco.AI.Prompt/Umbraco.AI.Prompt.slnx` — 60/60 pass (5 new)
- [x] `dotnet test Umbraco.AI/Umbraco.AI.slnx` — 714 unit + 25 integration pass
- [ ] Manual: create a Single Option prompt, run a test with the regex `^[\s\S]{1,160}$` and an LLM Judge, confirm graders evaluate the unwrapped text

🤖 Generated with [Claude Code](https://claude.com/claude-code)