### PR TITLE
fix(frontend): Open variation editor modal via route registration

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/components/test-variation-config-builder/test-variation-config-builder.element.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/components/test-variation-config-builder/test-variation-config-builder.element.ts
@@ -1,11 +1,22 @@
 import { css, html, customElement, property, repeat } from "@umbraco-cms/backoffice/external/lit";
 import { UmbLitElement } from "@umbraco-cms/backoffice/lit-element";
 import { UmbChangeEvent } from "@umbraco-cms/backoffice/event";
-import { UMB_MODAL_MANAGER_CONTEXT } from "@umbraco-cms/backoffice/modal";
+import { UmbModalRouteRegistrationController } from "@umbraco-cms/backoffice/router";
 import { UAI_TEST_VARIATION_CONFIG_EDITOR_MODAL } from "../../modals/test-variation-config-editor/index.js";
 import type { UaiTestVariation } from "../../types.js";
 import { getVariationSummary } from "../../types.js";
 
+/**
+ * Variation list with add/edit/remove actions.
+ *
+ * The editor modal is opened via UmbModalRouteRegistrationController + history.pushState
+ * (rather than modalManager.open), so the modal carries a router and publishes
+ * UMB_ROUTE_CONTEXT to its content. Property editors hosted inside the modal — notably
+ * the entity context picker (uai-mock-entity), which itself route-registers a nested
+ * editor modal for block grid support — depend on that context being reachable.
+ *
+ * @fires change - Fires when the variation list changes (UmbChangeEvent).
+ */
 @customElement("uai-test-variation-config-builder")
 export class UaiTestVariationConfigBuilderElement extends UmbLitElement {
     @property({ type: Array })
@@ -14,48 +25,84 @@ export class UaiTestVariationConfigBuilderElement extends UmbLitElement {
     @property({ type: String })
     testFeatureId = "";
 
-    async #onAdd() {
-        const modalManager = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
-        if (!modalManager) return;
+    /**
+     * Route path for the editor modal, emitted by UmbModalRouteRegistrationController
+     * once the route is registered (ready shortly after construction).
+     */
+    #editorRoutePath?: string;
 
-        const modal = modalManager.open(this, UAI_TEST_VARIATION_CONFIG_EDITOR_MODAL, {
-            data: {
-                testFeatureId: this.testFeatureId,
-            },
-        });
+    /**
+     * In-flight flow metadata for the current editor invocation. `existingVariation`
+     * is undefined for an Add and set to the source variation for an Edit; on submit
+     * it tells us whether to insert or replace. Lives only between open and
+     * submit/reject. URL cleanup on close is handled by the modal context.
+     */
+    #pendingFlow?: { existingVariation?: UaiTestVariation };
 
-        try {
-            const result = await modal.onSubmit();
-            this.variations = [...this.variations, result.variation];
-            this.dispatchEvent(new UmbChangeEvent());
-        } catch {
-            // User cancelled
-        }
+    constructor() {
+        super();
+
+        new UmbModalRouteRegistrationController(this, UAI_TEST_VARIATION_CONFIG_EDITOR_MODAL)
+            .addAdditionalPath("variation-editor")
+            .onSetup(() => {
+                // Guard against stray navigation (e.g. URL replayed via back/forward
+                // without going through Add/Edit): refuse to open without pending data.
+                if (!this.#pendingFlow) return false;
+                return {
+                    data: {
+                        existingVariation: this.#pendingFlow.existingVariation,
+                        testFeatureId: this.testFeatureId,
+                    },
+                };
+            })
+            .onSubmit((value) => {
+                const flow = this.#pendingFlow;
+                if (!flow || !value) {
+                    this.#pendingFlow = undefined;
+                    return;
+                }
+                if (flow.existingVariation) {
+                    const id = flow.existingVariation.id;
+                    this.variations = this.variations.map((v) => (v.id === id ? value.variation : v));
+                } else {
+                    this.variations = [...this.variations, value.variation];
+                }
+                this.#pendingFlow = undefined;
+                this.dispatchEvent(new UmbChangeEvent());
+            })
+            .onReject(() => {
+                this.#pendingFlow = undefined;
+            })
+            .observeRouteBuilder((routeBuilder) => {
+                this.#editorRoutePath = routeBuilder({});
+            });
     }
 
-    async #onEdit(variation: UaiTestVariation) {
-        const modalManager = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
-        if (!modalManager) return;
+    #onAdd() {
+        this.#pendingFlow = { existingVariation: undefined };
+        this.#navigateToEditorRoute();
+    }
 
-        const modal = modalManager.open(this, UAI_TEST_VARIATION_CONFIG_EDITOR_MODAL, {
-            data: {
-                existingVariation: variation,
-                testFeatureId: this.testFeatureId,
-            },
-        });
-
-        try {
-            const result = await modal.onSubmit();
-            this.variations = this.variations.map((v) => (v.id === variation.id ? result.variation : v));
-            this.dispatchEvent(new UmbChangeEvent());
-        } catch {
-            // User cancelled
-        }
+    #onEdit(variation: UaiTestVariation) {
+        this.#pendingFlow = { existingVariation: variation };
+        this.#navigateToEditorRoute();
     }
 
     #onRemove(variationId: string) {
         this.variations = this.variations.filter((v) => v.id !== variationId);
         this.dispatchEvent(new UmbChangeEvent());
+    }
+
+    #navigateToEditorRoute() {
+        if (!this.#editorRoutePath) {
+            // Registration runs synchronously in the constructor, but the route
+            // builder observable can fire on the next microtask. If this ever
+            // happens in practice, surface it loudly so we can investigate.
+            console.error("Variation editor route path not yet registered.");
+            this.#pendingFlow = undefined;
+            return;
+        }
+        window.history.pushState({}, "", this.#editorRoutePath);
     }
 
     override render() {

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/modals/test-variation-config-editor/test-variation-config-editor-modal.token.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/modals/test-variation-config-editor/test-variation-config-editor-modal.token.ts
@@ -6,9 +6,18 @@ export interface UaiTestVariationConfigEditorModalData {
     testFeatureId: string;
 }
 
-export interface UaiTestVariationConfigEditorModalValue {
-    variation: UaiTestVariation;
-}
+/**
+ * Submit value of the variation config editor modal. Includes `| undefined` so the
+ * modal can be registered via UmbModalRouteRegistrationController (whose onSetup
+ * return type requires `value` only when the token's value type is non-undefined).
+ * The modal itself only ever reaches `submit()` after building a real value, so
+ * consumers only need to handle undefined on the route-setup callback path.
+ */
+export type UaiTestVariationConfigEditorModalValue =
+    | {
+          variation: UaiTestVariation;
+      }
+    | undefined;
 
 export const UAI_TEST_VARIATION_CONFIG_EDITOR_MODAL = new UmbModalToken<
     UaiTestVariationConfigEditorModalData,


### PR DESCRIPTION
## Summary

Closes #144. Selecting a document type in the Entity Context picker on a test variation silently did nothing.

The variation config editor modal was opened via `modalManager.open()`, so `<umb-modal>` mounted an `UmbContextBoundary` over `UMB_ROUTE_CONTEXT` instead of a real `<umb-router-slot>`. Inside the modal, `uai-mock-entity` (added in #125) could no longer consume `UMB_ROUTE_CONTEXT`, its `UmbModalRouteRegistrationController` never fired, and `#editorRoutePath` never resolved — so the sub-type click pushed nothing.

This switches the variation builder to `UmbModalRouteRegistrationController` + `history.pushState`, mirroring `uai-mock-entity`'s own pattern. The modal now carries a router, publishes `UMB_ROUTE_CONTEXT` to its content, and the chain that #125 needs for nested block-grid editors stays intact.

`UaiTestVariationConfigEditorModalValue` gets `| undefined` added for the same reason `UaiMockEntityEditorModalValue` does — `UmbModalRouteSetupReturn`'s typing only makes `value` optional when the token's value type is `... | undefined`.

## Test plan

- [ ] Test → variation → Entity Context → +Add → Document → Article — the mock entity editor should now open
- [ ] Inside the entity context editor, exercise a doc-type with block grid / block list / block rte properties — "Create new" should still open the catalogue modal (not silently insert), and block edit links should still work (regression check for #125)
- [ ] Add a new variation, edit an existing variation, cancel via Escape, cancel via the Cancel button — variations array should reflect the action correctly
- [ ] After submit/cancel, hit browser back/forward — the variation modal should not re-open into a stale Add state

🤖 Generated with [Claude Code](https://claude.com/claude-code)