### PR TITLE
fix(chat): Register UsageDetails to UsageModel mapper

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Web/Api/Common/Mapping/UsageDetailsMapDefinition.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Web/Api/Common/Mapping/UsageDetailsMapDefinition.cs
@@ -5,12 +5,12 @@ using Umbraco.Cms.Core.Mapping;
 namespace Umbraco.AI.Web.Api.Common.Mapping;
 
 /// <summary>
-/// Map definitions for common models shared across API features.
+/// Maps Microsoft.Extensions.AI <see cref="UsageDetails"/> to <see cref="UsageModel"/> for API responses.
 /// </summary>
-public class CommonMapDefinition : IMapDefinition
+public class UsageDetailsMapDefinition : IMapDefinition
 {
     /// <inheritdoc />
-    public void DefineMaps(IUmbracoMapper mapper) 
+    public void DefineMaps(IUmbracoMapper mapper)
     {
         mapper.Define<UsageDetails, UsageModel>((_, _) => new UsageModel(), Map);
     }

--- a/Umbraco.AI/src/Umbraco.AI.Web/Configuration/UmbracoBuilderExtensions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Web/Configuration/UmbracoBuilderExtensions.cs
@@ -8,6 +8,7 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 using Umbraco.AI.Web;
 using Umbraco.AI.Web.Api;
 using Umbraco.AI.Web.Api.Common.Configuration;
+using Umbraco.AI.Web.Api.Common.Mapping;
 using Umbraco.AI.Web.Api.Common.Models;
 using Umbraco.AI.Web.Api.Management.Analytics.Usage.Mapping;
 using Umbraco.AI.Web.Api.Management.AuditLog.Mapping;
@@ -64,6 +65,7 @@ public static class UmbracoBuilderExtensions
     private static IUmbracoBuilder AddUmbracoAIMapDefinitions(this IUmbracoBuilder builder)
     {
         builder.WithCollectionBuilder<MapDefinitionCollectionBuilder>()
+            .Add<UsageDetailsMapDefinition>()
             .Add<CommonMapDefinition>()
             .Add<ConnectionMapDefinition>()
             .Add<ProfileMapDefinition>()

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Api/Management/Chat/ChatMapDefinitionTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Api/Management/Chat/ChatMapDefinitionTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Shouldly;
+using Umbraco.AI.Web.Api.Common.Mapping;
 using Umbraco.AI.Web.Api.Management.Chat.Mapping;
 using Umbraco.AI.Web.Api.Management.Chat.Models;
 using Umbraco.Cms.Core.Mapping;
@@ -16,9 +17,12 @@ public class ChatMapDefinitionTests
 
     public ChatMapDefinitionTests()
     {
-        var definition = new ChatMapDefinition();
         _mapper = new UmbracoMapper(
-            new MapDefinitionCollection(() => new IMapDefinition[] { definition }),
+            new MapDefinitionCollection(() => new IMapDefinition[]
+            {
+                new ChatMapDefinition(),
+                new UsageDetailsMapDefinition()
+            }),
             Mock.Of<ICoreScopeProvider>(),
             NullLogger<UmbracoMapper>.Instance);
     }
@@ -185,4 +189,29 @@ public class ChatMapDefinitionTests
     }
 
 #pragma warning restore CS0618
+
+    // Regression test for issue #155: chat completion failed with
+    // "Don't know how to map UsageDetails to UsageModel" because the
+    // UsageDetailsMapDefinition was not registered alongside ChatMapDefinition.
+    [Fact]
+    public void Map_ChatResponseWithUsage_PopulatesUsageModel()
+    {
+        var response = new ChatResponse(new ChatMessage(ChatRole.Assistant, "hi"))
+        {
+            Usage = new UsageDetails
+            {
+                InputTokenCount = 12,
+                OutputTokenCount = 7,
+                TotalTokenCount = 19
+            }
+        };
+
+        var result = _mapper.Map<ChatResponseModel>(response);
+
+        result.ShouldNotBeNull();
+        result!.Usage.ShouldNotBeNull();
+        result.Usage!.InputTokens.ShouldBe(12);
+        result.Usage.OutputTokens.ShouldBe(7);
+        result.Usage.TotalTokens.ShouldBe(19);
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes #155: chat completion endpoint returned HTTP 400 *"Don't know how to map Microsoft.Extensions.AI.UsageDetails to Umbraco.AI.Web.Api.Common.Models.UsageModel"*
- Root cause: two `IMapDefinition` classes were both named `CommonMapDefinition` in adjacent namespaces. A missing `using` in `UmbracoBuilderExtensions.cs` caused `.Add<CommonMapDefinition>()` to silently bind to `Umbraco.AI.Web.Api.Management.Common.Mapping.CommonMapDefinition` (no `UsageDetails` mapping) instead of `Umbraco.AI.Web.Api.Common.Mapping.CommonMapDefinition` (which has it), so the `UsageDetails → UsageModel` mapper was never registered.
- Renamed the Common-namespace one to `UsageDetailsMapDefinition` to remove the name collision, and registered it explicitly. Avoided `UsageMapDefinition` as a name because there's already one in `Api.Management.Analytics.Usage.Mapping` — which would have re-created the trap.
- Added a regression test in `ChatMapDefinitionTests` that maps `ChatResponse` with `Usage` populated. Without the fix, the test fails with the exact error from the issue.

## Test plan

- [x] `dotnet build Umbraco.AI/Umbraco.AI.slnx` — clean (warnings unchanged)
- [x] `dotnet test Umbraco.AI/Umbraco.AI.slnx` — 755 passing (was 754; +1 regression test)
- [ ] Manual verification: call `POST /umbraco/ai/management/api/v1/chat/complete` and confirm 200 response with populated `usage` object

🤖 Generated with [Claude Code](https://claude.com/claude-code)