### PR TITLE
feat: AI save and save_and_publish tools

### DIFF
--- a/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/copilot/tools/entity/manifests.ts
+++ b/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/copilot/tools/entity/manifests.ts
@@ -240,6 +240,69 @@ const clearValueTool: ManifestUaiAgentFrontendTool = {
     },
 };
 
+// ─── save ──────────────────────────────────────────────────────────────────────
+
+const saveRenderer: ManifestUaiAgentToolRenderer = {
+    type: "uaiAgentToolRenderer",
+    kind: "default",
+    alias: "Uai.AgentToolRenderer.Save",
+    name: "Save Tool Renderer",
+    meta: { toolName: "save", label: "Save", icon: "icon-save", approval: true },
+};
+
+const saveTool: ManifestUaiAgentFrontendTool = {
+    type: "uaiAgentFrontendTool",
+    alias: "Uai.AgentFrontendTool.Save",
+    name: "Save Frontend Tool",
+    api: () => import("./save.api.ts"),
+    meta: {
+        toolName: "save",
+        description:
+            "Persist the selected entity's staged changes (the workspace's Save action). " +
+            "Use this after add_item / set_value / etc. to commit changes the user has approved. " +
+            "Documents stay as drafts; media is saved (media is always live). " +
+            "Block workspaces cannot be saved directly — their changes save with the parent document. " +
+            "If you need the changes to go live on the public site, use save_and_publish instead.",
+        parameters: {
+            type: "object",
+            properties: {},
+        },
+        scope: "entity-save",
+        isDestructive: true,
+    },
+};
+
+// ─── save_and_publish ──────────────────────────────────────────────────────────
+
+const saveAndPublishRenderer: ManifestUaiAgentToolRenderer = {
+    type: "uaiAgentToolRenderer",
+    kind: "default",
+    alias: "Uai.AgentToolRenderer.SaveAndPublish",
+    name: "Save and Publish Tool Renderer",
+    meta: { toolName: "save_and_publish", label: "Save and Publish", icon: "icon-globe", approval: true },
+};
+
+const saveAndPublishTool: ManifestUaiAgentFrontendTool = {
+    type: "uaiAgentFrontendTool",
+    alias: "Uai.AgentFrontendTool.SaveAndPublish",
+    name: "Save and Publish Frontend Tool",
+    api: () => import("./save-and-publish.api.ts"),
+    meta: {
+        toolName: "save_and_publish",
+        description:
+            "Persist the selected document's staged changes AND publish them to the public site. " +
+            "Only documents support publish; media is always live (use save) and block workspaces save " +
+            "with their parent document. On multi-variant documents the workspace may surface a " +
+            "variant-picker modal — this is the same flow a human gets and cannot be bypassed.",
+        parameters: {
+            type: "object",
+            properties: {},
+        },
+        scope: "entity-publish",
+        isDestructive: true,
+    },
+};
+
 export const manifests = [
     setValueRenderer,
     setValueTool,
@@ -251,4 +314,8 @@ export const manifests = [
     moveItemTool,
     clearValueRenderer,
     clearValueTool,
+    saveRenderer,
+    saveTool,
+    saveAndPublishRenderer,
+    saveAndPublishTool,
 ];

--- a/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/copilot/tools/entity/manifests.ts
+++ b/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/copilot/tools/entity/manifests.ts
@@ -247,7 +247,7 @@ const saveRenderer: ManifestUaiAgentToolRenderer = {
     kind: "default",
     alias: "Uai.AgentToolRenderer.Save",
     name: "Save Tool Renderer",
-    meta: { toolName: "save", label: "Save", icon: "icon-save", approval: true },
+    meta: { toolName: "save", label: "Save", icon: "icon-save" },
 };
 
 const saveTool: ManifestUaiAgentFrontendTool = {
@@ -269,6 +269,7 @@ const saveTool: ManifestUaiAgentFrontendTool = {
         },
         scope: "entity-save",
         isDestructive: true,
+        approval: true,
     },
 };
 
@@ -279,7 +280,7 @@ const saveAndPublishRenderer: ManifestUaiAgentToolRenderer = {
     kind: "default",
     alias: "Uai.AgentToolRenderer.SaveAndPublish",
     name: "Save and Publish Tool Renderer",
-    meta: { toolName: "save_and_publish", label: "Save and Publish", icon: "icon-globe", approval: true },
+    meta: { toolName: "save_and_publish", label: "Save and Publish", icon: "icon-globe" },
 };
 
 const saveAndPublishTool: ManifestUaiAgentFrontendTool = {
@@ -300,6 +301,7 @@ const saveAndPublishTool: ManifestUaiAgentFrontendTool = {
         },
         scope: "entity-publish",
         isDestructive: true,
+        approval: true,
     },
 };
 

--- a/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/copilot/tools/entity/save-and-publish.api.ts
+++ b/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/copilot/tools/entity/save-and-publish.api.ts
@@ -1,0 +1,46 @@
+import { UmbControllerBase } from "@umbraco-cms/backoffice/class-api";
+import type { UaiAgentToolApi } from "@umbraco-ai/agent-ui";
+import { UAI_ENTITY_ADAPTER_CONTEXT } from "../../contexts/entity-adapter.context-token.js";
+
+/**
+ * Frontend tool: save_and_publish.
+ *
+ * Persists staged changes and publishes the document to the public site (the equivalent of the
+ * user clicking Save and publish). Only documents have a publish concept — media/blocks/etc.
+ * return a structured error directing the LLM to use save instead.
+ *
+ * Multi-variant documents may surface a CMS variant picker modal as part of saveAndPublish; this
+ * is the same UX a human gets and is intentional — the LLM cannot bypass the workspace's
+ * publication confirmation flow.
+ */
+export default class SaveAndPublishApi extends UmbControllerBase implements UaiAgentToolApi {
+    async execute(_args: Record<string, unknown>): Promise<string> {
+        const adapterContext = await this.getContext(UAI_ENTITY_ADAPTER_CONTEXT);
+        if (!adapterContext) {
+            return JSON.stringify({
+                success: false,
+                error: {
+                    code: "no-adapter-context",
+                    message: "Entity adapter context not available. This tool requires an active entity editor.",
+                },
+            });
+        }
+
+        const result = await adapterContext.publishSelectedEntity();
+
+        if (!result.success) {
+            return JSON.stringify({
+                success: false,
+                error: {
+                    code: "publish-failed",
+                    message: result.error ?? "Publish failed.",
+                },
+            });
+        }
+
+        return JSON.stringify({
+            success: true,
+            message: "Document saved and published.",
+        });
+    }
+}

--- a/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/copilot/tools/entity/save.api.ts
+++ b/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/copilot/tools/entity/save.api.ts
@@ -1,0 +1,43 @@
+import { UmbControllerBase } from "@umbraco-cms/backoffice/class-api";
+import type { UaiAgentToolApi } from "@umbraco-ai/agent-ui";
+import { UAI_ENTITY_ADAPTER_CONTEXT } from "../../contexts/entity-adapter.context-token.js";
+
+/**
+ * Frontend tool: save.
+ *
+ * Persists the staged changes on the currently selected entity (the equivalent of the user
+ * clicking the workspace's Save button). Returns a structured error for entity types without a
+ * direct save action — most commonly when a block workspace is selected, since block changes
+ * persist through their parent document.
+ */
+export default class SaveApi extends UmbControllerBase implements UaiAgentToolApi {
+    async execute(_args: Record<string, unknown>): Promise<string> {
+        const adapterContext = await this.getContext(UAI_ENTITY_ADAPTER_CONTEXT);
+        if (!adapterContext) {
+            return JSON.stringify({
+                success: false,
+                error: {
+                    code: "no-adapter-context",
+                    message: "Entity adapter context not available. This tool requires an active entity editor.",
+                },
+            });
+        }
+
+        const result = await adapterContext.saveSelectedEntity();
+
+        if (!result.success) {
+            return JSON.stringify({
+                success: false,
+                error: {
+                    code: "save-failed",
+                    message: result.error ?? "Save failed.",
+                },
+            });
+        }
+
+        return JSON.stringify({
+            success: true,
+            message: "Staged changes saved.",
+        });
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Scopes/BuiltInScopes.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Scopes/BuiltInScopes.cs
@@ -119,3 +119,33 @@ public sealed class EntityWriteScope : AIToolScopeBase
     /// </summary>
     public const string ScopeId = "entity-write";
 }
+
+/// <summary>
+/// The entity save scope. Tools that persist staged workspace changes to the database (without
+/// publishing) should use this scope. Separated from <see cref="EntityWriteScope"/> so an agent
+/// can be granted permission to mutate values without also gaining permission to commit them.
+/// </summary>
+[AIToolScope(ScopeId, Icon = "icon-save", IsDestructive = true, Domain = "Entity")]
+public sealed class EntitySaveScope : AIToolScopeBase
+{
+    /// <summary>
+    /// The unique identifier for the entity save scope. Tools that persist staged workspace
+    /// changes (saving without publishing) should use this scope.
+    /// </summary>
+    public const string ScopeId = "entity-save";
+}
+
+/// <summary>
+/// The entity publish scope. Tools that persist staged workspace changes AND publish them to
+/// the public site should use this scope. Separated from <see cref="EntitySaveScope"/> so an
+/// agent can be allowed to save drafts without also being allowed to push live.
+/// </summary>
+[AIToolScope(ScopeId, Icon = "icon-globe", IsDestructive = true, Domain = "Entity")]
+public sealed class EntityPublishScope : AIToolScopeBase
+{
+    /// <summary>
+    /// The unique identifier for the entity publish scope. Tools that publish content to the
+    /// public site should use this scope.
+    /// </summary>
+    public const string ScopeId = "entity-publish";
+}

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/adapters/document.adapter.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/adapters/document.adapter.ts
@@ -7,9 +7,11 @@
 
 import { map, type Observable } from "@umbraco-cms/backoffice/external/rxjs";
 import { UmbVariantId } from "@umbraco-cms/backoffice/variant";
+import { UMB_DOCUMENT_PUBLISHING_WORKSPACE_CONTEXT } from "@umbraco-cms/backoffice/document";
 import type {
     UaiEntityAdapterApi,
     UaiEntityContext,
+    UaiPersistResult,
     UaiValueChange,
     UaiValueChangeResult,
     UaiSerializedEntity,
@@ -67,6 +69,11 @@ interface DocumentWorkspaceContextLike {
     };
     // Property mutation - sets value in workspace (staged, not persisted)
     setPropertyValue?<T>(alias: string, value: T, variantId?: UmbVariantId): Promise<void>;
+    // Persists staged changes (clicking the workspace Save button). Throws on validation failure.
+    requestSubmit?(): Promise<void>;
+    // The workspace context is itself a UmbControllerBase so it can resolve sibling contexts
+    // registered against the same host element — used to fetch the publishing context.
+    getContext?<T>(token: unknown): Promise<T | undefined>;
     // Check if entity is new (being created)
     getIsNew?(): boolean | undefined;
     // Internal method for parent access when creating new entities
@@ -353,6 +360,66 @@ export class UaiDocumentAdapter implements UaiEntityAdapterApi {
             return {
                 success: false,
                 error: error instanceof Error ? error.message : "Unknown error applying value change",
+            };
+        }
+    }
+
+    /**
+     * Persist staged changes to the document (equivalent to clicking Save).
+     * Delegates to the workspace's `requestSubmit()`; any validation failure thrown by the
+     * workspace is converted into a structured error so the LLM can read it.
+     */
+    async save(workspaceContext: unknown): Promise<UaiPersistResult> {
+        const ctx = workspaceContext as DocumentWorkspaceContextLike;
+
+        if (typeof ctx.requestSubmit !== "function") {
+            return { success: false, error: "Workspace does not support save (no requestSubmit on context)." };
+        }
+
+        try {
+            await ctx.requestSubmit();
+            return { success: true };
+        } catch (error) {
+            return {
+                success: false,
+                error: error instanceof Error ? error.message : "Save failed (workspace rejected the request).",
+            };
+        }
+    }
+
+    /**
+     * Save the document and publish it. Resolves the document publishing workspace context as a
+     * sibling of the workspace context (both register against the same host) and delegates to
+     * `saveAndPublish()`. On multi-variant documents this can surface the CMS's variant-picker
+     * modal — same UX as clicking the Save and publish button.
+     */
+    async publish(workspaceContext: unknown): Promise<UaiPersistResult> {
+        const ctx = workspaceContext as DocumentWorkspaceContextLike;
+
+        if (typeof ctx.getContext !== "function") {
+            return {
+                success: false,
+                error: "Workspace context does not expose getContext; cannot reach the publishing context.",
+            };
+        }
+
+        type PublishingCtxLike = { saveAndPublish?: () => Promise<void> };
+        const publishing = await ctx.getContext<PublishingCtxLike>(UMB_DOCUMENT_PUBLISHING_WORKSPACE_CONTEXT);
+
+        if (!publishing || typeof publishing.saveAndPublish !== "function") {
+            return {
+                success: false,
+                error: "Document publishing context is not available on this workspace.",
+            };
+        }
+
+        try {
+            await publishing.saveAndPublish();
+            return { success: true };
+        } catch (error) {
+            return {
+                success: false,
+                error: error instanceof Error ? error.message : "Publish failed (publishing context rejected the request).",
             };
         }
     }

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/adapters/media.adapter.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/adapters/media.adapter.ts
@@ -16,6 +16,7 @@ import { UmbVariantId } from "@umbraco-cms/backoffice/variant";
 import type {
     UaiEntityAdapterApi,
     UaiEntityContext,
+    UaiPersistResult,
     UaiValueChange,
     UaiValueChangeResult,
     UaiSerializedEntity,
@@ -86,6 +87,8 @@ interface MediaWorkspaceContextLike {
     // Media is always invariant but the method still accepts a variantId for
     // consistency with the shared UmbContentDetailWorkspaceContextBase.
     setPropertyValue?<T>(alias: string, value: T, variantId?: UmbVariantId): Promise<void>;
+    // Persists staged changes (clicking the workspace Save button).
+    requestSubmit?(): Promise<void>;
     // Check if entity is new (being created)
     getIsNew?(): boolean | undefined;
     // Internal method for parent access when creating new entities.
@@ -309,6 +312,29 @@ export class UaiMediaAdapter implements UaiEntityAdapterApi {
             return {
                 success: false,
                 error: error instanceof Error ? error.message : "Unknown error applying value change",
+            };
+        }
+    }
+
+    /**
+     * Persist staged changes to the media item (equivalent to clicking Save). Media has no
+     * publish concept — always-live — so only `save` is implemented; the absence of `publish`
+     * on this adapter lets the caller return a clear "not supported" error.
+     */
+    async save(workspaceContext: unknown): Promise<UaiPersistResult> {
+        const ctx = workspaceContext as MediaWorkspaceContextLike;
+
+        if (typeof ctx.requestSubmit !== "function") {
+            return { success: false, error: "Workspace does not support save (no requestSubmit on context)." };
+        }
+
+        try {
+            await ctx.requestSubmit();
+            return { success: true };
+        } catch (error) {
+            return {
+                success: false,
+                error: error instanceof Error ? error.message : "Save failed (workspace rejected the request).",
             };
         }
     }

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/entity-adapter.context.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/entity-adapter.context.ts
@@ -22,6 +22,7 @@ import { UAI_ENTITY_ADAPTER_EXTENSION_TYPE, type ManifestEntityAdapter } from ".
 import type {
     UaiDetectedEntity,
     UaiEntityAdapterApi,
+    UaiPersistResult,
     UaiValueChange,
     UaiValueChangeResult,
     UaiSerializedEntity,
@@ -169,6 +170,53 @@ export class UaiEntityAdapterContext extends UmbControllerBase {
         }
 
         return selected.adapter.applyValueChange(selected.workspaceContext, change);
+    }
+
+    /**
+     * Persist the currently selected entity's staged changes (equivalent of the user clicking
+     * Save). Returns a structured "not supported" error when the entity type doesn't own a save
+     * action — most commonly when the user has a block workspace selected, since block changes
+     * save with the parent document.
+     */
+    async saveSelectedEntity(): Promise<UaiPersistResult> {
+        await this.#initialized;
+
+        const selected = this.getSelectedEntity();
+        if (!selected) {
+            return { success: false, error: "No entity is currently selected." };
+        }
+
+        if (!selected.adapter.save) {
+            return {
+                success: false,
+                error: `Entity type "${selected.entityContext.entityType}" cannot be saved directly. If this is a block, switch to the parent document and save from there.`,
+            };
+        }
+
+        return selected.adapter.save(selected.workspaceContext);
+    }
+
+    /**
+     * Persist and publish the currently selected entity. Returns a structured "not supported"
+     * error for entity types without a publish concept (media, blocks) — publishing only applies
+     * to documents.
+     */
+    async publishSelectedEntity(): Promise<UaiPersistResult> {
+        await this.#initialized;
+
+        const selected = this.getSelectedEntity();
+        if (!selected) {
+            return { success: false, error: "No entity is currently selected." };
+        }
+
+        if (!selected.adapter.publish) {
+            return {
+                success: false,
+                error: `Entity type "${selected.entityContext.entityType}" does not support publish. Try save instead.`,
+            };
+        }
+
+        return selected.adapter.publish(selected.workspaceContext);
     }
 
     // ─────────────────────────────────────────────────────────────────────────────

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/index.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/index.ts
@@ -46,6 +46,7 @@ export type {
     UaiDetectedEntity,
     UaiEntityAdapterApi,
     UaiEntityContext,
+    UaiPersistResult,
     UaiValueChange,
     UaiValueChangeResult,
     UaiSerializedEntity,

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/types.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/types.ts
@@ -103,6 +103,18 @@ export interface UaiValueChangeResult {
 }
 
 /**
+ * Result of a save (or save-and-publish) operation triggered by an AI tool. Adapters convert
+ * exceptions thrown by the underlying workspace into a structured payload so the LLM can read the
+ * error message rather than treat the call as silently successful.
+ */
+export interface UaiPersistResult {
+    /** Whether persistence completed successfully. */
+    success: boolean;
+    /** Human-readable error message if persistence failed. */
+    error?: string;
+}
+
+/**
  * Entity adapter API interface.
  * Adapters are responsible for:
  * - Detecting if they can handle a workspace context
@@ -164,6 +176,21 @@ export interface UaiEntityAdapterApi extends UmbApi {
      * @returns Result indicating success or failure with error message
      */
     applyValueChange?(workspaceContext: unknown, change: UaiValueChange): Promise<UaiValueChangeResult>;
+
+    /**
+     * Persist the workspace's staged changes (the equivalent of clicking the workspace's Save
+     * button). Optional — entity types that don't own their own save (e.g. blocks, whose changes
+     * save with the parent document) should omit this so the caller can return a clear "not
+     * supported" error.
+     */
+    save?(workspaceContext: unknown): Promise<UaiPersistResult>;
+
+    /**
+     * Persist the workspace's staged changes and publish them. Optional — only entity types with
+     * a publish concept (documents) implement this; media and other always-live entities should
+     * omit it.
+     */
+    publish?(workspaceContext: unknown): Promise<UaiPersistResult>;
 }
 
 /**

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/lang/en.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/lang/en.ts
@@ -106,6 +106,16 @@ export default {
         selectAll: "Select All",
         selectAllDescription: "Select or deselect all tool permissions at once",
     },
+    // Per-scope labels and descriptions for the scope picker.
+    // Keys must be `{camelCase(scope.id)}Label` / `{camelCase(scope.id)}Description`; the picker
+    // resolves them via `localize.term("uaiToolScope_${camelCase(id)}Label")`. Falls back to the
+    // raw scope id when no key is registered.
+    uaiToolScope: {
+        entitySaveLabel: "Save Entity",
+        entitySaveDescription: "Persist staged workspace changes (save without publishing)",
+        entityPublishLabel: "Publish Entity",
+        entityPublishDescription: "Save and publish content to the public site",
+    },
     uaiAuditLog: {
         bulkDeleteConfirm: (count: number) => `Are you sure you want to delete ${count} log entry(ies)?`,
     },


### PR DESCRIPTION
## Summary

Stacked on [#160](https://github.com/umbraco/Umbraco.AI/pull/160) (which itself stacks on [#153](https://github.com/umbraco/Umbraco.AI/pull/153)). Adds two new LLM-visible tools for persisting AI-driven workspace changes:

- **`save`** — calls the workspace's `requestSubmit()`; equivalent to clicking Save. Works on documents and media.
- **`save_and_publish`** — calls the document publishing context's `saveAndPublish()`. Documents only.

The property-value-handler tools introduced in #160 stage changes on the workspace; until now the only way to persist them was a human clicking Save. These tools close that gap so the LLM can complete the staging → persistence flow on the user's behalf.

## Design

Both tools route through the entity adapter contract, mirroring the existing `applyValueChange` shape:

- `UaiEntityAdapterApi` gains optional `save?(ctx)` and `publish?(ctx)` methods returning a new `UaiPersistResult { success, error? }`.
- `UaiEntityAdapterContext` gains `saveSelectedEntity()` / `publishSelectedEntity()` that delegate to the adapter and produce structured "not supported" errors when an adapter omits a method.

Per-adapter behavior:

| Adapter | save | publish |
|---|---|---|
| Document | `requestSubmit()` | resolves `UMB_DOCUMENT_PUBLISHING_WORKSPACE_CONTEXT` as a sibling and calls `saveAndPublish()` |
| Media | `requestSubmit()` (always live, so save IS publish) | omitted — LLM gets "use save instead" |
| Block | omitted | omitted — LLM gets "save the parent document" |

Two new tool scopes back the tools: `entity-save` and `entity-publish`. Both destructive. Split from the existing `entity-write` so an agent can be granted permission to mutate staged values without also being allowed to commit them, or to save drafts without publishing live.

## Permissions migration

Agents currently using `AllowedToolScopeIds: ["entity-write"]` will **not** automatically pick these tools up. To enable them, grant the new scopes:

- `entity-save` for save
- `entity-publish` for publish (implies save semantics — publishing always saves first)

Agents using explicit `AllowedToolIds` need:
- `Uai.AgentFrontendTool.Save`
- `Uai.AgentFrontendTool.SaveAndPublish`

## Test plan

- [ ] Existing entity-write tools (set_value, add_item, etc.) continue to work
- [ ] `save` from a document workspace persists staged AI-driven changes
- [ ] `save` from a media workspace persists staged changes
- [ ] `save` from a block workspace returns the structured "save the parent document" error
- [ ] `save_and_publish` from a document workspace publishes the document
- [ ] `save_and_publish` from a media workspace returns "use save instead"
- [ ] `save_and_publish` on a multi-variant document surfaces the variant-picker modal (intentional — same UX as clicking the button)
- [ ] An agent without `entity-save` scope cannot invoke `save`
- [ ] An agent without `entity-publish` scope cannot invoke `save_and_publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)