### PR TITLE
fix(automate, agent): Persist RunId/ThreadId in Automate audit logs

### DIFF
--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Agents/AIAgentExecutionOptions.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Agents/AIAgentExecutionOptions.cs
@@ -43,4 +43,20 @@ public class AIAgentExecutionOptions
     /// When set, the agent's response will be constrained to this schema.
     /// </summary>
     public AIOutputSchema? OutputSchema { get; init; }
+
+    /// <summary>
+    /// Optional additional properties to inject into the agent's runtime context for the duration
+    /// of this execution. Keys placed here flow into <see cref="Umbraco.AI.Core.RuntimeContext.AIRuntimeContext"/>
+    /// via <see cref="Chat.ScopedAIAgent"/> and are visible to chat middleware (including the audit-log
+    /// middleware) at LLM-invocation time.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// To have a key persisted onto the resulting <c>AIAuditLog.Metadata</c> column, also include
+    /// <see cref="Umbraco.AI.Core.Constants.ContextKeys.LogKeys"/> in this dictionary with a
+    /// <c>string[]</c> value listing the keys to persist. This mirrors the contract used by the
+    /// AG-UI streaming path on <see cref="IAIAgentService"/>.
+    /// </para>
+    /// </remarks>
+    public IReadOnlyDictionary<string, object?>? AdditionalProperties { get; init; }
 }

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Agents/AIAgentService.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Agents/AIAgentService.cs
@@ -732,22 +732,38 @@ internal sealed class AIAgentService : IAIAgentService
     }
 
     /// <summary>
-    /// Builds additional properties dict with OutputSchema override if present in execution options.
+    /// Builds the additional-properties dictionary forwarded to <see cref="PrepareAgentExecutionAsync"/>
+    /// from execution options: <see cref="AIAgentExecutionOptions.OutputSchema"/> becomes a
+    /// <see cref="CoreConstants.ContextKeys.ChatOptionsOverride"/> entry, and any caller-supplied
+    /// <see cref="AIAgentExecutionOptions.AdditionalProperties"/> entries are copied through.
+    /// Returns null when both inputs are null so the existing "no extra props" path is preserved.
     /// </summary>
-    private static Dictionary<string, object?>? BuildOutputSchemaOverride(AIAgentExecutionOptions options)
+    private static Dictionary<string, object?>? BuildAdditionalPropertiesFromOptions(AIAgentExecutionOptions options)
     {
-        if (options.OutputSchema is null)
+        if (options.OutputSchema is null && options.AdditionalProperties is null)
         {
             return null;
         }
 
-        return new Dictionary<string, object?>
+        var properties = new Dictionary<string, object?>();
+
+        if (options.OutputSchema is not null)
         {
-            [CoreConstants.ContextKeys.ChatOptionsOverride] = new ChatOptions
+            properties[CoreConstants.ContextKeys.ChatOptionsOverride] = new ChatOptions
             {
-                ResponseFormat = options.OutputSchema.ResponseFormat
+                ResponseFormat = options.OutputSchema.ResponseFormat,
+            };
+        }
+
+        if (options.AdditionalProperties is not null)
+        {
+            foreach (var kvp in options.AdditionalProperties)
+            {
+                properties[kvp.Key] = kvp.Value;
             }
-        };
+        }
+
+        return properties;
     }
 
     /// <summary>
@@ -765,7 +781,7 @@ internal sealed class AIAgentService : IAIAgentService
         var context = await PrepareAgentExecutionAsync(
             agent, chatMessages, options, frontendTools: null,
             contextItems: options.ContextItems,
-            additionalProperties: BuildOutputSchemaOverride(options),
+            additionalProperties: BuildAdditionalPropertiesFromOptions(options),
             cancellationToken);
 
         if (context is null)
@@ -809,7 +825,7 @@ internal sealed class AIAgentService : IAIAgentService
         var context = await PrepareAgentExecutionAsync(
             agent, chatMessages, options, frontendTools: null,
             contextItems: options.ContextItems,
-            additionalProperties: null,
+            additionalProperties: BuildAdditionalPropertiesFromOptions(options),
             cancellationToken);
 
         if (context is null)

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/Agents/AIAgentExecutionOptionsTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/Agents/AIAgentExecutionOptionsTests.cs
@@ -1,0 +1,31 @@
+using Shouldly;
+using Umbraco.AI.Agent.Core.Agents;
+using Xunit;
+
+namespace Umbraco.AI.Agent.Tests.Unit.Agents;
+
+public class AIAgentExecutionOptionsTests
+{
+    [Fact]
+    public void AdditionalProperties_DefaultsToNull()
+    {
+        var options = new AIAgentExecutionOptions();
+        options.AdditionalProperties.ShouldBeNull();
+    }
+
+    [Fact]
+    public void AdditionalProperties_PreservesAssignedValues()
+    {
+        var props = new Dictionary<string, object?>
+        {
+            ["key-a"] = "value-a",
+            ["key-b"] = 42,
+        };
+
+        var options = new AIAgentExecutionOptions { AdditionalProperties = props };
+
+        options.AdditionalProperties.ShouldNotBeNull();
+        options.AdditionalProperties!["key-a"].ShouldBe("value-a");
+        options.AdditionalProperties["key-b"].ShouldBe(42);
+    }
+}

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/Agents/AIAgentServiceExecutionTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/Agents/AIAgentServiceExecutionTests.cs
@@ -1,0 +1,119 @@
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Moq;
+using Shouldly;
+using Umbraco.AI.Agent.Core.Agents;
+using Umbraco.AI.Agent.Core.Chat;
+using Umbraco.AI.Core.RuntimeContext;
+using Umbraco.AI.Core.Tools;
+using Umbraco.Cms.Core.Events;
+using Xunit;
+using AIAgent = Umbraco.AI.Agent.Core.Agents.AIAgent;
+using MsAIAgent = Microsoft.Agents.AI.AIAgent;
+
+namespace Umbraco.AI.Agent.Tests.Unit.Agents;
+
+public class AIAgentServiceExecutionTests
+{
+    private static readonly Guid TestAgentId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    [Fact]
+    public async Task RunAgentAsync_ForwardsAdditionalPropertiesToAgentFactory()
+    {
+        // Arrange
+        var agent = CreateAgent(TestAgentId);
+        var repositoryMock = new Mock<IAIAgentRepository>();
+        repositoryMock
+            .Setup(x => x.GetByIdAsync(TestAgentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        IReadOnlyDictionary<string, object?>? capturedAdditionalProperties = null;
+        var agentFactoryMock = new Mock<IAIAgentFactory>();
+        agentFactoryMock
+            .Setup(x => x.CreateAgentAsync(
+                agent,
+                It.IsAny<IEnumerable<AIRequestContextItem>?>(),
+                It.IsAny<IEnumerable<AITool>?>(),
+                It.IsAny<IReadOnlyDictionary<string, object?>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<AIAgent, IEnumerable<AIRequestContextItem>?, IEnumerable<AITool>?, IReadOnlyDictionary<string, object?>?, CancellationToken>(
+                (_, _, _, properties, _) => capturedAdditionalProperties = properties)
+            .ReturnsAsync(CreateRespondingAgent());
+
+        var eventAggregatorMock = new Mock<IEventAggregator>();
+        eventAggregatorMock
+            .Setup(x => x.PublishAsync(It.IsAny<AIAgentExecutingNotification>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        eventAggregatorMock
+            .Setup(x => x.PublishAsync(It.IsAny<AIAgentExecutedNotification>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var service = CreateService(repositoryMock.Object, agentFactoryMock.Object, eventAggregatorMock.Object);
+        var additionalProperties = new Dictionary<string, object?>
+        {
+            ["key-a"] = "value-a",
+            ["key-b"] = 42,
+        };
+
+        // Act
+        await service.RunAgentAsync(
+            TestAgentId,
+            [new ChatMessage(ChatRole.User, "Hello")],
+            new AIAgentExecutionOptions { AdditionalProperties = additionalProperties },
+            CancellationToken.None);
+
+        // Assert
+        capturedAdditionalProperties.ShouldNotBeNull();
+        capturedAdditionalProperties!["key-a"].ShouldBe("value-a");
+        capturedAdditionalProperties["key-b"].ShouldBe(42);
+    }
+
+    private static AIAgentService CreateService(
+        IAIAgentRepository repository,
+        IAIAgentFactory agentFactory,
+        IEventAggregator eventAggregator)
+        => new(
+            repository,
+            null!, // IAIEntityVersionService
+            agentFactory,
+            null!, // IAGUIStreamingService
+            null!, // IAGUIContextConverter
+            null!, // IAGUIMessageConverter
+            new AIToolCollection(() => []),
+            null!, // IAIProfileService
+            null!, // IAIGuardrailService
+            null!, // IAIContextService
+            null!, // IAIChatClientFactory
+            null!, // AIAgentScopeValidator
+            null!, // AIAgentSurfaceCollection
+            eventAggregator,
+            null); // IBackOfficeSecurityAccessor
+
+    private static AIAgent CreateAgent(Guid id)
+        => new()
+        {
+            Id = id,
+            Alias = "test-agent",
+            Name = "Test Agent",
+            AgentType = AIAgentType.Standard,
+            Config = new AIStandardAgentConfig
+            {
+                AllowedToolIds = [],
+                AllowedToolScopeIds = [],
+            },
+            IsActive = true,
+        };
+
+    private static MsAIAgent CreateRespondingAgent()
+    {
+        var chatClientMock = new Mock<IChatClient>();
+        chatClientMock
+            .Setup(x => x.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, "ok")));
+
+        return new ChatClientAgent(chatClientMock.Object);
+    }
+}

--- a/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Actions/RunAgentAction.cs
+++ b/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Actions/RunAgentAction.cs
@@ -3,12 +3,14 @@ using Json.Schema;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
+using Umbraco.AI.Agent.Core;
 using Umbraco.AI.Agent.Core.Agents;
 using Umbraco.AI.Automate.Helpers;
 using Umbraco.AI.Automate.Triggers;
 using Umbraco.Automate.Core.Actions;
 using Umbraco.Cms.Core.Services;
 using AIAgent = Umbraco.AI.Agent.Core.Agents.AIAgent;
+using CoreConstants = Umbraco.AI.Core.Constants;
 
 namespace Umbraco.AI.Automate.Actions;
 
@@ -122,9 +124,20 @@ public sealed class RunAgentAction : ActionBase<RunAgentSettings, object>
                 new(ChatRole.User, settings.Message),
             };
 
+            // Populate metadata context keys so AIAuditingChatClient can persist RunId/ThreadId
+            // onto the resulting AIAuditLog.Metadata column. Mirrors the AG-UI streaming path.
+            // TryAdd preserves caller-supplied values if this surface ever accepts pre-populated entries.
+            var additionalProperties = new Dictionary<string, object?>();
+            additionalProperties.TryAdd(Constants.ContextKeys.RunId, Guid.NewGuid().ToString());
+            additionalProperties.TryAdd(Constants.ContextKeys.ThreadId, context.RunId.ToString());
+            additionalProperties.TryAdd(
+                CoreConstants.ContextKeys.LogKeys,
+                new[] { Constants.ContextKeys.RunId, Constants.ContextKeys.ThreadId });
+
             var options = new AIAgentExecutionOptions
             {
                 UserGroupIds = userGroupIds,
+                AdditionalProperties = additionalProperties,
             };
 
             // Mark the async flow as Automate-driven so the agent run triggers

--- a/Umbraco.AI.Automate/tests/Umbraco.AI.Automate.Tests.Unit/Actions/RunAgentActionTests.cs
+++ b/Umbraco.AI.Automate/tests/Umbraco.AI.Automate.Tests.Unit/Actions/RunAgentActionTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Shouldly;
+using Umbraco.AI.Agent.Core;
 using Umbraco.AI.Agent.Core.Agents;
 using Umbraco.AI.Automate.Actions;
 using Umbraco.Automate.Core.Actions;
@@ -10,6 +11,7 @@ using Umbraco.Automate.Core.Settings;
 using Umbraco.Cms.Core.Services;
 using Xunit;
 using AIAgent = Umbraco.AI.Agent.Core.Agents.AIAgent;
+using CoreConstants = Umbraco.AI.Core.Constants;
 
 namespace Umbraco.AI.Automate.Tests.Unit.Actions;
 
@@ -66,6 +68,64 @@ public class RunAgentActionTests
         // Assert
         result.Status.ShouldBe(ActionResultStatus.Success);
         result.OutputData.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PopulatesAuditMetadataKeysOnExecutionOptions()
+    {
+        // Arrange
+        var agent = new AIAgent
+        {
+            Alias = "test-agent",
+            Name = "Test Agent",
+        };
+
+        var responseMessage = new ChatMessage(ChatRole.Assistant, "ok");
+        var agentResponse = new AgentResponse(responseMessage);
+        var automationRunId = Guid.NewGuid();
+
+        _agentServiceMock
+            .Setup(s => s.GetAgentAsync(TestAgentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        AIAgentExecutionOptions? capturedOptions = null;
+        _agentServiceMock
+            .Setup(s => s.RunAgentAsync(
+                agent.Id,
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<AIAgentExecutionOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Guid, IEnumerable<ChatMessage>, AIAgentExecutionOptions?, CancellationToken>(
+                (_, _, opts, _) => capturedOptions = opts)
+            .ReturnsAsync(agentResponse);
+
+        var action = CreateAction();
+        var context = CreateContext(
+            new RunAgentSettings { AgentId = TestAgentId, Message = "Hi" },
+            runId: automationRunId);
+
+        // Act
+        var result = await action.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.Status.ShouldBe(ActionResultStatus.Success);
+        capturedOptions.ShouldNotBeNull();
+        capturedOptions!.AdditionalProperties.ShouldNotBeNull();
+
+        var props = capturedOptions.AdditionalProperties!;
+        props.Keys.ShouldContain(Constants.ContextKeys.RunId);
+        props.Keys.ShouldContain(Constants.ContextKeys.ThreadId);
+        props.Keys.ShouldContain(CoreConstants.ContextKeys.LogKeys);
+
+        Guid.TryParse(props[Constants.ContextKeys.RunId]?.ToString(), out _)
+            .ShouldBeTrue();
+        props[Constants.ContextKeys.ThreadId]
+            .ShouldBe(automationRunId.ToString());
+
+        var logKeys = props[CoreConstants.ContextKeys.LogKeys].ShouldBeOfType<string[]>();
+        logKeys.ShouldBe(
+            new[] { Constants.ContextKeys.RunId, Constants.ContextKeys.ThreadId },
+            ignoreOrder: true);
     }
 
     [Fact]
@@ -194,11 +254,11 @@ public class RunAgentActionTests
     private RunAgentAction CreateAction()
         => new(_infrastructure, _agentServiceMock.Object, _userServiceMock.Object, _loggerMock.Object);
 
-    private static ActionContext CreateContext(RunAgentSettings settings)
+    private static ActionContext CreateContext(RunAgentSettings settings, Guid? runId = null)
         => new()
         {
             AutomationId = Guid.NewGuid(),
-            RunId = Guid.NewGuid(),
+            RunId = runId ?? Guid.NewGuid(),
             StepId = Guid.NewGuid(),
             ActionAlias = UmbracoAIAutomateConstants.ActionTypes.RunAgent,
             Settings = settings,


### PR DESCRIPTION
Closes #168

When an Automate workflow invokes an AI agent via `RunAgentAction`, the resulting `AIAuditLog` row's `Metadata` column was `null` because the action did not surface the `RunId` / `ThreadId` context keys to the audit middleware. This PR populates `Umbraco.AI.Agent.RunId`, `Umbraco.AI.Agent.ThreadId`, and `Umbraco.AI.LogKeys` on a new additive `AIAgentExecutionOptions.AdditionalProperties` dictionary that flows through `AIAgentService.RunPersistedAgentAsync` / `StreamPersistedAgentAsync` into the agent runtime context — mirroring the AG-UI/Copilot path exactly.

## Validation

Manually verified end-to-end on a test site against the Automate path:
- 5 post-PR rows show `AIAuditLog.Metadata` populated with `Umbraco.AI.Agent.RunId` (fresh `Guid.NewGuid()` per `ExecuteAsync`) and `Umbraco.AI.Agent.ThreadId` (the Automate workflow run GUID, byte-identical to the editor-facing modal data).
- 6 pre-PR rows in the same DB show `Metadata = null` (baseline confirmed — pre-patched rows unchanged).
- 1:1 cardinality of `(RunId, ThreadId)` per row observed for the single-step single-call case.

Code-sound but not empirically exercised in this validation session — flagging in case reviewers want to spot-check:
- **Multi-tool-round case**: design says all chat calls within one `ExecuteAsync` share the same `RunId` (because `ScopedAIAgent.PopulateScopeContext` sets values once at scope creation, and the scope wraps the entire `InnerAgent.RunAsync` including all tool rounds). The test agent used was single-call (no tools).
- **Multi-step workflow**: 2+ `Run AI Agent` action steps in one workflow should produce N rows with N distinct `RunId`s and a single shared `ThreadId`. Same per-`ExecuteAsync` `Guid.NewGuid()` invariant — code-sound but not directly observed.
- **AG-UI / Copilot path** (`AIAgentService.cs` `StreamAgentAGUIAsync`): unchanged by this PR (only refactored the `RunPersistedAgentAsync` / `StreamPersistedAgentAsync` execution-options forwarding). Regression spot-check welcome but expected to be a no-op.

## Background

Direction discussed with Matt Brailsford on Slack 2026-05-12 (greenlight) and 2026-05-13 (scope expansion to `Agent.Core` once recon showed the action layer can't reach `ChatOptions` directly). `ThreadId` semantic per Matt's explicit preference: use `ActionContext.RunId` so all agent runs within one workflow run share a thread id.

## Naming

Chose `AdditionalProperties` per Matt's Slack note 2026-05-13. Recon of the existing codebase found `Metadata` is the dominant name for string-valued dictionaries (`AIAuditLog`, `AIAuditContext`, `AIModelDescriptor` — all `IReadOnlyDictionary<string, string>` or `JsonElement`), while `AdditionalProperties` is the existing precedent for object-valued bags (`AIInlineAgentBuilder.AdditionalProperties` — `IReadOnlyDictionary<string, object?>`). The new field must be object-valued to carry `LogKeys` as a `string[]` (and future typed entries like `ChatOptionsOverride`), so it matches the `AdditionalProperties` type-shape convention rather than the `Metadata` one. Also aligns with the camelCase parameter name `additionalProperties` used throughout `IAIAgentFactory.CreateAgentAsync`, `ScopedAIAgent`, and `PrepareAgentExecutionAsync`.

## Release coupling

This PR intentionally ships Agent and Automate together: Automate consumes the new `AIAgentExecutionOptions.AdditionalProperties` API, so release manifests must include both products for package-reference builds. PR CI passes (unified Build stage uses project references) and push-to-`dev` Pack stage passes (`useProjectReferences=true` on dev). On a release cut from dev, PackLevel1 publishes the updated Agent into the pipeline's `LocalCI` feed before PackLevel2 builds Automate with `useProjectReferences=false`, so the new property is visible. Standalone `dotnet build Umbraco.AI.Automate.slnx -p:UseProjectReferences=false` without that local feed wired up will fail with CS0117 until the new Agent NuGet is published — that's a debugging-time artefact, not a CI-time one.

## Test plan

- [ ] Build clean: `dotnet build Umbraco.AI.Agent.slnx` and `dotnet build Umbraco.AI.Automate.slnx` both report 0 errors.
- [ ] `dotnet test Umbraco.AI.Agent.slnx` — 142/142 pass (incl. 2 new `AIAgentExecutionOptionsTests` + 1 new `AIAgentServiceExecutionTests` proving forwarding through `IAIAgentFactory`).
- [ ] `dotnet test Umbraco.AI.Automate.slnx` — 37/37 pass (incl. new `ExecuteAsync_PopulatesAuditMetadataKeysOnExecutionOptions`).
- [ ] Spot-check: run an Automate workflow that invokes `Run AI Agent`; confirm the resulting `AIAuditLog` row's `Metadata` column contains both `Umbraco.AI.Agent.RunId` (GUID string) and `Umbraco.AI.Agent.ThreadId` (= the automation `RunId`).
- [ ] Spot-check: run a Copilot agent invocation and confirm AG-UI metadata still populates (regression check on the unchanged path).

## Incidental findings — non-blocking for this PR, flagging for future adopters / maintainers

Both surfaced during local validation and cost real time before being understood:

1. **EF Core nuspec floor mismatch (Persistence packages).** `Umbraco.AI.Persistence.*` and `Umbraco.AI.Agent.Persistence.*` compile against `Microsoft.EntityFrameworkCore 10.0.7` (via Umbraco.Cms 17.3.2's transitive runtime version), but their generated nuspecs don't declare EF Core ≥ 10.0.7 as a dependency. Downstream consumers can resolve to `10.0.4` (Umbraco.Cms 17.3.2's lower bound) and hit `FileNotFoundException: Microsoft.EntityFrameworkCore, Version=10.0.7.0` at runtime. Fix options: bump `Umbraco.Cms.Persistence.EFCore`'s floor to 10.0.7 in `Directory.Packages.props`, or add explicit `<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />` to each Persistence csproj so the version surfaces in the nuspec.

2. **Local pack flow needs frontend build first.** Running `dotnet pack` against a per-product slnx without first running `npm install && npm run build:core && npm run build:agent` produces `StaticAssets` nupkgs missing the Bellissima frontend bundle (`staticwebassets/` empty — just `lib/net10.0/*.dll`). The backoffice composers register but no UI renders. CI handles this via `.github/actions/build-product/action.yml`'s `has-frontend` gating; local contributors trip on it. Worth a `CONTRIBUTING.md` note or a repo-root `build.sh` wrapper that does both steps before `dotnet pack`.

---

Happy to bump `Umbraco.AI.Agent/version.json` (additive surface → minor) in this PR if you'd prefer it landed alongside; otherwise leaving to release tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)