### PR TITLE
chore(deps): Bump Umbraco.Automate.Core floor to preview.420.ge63c76a

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
 
   <!-- Umbraco Automate -->
   <ItemGroup>
-    <PackageVersion Include="Umbraco.Automate.Core" Version="[0.1.0--preview.369.g5cabf66, 0.999.999)" />
+    <PackageVersion Include="Umbraco.Automate.Core" Version="[0.1.0--preview.420.ge63c76a, 0.999.999)" />
   </ItemGroup>
 
   <!-- Umbraco Search -->


### PR DESCRIPTION
## Summary

Bumps the `Umbraco.Automate.Core` floor in `Directory.Packages.props` from `0.1.0--preview.369.g5cabf66` to `0.1.0--preview.420.ge63c76a` — the nightly that includes [Umbraco.Automate#50](https://github.com/umbraco/Umbraco.Automate/pull/50) (the new `ITriggerDispatchAuthorizer` extensibility point).

## Why

Keeps distribution-mode builds (`UseProjectReferences=false`) on the latest nightly. Umbraco.AI.Automate doesn't *use* the new extension point yet — AI agent runs aren't a CMS resource the dispatch-time authoriser applies to — so the floor bump is purely a tracking concern, not a behaviour change.

## Test plan

- [x] dotnet restore succeeds against the new floor
- [x] dotnet build Umbraco.AI.Automate.slnx -p:UseProjectReferences=false — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)