### PR TITLE
chore(deps): Bump Umbraco.Automate.Core floor to preview.422.g8a1061d

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
 
   <!-- Umbraco Automate -->
   <ItemGroup>
-    <PackageVersion Include="Umbraco.Automate.Core" Version="[0.1.0--preview.420.ge63c76a, 0.999.999)" />
+    <PackageVersion Include="Umbraco.Automate.Core" Version="[0.1.0--preview.422.g8a1061d, 0.999.999)" />
   </ItemGroup>
 
   <!-- Umbraco Search -->


### PR DESCRIPTION
## Summary

Bumps the `Umbraco.Automate.Core` floor in `Directory.Packages.props` from `preview.420.ge63c76a` to `preview.422.g8a1061d` — the nightly that includes [Umbraco.Automate#51](https://github.com/umbraco/Umbraco.Automate/pull/51) (internal refactor moving the built-in CMS node-scope marker from the trigger class to the output class).

## Why

PR #51 is a pure internal refactor — no public API change, no behaviour change. This bump is purely housekeeping to keep distribution-mode builds on the latest nightly. Umbraco.AI.Automate doesn't use any of the affected types directly.

## Test plan

- [x] dotnet restore succeeds against the new floor

🤖 Generated with [Claude Code](https://claude.com/claude-code)