### PR TITLE
chore(deps): Bump Microsoft.Agents.AI floors to 1.6.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -63,8 +63,8 @@
 
   <!-- Microsoft AI Agent packages -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Agents.AI" Version="[1.6.0, 1.999.999)" />
-    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="[1.6.0, 1.999.999)" />
+    <PackageVersion Include="Microsoft.Agents.AI" Version="[1.6.1, 1.999.999)" />
+    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="[1.6.1, 1.999.999)" />
   </ItemGroup>
 
   <!-- Provider packages -->


### PR DESCRIPTION
## Summary
- Bump `Microsoft.Agents.AI` and `Microsoft.Agents.AI.Workflows` floors from `[1.6.0, 1.999.999)` to `[1.6.1, 1.999.999)`
- Picks up the patched `OpenTelemetry.Api 1.15.3` transitively, clearing the advisory on 1.13.x — no explicit override needed

## Test plan
- [x] `dotnet build Umbraco.AI.Agent/Umbraco.AI.Agent.slnx` succeeds
- [x] `project.assets.json` confirms `OpenTelemetry.Api/1.15.3` resolves
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)