### PR TITLE
chore(release): Prepare release 2026.05.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
 
   <!-- Umbraco Automate -->
   <ItemGroup>
-    <PackageVersion Include="Umbraco.Automate.Core" Version="[0.1.0--preview.420.ge63c76a, 0.999.999)" />
+    <PackageVersion Include="Umbraco.Automate.Core" Version="[0.1.0--preview.422.g8a1061d, 0.999.999)" />
   </ItemGroup>
 
   <!-- Umbraco Search -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -63,8 +63,8 @@
 
   <!-- Microsoft AI Agent packages -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Agents.AI" Version="[1.6.0, 1.999.999)" />
-    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="[1.6.0, 1.999.999)" />
+    <PackageVersion Include="Microsoft.Agents.AI" Version="[1.6.1, 1.999.999)" />
+    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="[1.6.1, 1.999.999)" />
   </ItemGroup>
 
   <!-- Provider packages -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
 
   <!-- Umbraco Automate -->
   <ItemGroup>
-    <PackageVersion Include="Umbraco.Automate.Core" Version="[0.1.0--preview.369.g5cabf66, 0.999.999)" />
+    <PackageVersion Include="Umbraco.Automate.Core" Version="[0.1.0--preview.420.ge63c76a, 0.999.999)" />
   </ItemGroup>
 
   <!-- Umbraco Search -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
 
   <!-- Umbraco Automate -->
   <ItemGroup>
-    <PackageVersion Include="Umbraco.Automate.Core" Version="[0.1.0--preview.369.g5cabf66, 0.999.999)" />
+    <PackageVersion Include="Umbraco.Automate.Core" Version="[0.1.0--preview.418.gb2b03a2, 0.999.999)" />
   </ItemGroup>
 
   <!-- Umbraco Search -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,18 +47,18 @@
 
   <!-- Inter-product dependencies (version ranges for NuGet packages) -->
   <ItemGroup>
-    <PackageVersion Include="Umbraco.AI.Core" Version="[1.11.0, 1.999.999)" />
-    <PackageVersion Include="Umbraco.AI.Web" Version="[1.11.0, 1.999.999)" />
+    <PackageVersion Include="Umbraco.AI.Core" Version="[1.12.0, 1.999.999)" />
+    <PackageVersion Include="Umbraco.AI.Web" Version="[1.12.0, 1.999.999)" />
     <PackageVersion Include="Umbraco.AI.AGUI" Version="[1.10.0, 1.999.999)" />
-    <PackageVersion Include="Umbraco.AI.Startup" Version="[1.11.0, 1.999.999)" />
-    <PackageVersion Include="Umbraco.AI.Agent" Version="[1.10.0, 1.999.999)" />
-    <PackageVersion Include="Umbraco.AI.Agent.Core" Version="[1.10.0, 1.999.999)" />
-    <PackageVersion Include="Umbraco.AI.Agent.Startup" Version="[1.10.0, 1.999.999)" />
+    <PackageVersion Include="Umbraco.AI.Startup" Version="[1.12.0, 1.999.999)" />
+    <PackageVersion Include="Umbraco.AI.Agent" Version="[1.10.2, 1.999.999)" />
+    <PackageVersion Include="Umbraco.AI.Agent.Core" Version="[1.10.2, 1.999.999)" />
+    <PackageVersion Include="Umbraco.AI.Agent.Startup" Version="[1.10.2, 1.999.999)" />
     <PackageVersion Include="Umbraco.AI.Agent.UI" Version="[1.0.0, 1.999.999)" />
     <PackageVersion Include="Umbraco.AI.Agent.Copilot" Version="[1.0.0, 1.999.999)" />
-    <PackageVersion Include="Umbraco.AI.Deploy" Version="[1.0.0, 1.999.999)" />
+    <PackageVersion Include="Umbraco.AI.Deploy" Version="[1.0.2, 1.999.999)" />
     <PackageVersion Include="Umbraco.AI.Automate" Version="[1.0.0-alpha1, 1.999.999)" />
-    <PackageVersion Include="Umbraco.AI.Prompt.Startup" Version="[1.8.4, 1.999.999)" />
+    <PackageVersion Include="Umbraco.AI.Prompt.Startup" Version="[1.8.6, 1.999.999)" />
   </ItemGroup>
 
   <!-- Microsoft AI Agent packages -->

--- a/Umbraco.AI.Agent.Copilot/version.json
+++ b/Umbraco.AI.Agent.Copilot/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.Agent.Deploy/version.json
+++ b/Umbraco.AI.Agent.Deploy/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.Agent.UI/version.json
+++ b/Umbraco.AI.Agent.UI/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.Agent/CHANGELOG.md
+++ b/Umbraco.AI.Agent/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Umbraco.AI.Agent will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.2](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.Agent@1.10.0...Umbraco.AI.Agent@1.10.2) (2026-05-20)
+
+### Internal
+
+* Bump `Microsoft.Agents.AI` and `Microsoft.Agents.AI.Workflows` to 1.6.1 to pick up patched `OpenTelemetry.Api` 1.15.3 (clears advisory on 1.13.x).
+* Bump to align with Umbraco.AI 1.12.0.
+
 ## [1.10.0](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.Agent@1.9.0...Umbraco.AI.Agent@1.10.0) (2026-05-14)
 
 ### fix

--- a/Umbraco.AI.Agent/version.json
+++ b/Umbraco.AI.Agent/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.10.1",
+    "version": "1.10.2",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.Agent/version.json
+++ b/Umbraco.AI.Agent/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.10.0",
+    "version": "1.10.1",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.Amazon/CHANGELOG.md
+++ b/Umbraco.AI.Amazon/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Umbraco.AI.Amazon will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.6](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.Amazon@1.1.4...Umbraco.AI.Amazon@1.1.6) (2026-05-20)
+
+### Internal
+
+* Bump to align with Umbraco.AI 1.12.0.
+
 ## [1.1.4](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.Amazon@1.1.2...Umbraco.AI.Amazon@1.1.4) (2026-05-14)
 
 ### Internal

--- a/Umbraco.AI.Amazon/version.json
+++ b/Umbraco.AI.Amazon/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.1.5",
+    "version": "1.1.6",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.Amazon/version.json
+++ b/Umbraco.AI.Amazon/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.Anthropic/CHANGELOG.md
+++ b/Umbraco.AI.Anthropic/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Umbraco.AI.Anthropic will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.4](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.Anthropic@1.3.2...Umbraco.AI.Anthropic@1.3.4) (2026-05-20)
+
+### Internal
+
+* Bump to align with Umbraco.AI 1.12.0.
+
 ## [1.3.2](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.Anthropic@1.3.0...Umbraco.AI.Anthropic@1.3.2) (2026-05-14)
 
 ### Internal

--- a/Umbraco.AI.Anthropic/version.json
+++ b/Umbraco.AI.Anthropic/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.Anthropic/version.json
+++ b/Umbraco.AI.Anthropic/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Actions/RunAgentAction.cs
+++ b/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Actions/RunAgentAction.cs
@@ -22,8 +22,7 @@ namespace Umbraco.AI.Automate.Actions;
 [Action(UmbracoAIAutomateConstants.ActionTypes.RunAgent, "Run AI Agent",
     Description = "Executes an AI agent and returns its response.",
     Group = "AI",
-    Icon = "icon-bot",
-    RequiredSections = [CoreConstants.Sections.AI])]
+    Icon = "icon-bot")]
 public sealed class RunAgentAction : ActionBase<RunAgentSettings, object>
 {
     private readonly IAIAgentService _agentService;

--- a/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Actions/RunAgentAction.cs
+++ b/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Actions/RunAgentAction.cs
@@ -22,7 +22,8 @@ namespace Umbraco.AI.Automate.Actions;
 [Action(UmbracoAIAutomateConstants.ActionTypes.RunAgent, "Run AI Agent",
     Description = "Executes an AI agent and returns its response.",
     Group = "AI",
-    Icon = "icon-bot")]
+    Icon = "icon-bot",
+    RequiredSections = [CoreConstants.Sections.AI])]
 public sealed class RunAgentAction : ActionBase<RunAgentSettings, object>
 {
     private readonly IAIAgentService _agentService;

--- a/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Actions/TranscribeAudioAction.cs
+++ b/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Actions/TranscribeAudioAction.cs
@@ -3,6 +3,9 @@ using Microsoft.Extensions.Logging;
 using Umbraco.AI.Core.Media;
 using Umbraco.AI.Core.SpeechToText;
 using Umbraco.Automate.Core.Actions;
+using Umbraco.Automate.Core.Security;
+using Umbraco.Cms.Core;
+using AIConstants = Umbraco.AI.Core.Constants;
 
 #pragma warning disable MEAI001 // SpeechToTextOptions / ISpeechToTextClient are experimental in M.E.AI
 
@@ -16,11 +19,13 @@ namespace Umbraco.AI.Automate.Actions;
 [Action(UmbracoAIAutomateConstants.ActionTypes.TranscribeAudio, "Transcribe Audio",
     Description = "Transcribes an audio file from an Umbraco media reference using an AI speech-to-text profile.",
     Group = "AI",
-    Icon = "icon-mic")]
+    Icon = "icon-mic",
+    RequiredSections = [AIConstants.Sections.AI, Constants.Applications.Media])]
 public sealed class TranscribeAudioAction : ActionBase<TranscribeAudioSettings, object>
 {
     private readonly IAISpeechToTextService _speechToTextService;
     private readonly IAIUmbracoMediaResolver _mediaResolver;
+    private readonly IAutomationActionAuthorizer _authorizer;
     private readonly ILogger<TranscribeAudioAction> _logger;
 
     /// <summary>
@@ -30,11 +35,13 @@ public sealed class TranscribeAudioAction : ActionBase<TranscribeAudioSettings, 
         ActionInfrastructure infrastructure,
         IAISpeechToTextService speechToTextService,
         IAIUmbracoMediaResolver mediaResolver,
+        IAutomationActionAuthorizer authorizer,
         ILogger<TranscribeAudioAction> logger)
         : base(infrastructure)
     {
         _speechToTextService = speechToTextService;
         _mediaResolver = mediaResolver;
+        _authorizer = authorizer;
         _logger = logger;
     }
 
@@ -70,6 +77,15 @@ public sealed class TranscribeAudioAction : ActionBase<TranscribeAudioSettings, 
                     new InvalidOperationException(
                         $"Resolved file is not an audio file (media type: {media.MediaType})."),
                     StepRunErrorCategory.Validation);
+            }
+
+            // Node-level authorisation: when the audio source was an Umbraco media reference,
+            // the service account must have access to that node. Raw file paths bypass this
+            // because they're not CMS nodes — the operator has explicitly configured them.
+            if (media.MediaKey is { } mediaKey
+                && await _authorizer.AuthorizeMediaOrFailAsync(mediaKey, cancellationToken) is { } failure)
+            {
+                return failure;
             }
 
             await using var audioStream = new MemoryStream(media.Data);

--- a/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Actions/TranscribeAudioAction.cs
+++ b/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Actions/TranscribeAudioAction.cs
@@ -5,7 +5,6 @@ using Umbraco.AI.Core.SpeechToText;
 using Umbraco.Automate.Core.Actions;
 using Umbraco.Automate.Core.Security;
 using Umbraco.Cms.Core;
-using AIConstants = Umbraco.AI.Core.Constants;
 
 #pragma warning disable MEAI001 // SpeechToTextOptions / ISpeechToTextClient are experimental in M.E.AI
 
@@ -20,7 +19,7 @@ namespace Umbraco.AI.Automate.Actions;
     Description = "Transcribes an audio file from an Umbraco media reference using an AI speech-to-text profile.",
     Group = "AI",
     Icon = "icon-mic",
-    RequiredSections = [AIConstants.Sections.AI, Constants.Applications.Media])]
+    RequiredSections = [Constants.Applications.Media])]
 public sealed class TranscribeAudioAction : ActionBase<TranscribeAudioSettings, object>
 {
     private readonly IAISpeechToTextService _speechToTextService;

--- a/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Triggers/AgentRunCompletedTrigger.cs
+++ b/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Triggers/AgentRunCompletedTrigger.cs
@@ -1,5 +1,6 @@
 using Umbraco.AI.Agent.Core.Agents;
 using Umbraco.Automate.Core.Triggers;
+using CoreConstants = Umbraco.AI.Core.Constants;
 
 namespace Umbraco.AI.Automate.Triggers;
 
@@ -10,7 +11,8 @@ namespace Umbraco.AI.Automate.Triggers;
 [Trigger(UmbracoAIAutomateConstants.TriggerTypes.AgentRunCompleted, "AI Agent Run Completed",
     Description = "Fires when an AI agent run completes successfully.",
     Group = "AI",
-    Icon = "icon-bot")]
+    Icon = "icon-bot",
+    RequiredSections = [CoreConstants.Sections.AI])]
 public sealed class AgentRunCompletedTrigger
     : NotificationTriggerBase<AgentRunCompletedTriggerSettings, AgentRunCompletedTriggerOutput, AIAgentExecutedNotification>
 {

--- a/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Triggers/AgentRunFailedTrigger.cs
+++ b/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Triggers/AgentRunFailedTrigger.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Umbraco.AI.Agent.Core.Agents;
 using Umbraco.Automate.Core.Triggers;
+using CoreConstants = Umbraco.AI.Core.Constants;
 
 namespace Umbraco.AI.Automate.Triggers;
 
@@ -11,7 +12,8 @@ namespace Umbraco.AI.Automate.Triggers;
 [Trigger(UmbracoAIAutomateConstants.TriggerTypes.AgentRunFailed, "AI Agent Run Failed",
     Description = "Fires when an AI agent run fails.",
     Group = "AI",
-    Icon = "icon-alert")]
+    Icon = "icon-alert",
+    RequiredSections = [CoreConstants.Sections.AI])]
 public sealed class AgentRunFailedTrigger
     : NotificationTriggerBase<AgentRunFailedTriggerSettings, AgentRunFailedTriggerOutput, AIAgentExecutedNotification>
 {

--- a/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Triggers/AgentTrigger.cs
+++ b/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Triggers/AgentTrigger.cs
@@ -1,4 +1,5 @@
 using Umbraco.Automate.Core.Triggers;
+using CoreConstants = Umbraco.AI.Core.Constants;
 
 namespace Umbraco.AI.Automate.Triggers;
 
@@ -9,7 +10,8 @@ namespace Umbraco.AI.Automate.Triggers;
 [Trigger(UmbracoAIAutomateConstants.TriggerTypes.AgentTrigger, "AI Agent Request",
     Description = "Fires when requested by an AI agent during a conversation.",
     Group = "AI",
-    Icon = "icon-bot")]
+    Icon = "icon-bot",
+    RequiredSections = [CoreConstants.Sections.AI])]
 public sealed class AgentTrigger : TriggerBase<object, AgentTriggerOutput>
 {
     /// <summary>

--- a/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Triggers/AgentTrigger.cs
+++ b/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Triggers/AgentTrigger.cs
@@ -1,5 +1,4 @@
 using Umbraco.Automate.Core.Triggers;
-using CoreConstants = Umbraco.AI.Core.Constants;
 
 namespace Umbraco.AI.Automate.Triggers;
 
@@ -10,8 +9,7 @@ namespace Umbraco.AI.Automate.Triggers;
 [Trigger(UmbracoAIAutomateConstants.TriggerTypes.AgentTrigger, "AI Agent Request",
     Description = "Fires when requested by an AI agent during a conversation.",
     Group = "AI",
-    Icon = "icon-bot",
-    RequiredSections = [CoreConstants.Sections.AI])]
+    Icon = "icon-bot")]
 public sealed class AgentTrigger : TriggerBase<object, AgentTriggerOutput>
 {
     /// <summary>

--- a/Umbraco.AI.Automate/tests/Umbraco.AI.Automate.Tests.Unit/Actions/TranscribeAudioActionTests.cs
+++ b/Umbraco.AI.Automate/tests/Umbraco.AI.Automate.Tests.Unit/Actions/TranscribeAudioActionTests.cs
@@ -7,6 +7,7 @@ using Umbraco.AI.Automate.Actions;
 using Umbraco.AI.Core.Media;
 using Umbraco.AI.Core.SpeechToText;
 using Umbraco.Automate.Core.Actions;
+using Umbraco.Automate.Core.Security;
 using Umbraco.Automate.Core.Settings;
 using Xunit;
 
@@ -18,12 +19,18 @@ public class TranscribeAudioActionTests
 {
     private readonly Mock<IAISpeechToTextService> _speechToTextServiceMock = new();
     private readonly Mock<IAIUmbracoMediaResolver> _mediaResolverMock = new();
+    private readonly Mock<IAutomationActionAuthorizer> _authorizerMock = new();
     private readonly Mock<ILogger<TranscribeAudioAction>> _loggerMock = new();
     private readonly ActionInfrastructure _infrastructure;
 
     public TranscribeAudioActionTests()
     {
         _infrastructure = new ActionInfrastructure(new Mock<IEditableModelResolver>().Object);
+
+        // Default: node-level authorisation passes. Tests that exercise the deny path
+        // override per-key.
+        _authorizerMock.Setup(a => a.AuthorizeMediaAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(AutomationAuthorizationResult.Success);
     }
 
     [Fact]
@@ -222,7 +229,7 @@ public class TranscribeAudioActionTests
     }
 
     private TranscribeAudioAction CreateAction()
-        => new(_infrastructure, _speechToTextServiceMock.Object, _mediaResolverMock.Object, _loggerMock.Object);
+        => new(_infrastructure, _speechToTextServiceMock.Object, _mediaResolverMock.Object, _authorizerMock.Object, _loggerMock.Object);
 
     private static ActionContext CreateContext(TranscribeAudioSettings settings)
         => new()

--- a/Umbraco.AI.Automate/tests/Umbraco.AI.Automate.Tests.Unit/Tools/RunAutomationToolTests.cs
+++ b/Umbraco.AI.Automate/tests/Umbraco.AI.Automate.Tests.Unit/Tools/RunAutomationToolTests.cs
@@ -159,9 +159,10 @@ public class RunAutomationToolTests
                 It.IsAny<string>(),
                 It.IsAny<string?>(),
                 It.IsAny<Dictionary<string, object?>?>(),
-                It.IsAny<CancellationToken>()))
-            .Callback<Automation, string, string?, Dictionary<string, object?>?, CancellationToken>(
-                (_, _, _, triggerData, _) => capturedTriggerData = triggerData)
+                It.IsAny<CancellationToken>(),
+                It.IsAny<IReadOnlyList<Guid>?>()))
+            .Callback<Automation, string, string?, Dictionary<string, object?>?, CancellationToken, IReadOnlyList<Guid>?>(
+                (_, _, _, triggerData, _, _) => capturedTriggerData = triggerData)
             .ReturnsAsync(TestRunId);
 
         var tool = CreateTool();
@@ -196,9 +197,10 @@ public class RunAutomationToolTests
                 It.IsAny<string>(),
                 It.IsAny<string?>(),
                 It.IsAny<Dictionary<string, object?>?>(),
-                It.IsAny<CancellationToken>()))
-            .Callback<Automation, string, string?, Dictionary<string, object?>?, CancellationToken>(
-                (_, _, _, triggerData, _) => capturedTriggerData = triggerData)
+                It.IsAny<CancellationToken>(),
+                It.IsAny<IReadOnlyList<Guid>?>()))
+            .Callback<Automation, string, string?, Dictionary<string, object?>?, CancellationToken, IReadOnlyList<Guid>?>(
+                (_, _, _, triggerData, _, _) => capturedTriggerData = triggerData)
             .ReturnsAsync(TestRunId);
 
         var tool = CreateTool();

--- a/Umbraco.AI.DeepSeek/CHANGELOG.md
+++ b/Umbraco.AI.DeepSeek/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Umbraco.AI.DeepSeek will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.DeepSeek@1.0.2...Umbraco.AI.DeepSeek@1.0.4) (2026-05-20)
+
+### Internal
+
+* Bump to align with Umbraco.AI 1.12.0.
+
 ## [1.0.2](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.DeepSeek@1.0.0...Umbraco.AI.DeepSeek@1.0.2) (2026-05-14)
 
 ### Internal

--- a/Umbraco.AI.DeepSeek/version.json
+++ b/Umbraco.AI.DeepSeek/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.DeepSeek/version.json
+++ b/Umbraco.AI.DeepSeek/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.Deploy/CHANGELOG.md
+++ b/Umbraco.AI.Deploy/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Umbraco.AI.Deploy will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.Deploy@1.0.0-beta3...Umbraco.AI.Deploy@1.0.2) (2026-05-20)
+
+### Internal
+
+* Bump to align with Umbraco.AI 1.12.0.
+
 ## [1.0.0](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.Deploy@1.0.0-beta3...Umbraco.AI.Deploy@1.0.0) (2026-05-14)
 
 ### Notes

--- a/Umbraco.AI.Deploy/version.json
+++ b/Umbraco.AI.Deploy/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.Deploy/version.json
+++ b/Umbraco.AI.Deploy/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.FireworksAI/CHANGELOG.md
+++ b/Umbraco.AI.FireworksAI/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Umbraco.AI.FireworksAI will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.FireworksAI@1.0.2...Umbraco.AI.FireworksAI@1.0.4) (2026-05-20)
+
+### Internal
+
+* Bump to align with Umbraco.AI 1.12.0.
+
 ## [1.0.2](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.FireworksAI@1.0.0...Umbraco.AI.FireworksAI@1.0.2) (2026-05-14)
 
 ### Internal

--- a/Umbraco.AI.FireworksAI/version.json
+++ b/Umbraco.AI.FireworksAI/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.FireworksAI/version.json
+++ b/Umbraco.AI.FireworksAI/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.Google/CHANGELOG.md
+++ b/Umbraco.AI.Google/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Umbraco.AI.Google will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.9](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.Google@1.1.7...Umbraco.AI.Google@1.1.9) (2026-05-20)
+
+### Internal
+
+* Bump to align with Umbraco.AI 1.12.0.
+
 ## [1.1.7](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.Google@1.1.5...Umbraco.AI.Google@1.1.7) (2026-05-14)
 
 ### Internal

--- a/Umbraco.AI.Google/version.json
+++ b/Umbraco.AI.Google/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.1.8",
+    "version": "1.1.9",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.Google/version.json
+++ b/Umbraco.AI.Google/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.1.7",
+    "version": "1.1.8",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.HuggingFace/CHANGELOG.md
+++ b/Umbraco.AI.HuggingFace/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Umbraco.AI.HuggingFace will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.HuggingFace@1.0.2...Umbraco.AI.HuggingFace@1.0.4) (2026-05-20)
+
+### Internal
+
+* Bump to align with Umbraco.AI 1.12.0.
+
 ## [1.0.2](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.HuggingFace@1.0.0...Umbraco.AI.HuggingFace@1.0.2) (2026-05-14)
 
 ### Internal

--- a/Umbraco.AI.HuggingFace/version.json
+++ b/Umbraco.AI.HuggingFace/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.HuggingFace/version.json
+++ b/Umbraco.AI.HuggingFace/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.MicrosoftFoundry/CHANGELOG.md
+++ b/Umbraco.AI.MicrosoftFoundry/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Umbraco.AI.MicrosoftFoundry will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.4](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.MicrosoftFoundry@1.2.2...Umbraco.AI.MicrosoftFoundry@1.2.4) (2026-05-20)
+
+### Internal
+
+* Bump to align with Umbraco.AI 1.12.0.
+
 ## [1.2.2](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.MicrosoftFoundry@1.2.0...Umbraco.AI.MicrosoftFoundry@1.2.2) (2026-05-14)
 
 ### fix

--- a/Umbraco.AI.MicrosoftFoundry/version.json
+++ b/Umbraco.AI.MicrosoftFoundry/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.MicrosoftFoundry/version.json
+++ b/Umbraco.AI.MicrosoftFoundry/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.Mistral/CHANGELOG.md
+++ b/Umbraco.AI.Mistral/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Umbraco.AI.Mistral will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.Mistral@1.0.2...Umbraco.AI.Mistral@1.0.4) (2026-05-20)
+
+### Internal
+
+* Bump to align with Umbraco.AI 1.12.0.
+
 ## [1.0.2](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.Mistral@1.0.0...Umbraco.AI.Mistral@1.0.2) (2026-05-14)
 
 ### Internal

--- a/Umbraco.AI.Mistral/version.json
+++ b/Umbraco.AI.Mistral/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.Mistral/version.json
+++ b/Umbraco.AI.Mistral/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.OpenAI/CHANGELOG.md
+++ b/Umbraco.AI.OpenAI/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Umbraco.AI.OpenAI will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.4](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.OpenAI@1.2.2...Umbraco.AI.OpenAI@1.2.4) (2026-05-20)
+
+### Internal
+
+* Bump to align with Umbraco.AI 1.12.0.
+
 ## [1.2.2](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.OpenAI@1.2.0...Umbraco.AI.OpenAI@1.2.2) (2026-05-14)
 
 ### fix

--- a/Umbraco.AI.OpenAI/version.json
+++ b/Umbraco.AI.OpenAI/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.OpenAI/version.json
+++ b/Umbraco.AI.OpenAI/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.Prompt.Deploy/version.json
+++ b/Umbraco.AI.Prompt.Deploy/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.Prompt/CHANGELOG.md
+++ b/Umbraco.AI.Prompt/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Umbraco.AI.Prompt will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.6](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.Prompt@1.8.4...Umbraco.AI.Prompt@1.8.6) (2026-05-20)
+
+### Internal
+
+* Bump to align with Umbraco.AI 1.12.0.
+
 ## [1.8.4](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.Prompt@1.8.2...Umbraco.AI.Prompt@1.8.4) (2026-05-14)
 
 ### Internal

--- a/Umbraco.AI.Prompt/version.json
+++ b/Umbraco.AI.Prompt/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.8.5",
+    "version": "1.8.6",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.Prompt/version.json
+++ b/Umbraco.AI.Prompt/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.8.4",
+    "version": "1.8.5",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.Search/CHANGELOG.md
+++ b/Umbraco.AI.Search/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Umbraco.AI.Search will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-beta8](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.Search@1.0.0-beta6...Umbraco.AI.Search@1.0.0-beta8) (2026-05-20)
+
+### Internal
+
+* Bump to align with Umbraco.AI 1.12.0.
+
 ## [1.0.0-beta6](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.Search@1.0.0-beta4...Umbraco.AI.Search@1.0.0-beta6) (2026-05-14)
 
 ### Internal

--- a/Umbraco.AI.Search/version.json
+++ b/Umbraco.AI.Search/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0.0-beta7",
+    "version": "1.0.0-beta8",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.Search/version.json
+++ b/Umbraco.AI.Search/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0.0-beta6",
+    "version": "1.0.0-beta7",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.TogetherAI/CHANGELOG.md
+++ b/Umbraco.AI.TogetherAI/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Umbraco.AI.TogetherAI will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.TogetherAI@1.0.2...Umbraco.AI.TogetherAI@1.0.4) (2026-05-20)
+
+### Internal
+
+* Bump to align with Umbraco.AI 1.12.0.
+
 ## [1.0.2](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI.TogetherAI@1.0.0...Umbraco.AI.TogetherAI@1.0.2) (2026-05-14)
 
 ### Internal

--- a/Umbraco.AI.TogetherAI/version.json
+++ b/Umbraco.AI.TogetherAI/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI.TogetherAI/version.json
+++ b/Umbraco.AI.TogetherAI/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI/CHANGELOG.md
+++ b/Umbraco.AI/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Umbraco.AI will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.0](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI@1.11.0...Umbraco.AI@1.12.0) (2026-05-20)
+
+### feat
+
+* **core:** Expose AI section alias via public `Constants.Sections.AI` for cross-package consumers ([3378338](https://github.com/umbraco/Umbraco.AI/commit/3378338c818699ca6d919b14fe36ad636498f48f))
+* **core:** Add `MediaKey` to `AIMediaContent` to enable per-node authorization of resolved media references ([3378338](https://github.com/umbraco/Umbraco.AI/commit/3378338c818699ca6d919b14fe36ad636498f48f))
+
 ## [1.11.0](https://github.com/umbraco/Umbraco.AI/compare/Umbraco.AI@1.10.1...Umbraco.AI@1.11.0) (2026-05-14)
 
 ### feat

--- a/Umbraco.AI/src/Umbraco.AI.Core/Constants.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Constants.cs
@@ -28,7 +28,7 @@ public static class Constants
     /// <summary>
     /// Section constants for Umbraco.AI. These can be used for checking the current section in Umbraco backoffice or for storing section information in metadata, etc.
     /// </summary>
-    internal static class Sections
+    public static class Sections
     {
         /// <summary>
         /// Section alias for Umbraco.AI.

--- a/Umbraco.AI/src/Umbraco.AI.Core/Media/AIMediaContent.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Media/AIMediaContent.cs
@@ -14,4 +14,11 @@ public sealed class AIMediaContent
     /// Gets or sets the MIME type of the media (e.g., "image/jpeg", "audio/mpeg").
     /// </summary>
     public required string MediaType { get; init; }
+
+    /// <summary>
+    /// Gets the Umbraco media node key when the content was resolved from a media reference
+    /// (GUID or media picker value). Null when the content was resolved from a raw file path —
+    /// in that case the source is not a CMS media node and no per-node authorisation applies.
+    /// </summary>
+    public Guid? MediaKey { get; init; }
 }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Media/AIUmbracoMediaResolver.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Media/AIUmbracoMediaResolver.cs
@@ -266,7 +266,13 @@ internal sealed class AIUmbracoMediaResolver : IAIUmbracoMediaResolver
             return null;
         }
 
-        return LoadFromPath(filePath);
+        var content = LoadFromPath(filePath);
+        return content is null ? null : new AIMediaContent
+        {
+            Data = content.Data,
+            MediaType = content.MediaType,
+            MediaKey = mediaKey,
+        };
     }
 
     private AIMediaContent? LoadFromPath(string filePath)

--- a/Umbraco.AI/version.json
+++ b/Umbraco.AI/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.11.1",
+    "version": "1.12.0",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/Umbraco.AI/version.json
+++ b/Umbraco.AI/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.11.0",
+    "version": "1.11.1",
     "assemblyVersion": {
         "precision": "build"
     },

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
         "rxjs": "^7.8.2"
     },
     "peerDependencyVersions": {
-        "@umbraco-ai/core": "^1.11.0",
-        "@umbraco-ai/agent": "^1.10.0",
+        "@umbraco-ai/core": "^1.12.0",
+        "@umbraco-ai/agent": "^1.10.2",
         "@umbraco-ai/agent-ui": "^1.0.0",
         "@umbraco-ai/agent-copilot": "^1.0.0",
         "@umbraco-cms/backoffice": "^17.4.0"

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -1,0 +1,25 @@
+{
+    "include": [
+        "Umbraco.AI",
+        "Umbraco.AI.Agent",
+        "Umbraco.AI.Amazon",
+        "Umbraco.AI.Anthropic",
+        "Umbraco.AI.DeepSeek",
+        "Umbraco.AI.Deploy",
+        "Umbraco.AI.FireworksAI",
+        "Umbraco.AI.Google",
+        "Umbraco.AI.HuggingFace",
+        "Umbraco.AI.MicrosoftFoundry",
+        "Umbraco.AI.Mistral",
+        "Umbraco.AI.OpenAI",
+        "Umbraco.AI.Prompt",
+        "Umbraco.AI.Search",
+        "Umbraco.AI.TogetherAI"
+    ],
+    "exclude": [
+        "Umbraco.AI.Agent.Deploy",
+        "Umbraco.AI.Agent.UI",
+        "Umbraco.AI.Automate",
+        "Umbraco.AI.Prompt.Deploy"
+    ]
+}

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -17,6 +17,7 @@
         "Umbraco.AI.TogetherAI"
     ],
     "exclude": [
+        "Umbraco.AI.Agent.Copilot",
         "Umbraco.AI.Agent.Deploy",
         "Umbraco.AI.Agent.UI",
         "Umbraco.AI.Automate",


### PR DESCRIPTION
## Summary

Release `2026.05.3` — 15 products. Umbraco.AI minor + cascade patches.

### Bumps

| Product | From | To | Driver |
|---|---|---|---|
| `Umbraco.AI` | 1.11.1 | **1.12.0** | feat (`Constants.Sections.AI` public, `AIMediaContent.MediaKey`) |
| `Umbraco.AI.Agent` | 1.10.1 | 1.10.2 | cascade + `Microsoft.Agents.AI` 1.6.1 (clears OpenTelemetry advisory) |
| `Umbraco.AI.Amazon` | 1.1.5 | 1.1.6 | cascade |
| `Umbraco.AI.Anthropic` | 1.3.3 | 1.3.4 | cascade |
| `Umbraco.AI.DeepSeek` | 1.0.3 | 1.0.4 | cascade |
| `Umbraco.AI.Deploy` | 1.0.1 | 1.0.2 | cascade |
| `Umbraco.AI.FireworksAI` | 1.0.3 | 1.0.4 | cascade |
| `Umbraco.AI.Google` | 1.1.8 | 1.1.9 | cascade |
| `Umbraco.AI.HuggingFace` | 1.0.3 | 1.0.4 | cascade |
| `Umbraco.AI.MicrosoftFoundry` | 1.2.3 | 1.2.4 | cascade |
| `Umbraco.AI.Mistral` | 1.0.3 | 1.0.4 | cascade |
| `Umbraco.AI.OpenAI` | 1.2.3 | 1.2.4 | cascade |
| `Umbraco.AI.Prompt` | 1.8.5 | 1.8.6 | cascade |
| `Umbraco.AI.Search` | 1.0.0-beta7 | 1.0.0-beta8 | cascade |
| `Umbraco.AI.TogetherAI` | 1.0.3 | 1.0.4 | cascade |

### Excluded

- `Umbraco.AI.Automate` — in-progress internal dev
- `Umbraco.AI.Agent.UI`, `Umbraco.AI.Agent.Copilot`, `Umbraco.AI.Agent.Deploy`, `Umbraco.AI.Prompt.Deploy` — range-delta acknowledgement only (no version bump needed)

## Test plan

- [ ] CI green on `release/2026.05.3`
- [ ] All 15 NuGet packages build
- [ ] All npm packages build
- [ ] Release pipeline tags repo with `[Product]@[Version]` and new date tag `2026.05.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)