### PR TITLE
fix(amazon): Discover all embedding models and support Cohere request format

### DIFF
--- a/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/AmazonEmbeddingCapability.cs
+++ b/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/AmazonEmbeddingCapability.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Amazon.Bedrock;
 using Amazon.BedrockRuntime;
 using Microsoft.Extensions.AI;
 using Umbraco.AI.Core.Models;
@@ -28,15 +29,36 @@ public class AmazonEmbeddingCapability(AmazonProvider provider) : AIEmbeddingCap
         new($@"^{RegionPrefixPattern}cohere\.embed-", RegexOptions.IgnoreCase | RegexOptions.Compiled),
     ];
 
+    /// <summary>
+    /// Pattern matching any Cohere embed model (with or without region prefix). Cohere models require a
+    /// different request/response shape than Titan and need a custom generator.
+    /// </summary>
+    private static readonly Regex CohereEmbedPattern =
+        new($@"^{RegionPrefixPattern}cohere\.embed-", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
     /// <inheritdoc />
     protected override async Task<IReadOnlyList<AIModelDescriptor>> GetModelsAsync(
         AmazonProviderSettings settings,
         CancellationToken cancellationToken = default)
     {
-        var allModels = await Provider.GetAvailableModelIdsAsync(settings, cancellationToken);
+        // Embedding models reach us via two Bedrock APIs:
+        //   ListFoundationModels (EMBEDDING modality) surfaces direct on-demand models like Titan and
+        //   Cohere Embed v3, which have no inference profile. ListInferenceProfiles surfaces newer
+        //   cross-region models like Cohere Embed v4, which is only invokable via a profile ID
+        //   (e.g. eu.cohere.embed-v4:0) and does not appear in ListFoundationModels under ON_DEMAND.
+        // Union both so the full set of usable embedding models is discoverable.
+        var foundationModelsTask = Provider.GetAvailableFoundationModelIdsAsync(
+            settings,
+            ModelModality.EMBEDDING,
+            cancellationToken);
+        var inferenceProfilesTask = Provider.GetAvailableModelIdsAsync(settings, cancellationToken);
 
-        return allModels
-            .Where(IsEmbeddingModel)
+        await Task.WhenAll(foundationModelsTask, inferenceProfilesTask);
+
+        return foundationModelsTask.Result
+            .Concat(inferenceProfilesTask.Result.Where(IsEmbeddingModel))
+            .Distinct()
+            .OrderBy(id => id)
             .Select(id => new AIModelDescriptor(
                 new AIModelRef(Provider.Id, id),
                 AmazonModelUtilities.FormatDisplayName(id)))
@@ -50,10 +72,20 @@ public class AmazonEmbeddingCapability(AmazonProvider provider) : AIEmbeddingCap
         {
             throw new InvalidOperationException(
                 "A model must be selected for Amazon Bedrock. " +
-                "Please select a model from the available inference profiles.");
+                "Please select a model from the available embedding models.");
         }
 
         var client = AmazonProvider.CreateBedrockRuntimeClient(settings);
+
+        // AWSSDK.Extensions.Bedrock.MEAI's AsIEmbeddingGenerator hardcodes the Titan request/response
+        // shape ({ "inputText": "..." } / { "embedding": [...] }). Cohere uses a different protocol
+        // ({ "texts": [...], "input_type": "...", "embedding_types": [...] } and
+        // { "embeddings": { "float": [[...]] } }), so we provide our own generator for Cohere.
+        if (CohereEmbedPattern.IsMatch(modelId))
+        {
+            return new CohereEmbeddingGenerator(client, modelId);
+        }
+
         return client.AsIEmbeddingGenerator(modelId);
     }
 

--- a/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/AmazonProvider.cs
+++ b/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/AmazonProvider.cs
@@ -15,6 +15,7 @@ namespace Umbraco.AI.Amazon;
 public class AmazonProvider : AIProviderBase<AmazonProviderSettings>
 {
     private const string CacheKeyPrefix = "Amazon_Models_";
+    private const string FoundationCacheKeyPrefix = "Amazon_FoundationModels_";
     private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(1);
 
     private readonly IMemoryCache _cache;
@@ -76,6 +77,56 @@ public class AmazonProvider : AIProviderBase<AmazonProviderSettings>
         while (!string.IsNullOrEmpty(nextToken));
 
         var modelIds = allProfiles
+            .OrderBy(id => id)
+            .ToList();
+
+        _cache.Set(cacheKey, (IReadOnlyList<string>)modelIds, CacheDuration);
+
+        return modelIds;
+    }
+
+    /// <summary>
+    /// Gets foundation model IDs that support on-demand invocation, optionally filtered by output modality.
+    /// Unlike <see cref="GetAvailableModelIdsAsync"/> which returns cross-region inference profiles,
+    /// this returns models invoked directly by their foundation model ID (e.g., <c>amazon.titan-embed-text-v2:0</c>).
+    /// Embedding models in particular generally don't have inference profiles, so this API is required to surface them.
+    /// </summary>
+    /// <param name="settings">The provider settings containing AWS credentials.</param>
+    /// <param name="outputModality">Optional output modality filter (e.g., <see cref="ModelModality.EMBEDDING"/>).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of foundation model IDs.</returns>
+    internal async Task<IReadOnlyList<string>> GetAvailableFoundationModelIdsAsync(
+        AmazonProviderSettings settings,
+        ModelModality? outputModality = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateSettings(settings);
+
+        var cacheKey = GetFoundationCacheKey(settings, outputModality);
+
+        if (_cache.TryGetValue<IReadOnlyList<string>>(cacheKey, out var cachedModels) && cachedModels is not null)
+        {
+            return cachedModels;
+        }
+
+        using var client = CreateBedrockClient(settings);
+
+        var request = new ListFoundationModelsRequest
+        {
+            ByInferenceType = InferenceType.ON_DEMAND
+        };
+
+        if (outputModality is not null)
+        {
+            request.ByOutputModality = outputModality;
+        }
+
+        var response = await client.ListFoundationModelsAsync(request, cancellationToken);
+
+        var modelIds = response.ModelSummaries
+            .Select(m => m.ModelId)
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Distinct()
             .OrderBy(id => id)
             .ToList();
 
@@ -153,5 +204,12 @@ public class AmazonProvider : AIProviderBase<AmazonProviderSettings>
         // Cache per credentials + region + endpoint combination
         var endpoint = settings.Endpoint ?? "default";
         return $"{CacheKeyPrefix}{settings.AccessKeyId?.GetHashCode()}:{settings.Region}:{endpoint}";
+    }
+
+    private static string GetFoundationCacheKey(AmazonProviderSettings settings, ModelModality? outputModality)
+    {
+        var endpoint = settings.Endpoint ?? "default";
+        var modality = outputModality?.Value ?? "any";
+        return $"{FoundationCacheKeyPrefix}{settings.AccessKeyId?.GetHashCode()}:{settings.Region}:{endpoint}:{modality}";
     }
 }

--- a/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/CohereEmbeddingGenerator.cs
+++ b/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/CohereEmbeddingGenerator.cs
@@ -1,0 +1,166 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Amazon.BedrockRuntime;
+using Amazon.BedrockRuntime.Model;
+using Microsoft.Extensions.AI;
+
+namespace Umbraco.AI.Amazon;
+
+/// <summary>
+/// <see cref="IEmbeddingGenerator{TInput,TEmbedding}"/> for Cohere Embed models on Amazon Bedrock.
+/// </summary>
+/// <remarks>
+/// AWSSDK.Extensions.Bedrock.MEAI's built-in generator only speaks the Amazon Titan protocol
+/// (<c>{ "inputText": "..." } / { "embedding": [...] }</c>). Cohere Embed v3 and v4 require
+/// <c>{ "texts": [...], "input_type": "...", "embedding_types": [...] }</c> and respond with
+/// <c>{ "embeddings": { "float": [[...]] } }</c>, so we implement the protocol ourselves.
+/// </remarks>
+internal sealed class CohereEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>
+{
+    private const string ProviderName = "aws.bedrock";
+    private const string DefaultInputType = "search_document";
+
+    /// <summary>
+    /// Override key in <see cref="EmbeddingGenerationOptions.AdditionalProperties"/> to specify
+    /// the Cohere <c>input_type</c> (e.g. <c>search_query</c> for queries vs <c>search_document</c>
+    /// for indexed content).
+    /// </summary>
+    private const string InputTypeOption = "input_type";
+
+    private readonly IAmazonBedrockRuntime _runtime;
+    private readonly string _modelId;
+    private readonly EmbeddingGeneratorMetadata _metadata;
+
+    public CohereEmbeddingGenerator(IAmazonBedrockRuntime runtime, string modelId)
+    {
+        ArgumentNullException.ThrowIfNull(runtime);
+        ArgumentException.ThrowIfNullOrWhiteSpace(modelId);
+
+        _runtime = runtime;
+        _modelId = modelId;
+        _metadata = new EmbeddingGeneratorMetadata(ProviderName, defaultModelId: modelId);
+    }
+
+    public void Dispose()
+    {
+        // Runtime is owned by the caller.
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        ArgumentNullException.ThrowIfNull(serviceType);
+
+        if (serviceKey is not null)
+        {
+            return null;
+        }
+
+        if (serviceType == typeof(EmbeddingGeneratorMetadata))
+        {
+            return _metadata;
+        }
+
+        if (serviceType.IsInstanceOfType(_runtime))
+        {
+            return _runtime;
+        }
+
+        if (serviceType.IsInstanceOfType(this))
+        {
+            return this;
+        }
+
+        return null;
+    }
+
+    public async Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(
+        IEnumerable<string> values,
+        EmbeddingGenerationOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+
+        var texts = values.ToList();
+        if (texts.Count == 0)
+        {
+            return [];
+        }
+
+        var requestBody = new CohereEmbedRequest
+        {
+            Texts = texts,
+            InputType = ResolveInputType(options),
+            EmbeddingTypes = ["float"]
+        };
+
+        var request = new InvokeModelRequest
+        {
+            ModelId = options?.ModelId ?? _modelId,
+            Accept = "application/json",
+            ContentType = "application/json",
+            Body = new MemoryStream(JsonSerializer.SerializeToUtf8Bytes(requestBody, CohereJsonContext.Default.CohereEmbedRequest))
+        };
+
+        var response = await _runtime.InvokeModelAsync(request, cancellationToken);
+
+        var cohereResponse = JsonSerializer.Deserialize(response.Body, CohereJsonContext.Default.CohereEmbedResponse)
+            ?? throw new InvalidOperationException("Cohere embedding response was empty.");
+
+        var vectors = cohereResponse.Embeddings?.Float;
+        if (vectors is null)
+        {
+            throw new InvalidOperationException(
+                "Cohere embedding response did not contain float embeddings. " +
+                "Check that the selected model supports the 'float' embedding type.");
+        }
+
+        var result = new GeneratedEmbeddings<Embedding<float>>(vectors.Count);
+        foreach (var vector in vectors)
+        {
+            result.Add(new Embedding<float>(vector));
+        }
+
+        return result;
+    }
+
+    private static string ResolveInputType(EmbeddingGenerationOptions? options)
+    {
+        if (options?.AdditionalProperties is { } props
+            && props.TryGetValue(InputTypeOption, out var value)
+            && value is string str
+            && !string.IsNullOrWhiteSpace(str))
+        {
+            return str;
+        }
+
+        return DefaultInputType;
+    }
+
+    internal sealed class CohereEmbedRequest
+    {
+        [JsonPropertyName("texts")]
+        public List<string>? Texts { get; set; }
+
+        [JsonPropertyName("input_type")]
+        public string? InputType { get; set; }
+
+        [JsonPropertyName("embedding_types")]
+        public List<string>? EmbeddingTypes { get; set; }
+    }
+
+    internal sealed class CohereEmbedResponse
+    {
+        [JsonPropertyName("embeddings")]
+        public CohereEmbedTypes? Embeddings { get; set; }
+    }
+
+    internal sealed class CohereEmbedTypes
+    {
+        [JsonPropertyName("float")]
+        public List<float[]>? Float { get; set; }
+    }
+}
+
+[JsonSerializable(typeof(CohereEmbeddingGenerator.CohereEmbedRequest))]
+[JsonSerializable(typeof(CohereEmbeddingGenerator.CohereEmbedResponse))]
+internal sealed partial class CohereJsonContext : JsonSerializerContext;


### PR DESCRIPTION
## Summary

- `ListInferenceProfiles` only surfaces models with cross-region inference profiles, so most embedding models (Amazon Titan v1/v2, Cohere Embed v3) never appeared in the picker — only Cohere Embed v4 did, because it ships as a SYSTEM_DEFINED inference profile. Embedding discovery now unions `ListInferenceProfiles` with `ListFoundationModels` filtered by `EMBEDDING` modality + `ON_DEMAND` inference type.
- `AWSSDK.Extensions.Bedrock.MEAI`'s `AsIEmbeddingGenerator` hardcodes the Titan request/response shape (`inputText` / `embedding`). Cohere uses `texts` / `input_type` / `embedding_types` and responds with `embeddings.float[][]`, so every Cohere call was malformed. Added a `CohereEmbeddingGenerator` that speaks the Cohere protocol; Titan continues using the AWS shim.
- `CohereEmbeddingGenerator` defaults `input_type` to `search_document` and lets callers override via `EmbeddingGenerationOptions.AdditionalProperties["input_type"]` (e.g. `search_query` for query-side embedding). Wiring the hint through the search pipeline is left for a follow-up.

## Test plan

- [x] Build clean (`dotnet build Umbraco.AI.Amazon.slnx`, 0 warnings, 0 errors)
- [x] Connection + embedding profile lists Titan and Cohere v3/v4 models
- [x] Rebuild search index using Cohere → indexes and queries successfully
- [x] Rebuild search index using a Titan model → indexes and queries successfully
- [ ] Follow-up: thread `input_type=search_query` from search pipeline for optimal Cohere recall

🤖 Generated with [Claude Code](https://claude.com/claude-code)