### PR TITLE
feat(speechtotext)!: Transcribe uploaded audio files via the file-processing pipeline

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.Collections.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.Collections.cs
@@ -138,7 +138,7 @@ public static partial class UmbracoBuilderExtensions
     /// <returns>The AI file processing handler collection builder.</returns>
     /// <remarks>
     /// Use this to add, remove, or reorder file processing handlers. The first handler
-    /// where <see cref="IAIFileProcessingHandler.CanHandle"/> returns <c>true</c> wins.
+    /// where <see cref="IAIFileProcessingHandler.CanHandleAsync"/> returns <c>true</c> wins.
     /// <code>
     /// builder.AIFileProcessingHandlers()
     ///     .Append&lt;CsvFileProcessingHandler&gt;()

--- a/Umbraco.AI/src/Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.cs
@@ -90,7 +90,8 @@ public static partial class UmbracoBuilderExtensions
         // Middleware is applied in order: first = innermost (closest to provider), last = outermost
         // File processing handlers (extensible - add custom handlers via AIFileProcessingHandlers())
         builder.AIFileProcessingHandlers()
-            .Append<OpenXmlFileProcessingHandler>();
+            .Append<OpenXmlFileProcessingHandler>()
+            .Append<AudioTranscriptionFileProcessingHandler>();
 
         builder.AIChatMiddleware()
             .Append<AIOpenTelemetryChatMiddleware>()          // OpenTelemetry tracing + metrics (innermost - zero cost when unconfigured)

--- a/Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/AIFileProcessingChatClient.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/AIFileProcessingChatClient.cs
@@ -117,7 +117,7 @@ internal sealed class AIFileProcessingChatClient : DelegatingChatClient
                     }
                 }
 
-                var handler = FindHandler(dataContent.MediaType);
+                var handler = await FindHandlerAsync(dataContent.MediaType, cancellationToken);
                 if (handler is null)
                 {
                     // No handler for this type — pass through (images, PDFs, etc.)
@@ -156,11 +156,11 @@ internal sealed class AIFileProcessingChatClient : DelegatingChatClient
         return result;
     }
 
-    private IAIFileProcessingHandler? FindHandler(string mimeType)
+    private async Task<IAIFileProcessingHandler?> FindHandlerAsync(string mimeType, CancellationToken cancellationToken)
     {
         foreach (var handler in _handlers)
         {
-            if (handler.CanHandle(mimeType))
+            if (await handler.CanHandleAsync(mimeType, cancellationToken))
             {
                 return handler;
             }

--- a/Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/AIFileProcessingHandlerCollectionBuilder.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/AIFileProcessingHandlerCollectionBuilder.cs
@@ -12,7 +12,7 @@ namespace Umbraco.AI.Core.FileProcessing;
 ///     .Append&lt;OpenXmlFileProcessingHandler&gt;()
 ///     .InsertBefore&lt;OpenXmlFileProcessingHandler, CsvFileProcessingHandler&gt;();
 /// </code>
-/// The first handler where <see cref="IAIFileProcessingHandler.CanHandle"/> returns <c>true</c> wins.
+/// The first handler where <see cref="IAIFileProcessingHandler.CanHandleAsync"/> returns <c>true</c> wins.
 /// </remarks>
 public class AIFileProcessingHandlerCollectionBuilder
     : OrderedCollectionBuilderBase<AIFileProcessingHandlerCollectionBuilder, AIFileProcessingHandlerCollection, IAIFileProcessingHandler>

--- a/Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/AudioTranscriptionFileProcessingHandler.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/AudioTranscriptionFileProcessingHandler.cs
@@ -1,0 +1,79 @@
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Umbraco.AI.Core.Models;
+using Umbraco.AI.Core.Profiles;
+using Umbraco.AI.Core.SpeechToText;
+
+#pragma warning disable MEAI001 // SpeechToTextResponse is experimental in M.E.AI
+
+namespace Umbraco.AI.Core.FileProcessing;
+
+/// <summary>
+/// Transcribes uploaded audio files to text using the default speech-to-text profile,
+/// so that audio attachments can be understood by chat models.
+/// </summary>
+/// <remarks>
+/// This handler only activates when a default speech-to-text profile is configured. When no
+/// default is configured the audio is left untouched and passed through to the model, which
+/// allows natively multimodal models to handle it themselves.
+/// </remarks>
+internal sealed class AudioTranscriptionFileProcessingHandler : IAIFileProcessingHandler
+{
+    private const string AudioMimeTypePrefix = "audio/";
+
+    private readonly IAIProfileService _profileService;
+    private readonly IAISpeechToTextService _speechToTextService;
+    private readonly ILogger<AudioTranscriptionFileProcessingHandler> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AudioTranscriptionFileProcessingHandler"/> class.
+    /// </summary>
+    public AudioTranscriptionFileProcessingHandler(
+        IAIProfileService profileService,
+        IAISpeechToTextService speechToTextService,
+        ILogger<AudioTranscriptionFileProcessingHandler> logger)
+    {
+        _profileService = profileService;
+        _speechToTextService = speechToTextService;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> CanHandleAsync(string mimeType, CancellationToken cancellationToken = default)
+    {
+        if (!mimeType.StartsWith(AudioMimeTypePrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        // Only claim audio files when a default speech-to-text profile is configured;
+        // otherwise leave the audio untouched so a multimodal model can handle it natively.
+        return await _profileService.HasDefaultProfileAsync(AICapability.SpeechToText, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<AIFileProcessingResult> ProcessAsync(
+        ReadOnlyMemory<byte> data,
+        string mimeType,
+        string? filename,
+        CancellationToken cancellationToken = default)
+    {
+        await using var stream = MemoryMarshal.TryGetArray(data, out var segment)
+            ? new MemoryStream(segment.Array!, segment.Offset, segment.Count, writable: false)
+            : new MemoryStream(data.ToArray());
+
+        var response = await _speechToTextService.TranscribeAsync(
+            b => b.WithAlias("file-processing-transcription"),
+            stream,
+            cancellationToken);
+
+        var text = response.Text ?? string.Empty;
+
+        _logger.LogDebug(
+            "Transcribed audio file \"{Filename}\" ({MimeType}), text length {TextLength}",
+            filename, mimeType, text.Length);
+
+        return new AIFileProcessingResult(text, WasTruncated: false);
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/IAIFileProcessingHandler.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/IAIFileProcessingHandler.cs
@@ -13,9 +13,14 @@ public interface IAIFileProcessingHandler
     /// <summary>
     /// Determines whether this handler can process files of the specified MIME type.
     /// </summary>
+    /// <remarks>
+    /// This is asynchronous because a handler's eligibility can depend on runtime state
+    /// (e.g., whether a default AI profile is configured), not just the MIME type alone.
+    /// </remarks>
     /// <param name="mimeType">The MIME type to check.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns><c>true</c> if this handler can process the MIME type; otherwise, <c>false</c>.</returns>
-    bool CanHandle(string mimeType);
+    Task<bool> CanHandleAsync(string mimeType, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Extracts text content from the given file data.

--- a/Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/OpenXmlFileProcessingHandler.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/OpenXmlFileProcessingHandler.cs
@@ -29,7 +29,8 @@ internal sealed class OpenXmlFileProcessingHandler : IAIFileProcessingHandler
     };
 
     /// <inheritdoc />
-    public bool CanHandle(string mimeType) => SupportedMimeTypes.Contains(mimeType);
+    public Task<bool> CanHandleAsync(string mimeType, CancellationToken cancellationToken = default)
+        => Task.FromResult(SupportedMimeTypes.Contains(mimeType));
 
     /// <inheritdoc />
     public Task<AIFileProcessingResult> ProcessAsync(

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/FileProcessing/AIFileProcessingChatClientTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/FileProcessing/AIFileProcessingChatClientTests.cs
@@ -239,7 +239,8 @@ public class AIFileProcessingChatClientTests
             _content = content;
         }
 
-        public bool CanHandle(string mimeType) => string.Equals(mimeType, _mimeType, StringComparison.OrdinalIgnoreCase);
+        public Task<bool> CanHandleAsync(string mimeType, CancellationToken cancellationToken = default)
+            => Task.FromResult(string.Equals(mimeType, _mimeType, StringComparison.OrdinalIgnoreCase));
 
         public Task<AIFileProcessingResult> ProcessAsync(
             ReadOnlyMemory<byte> data, string mimeType, string? filename,

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/FileProcessing/AudioTranscriptionFileProcessingHandlerTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/FileProcessing/AudioTranscriptionFileProcessingHandlerTests.cs
@@ -1,0 +1,110 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Shouldly;
+using Umbraco.AI.Core.FileProcessing;
+using Umbraco.AI.Core.Models;
+using Umbraco.AI.Core.Profiles;
+using Umbraco.AI.Core.SpeechToText;
+
+#pragma warning disable MEAI001 // SpeechToTextResponse is experimental in M.E.AI
+
+namespace Umbraco.AI.Tests.Unit.FileProcessing;
+
+public class AudioTranscriptionFileProcessingHandlerTests
+{
+    private readonly Mock<IAIProfileService> _profileService = new();
+    private readonly Mock<IAISpeechToTextService> _speechToTextService = new();
+
+    private AudioTranscriptionFileProcessingHandler CreateHandler()
+        => new(_profileService.Object, _speechToTextService.Object, NullLogger<AudioTranscriptionFileProcessingHandler>.Instance);
+
+    #region CanHandleAsync
+
+    [Theory]
+    [InlineData("application/pdf")]
+    [InlineData("image/png")]
+    [InlineData("text/plain")]
+    [InlineData("application/vnd.openxmlformats-officedocument.wordprocessingml.document")]
+    public async Task CanHandleAsync_WithNonAudioMimeType_ReturnsFalse(string mimeType)
+    {
+        var handler = CreateHandler();
+
+        var result = await handler.CanHandleAsync(mimeType);
+
+        result.ShouldBeFalse();
+        // Should short-circuit before checking for a configured profile.
+        _profileService.Verify(
+            s => s.HasDefaultProfileAsync(It.IsAny<AICapability>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Theory]
+    [InlineData("audio/mpeg")]
+    [InlineData("audio/wav")]
+    [InlineData("AUDIO/MP4")]
+    public async Task CanHandleAsync_WithAudioMimeType_AndDefaultProfileConfigured_ReturnsTrue(string mimeType)
+    {
+        _profileService
+            .Setup(s => s.HasDefaultProfileAsync(AICapability.SpeechToText, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        var handler = CreateHandler();
+
+        var result = await handler.CanHandleAsync(mimeType);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task CanHandleAsync_WithAudioMimeType_AndNoDefaultProfile_ReturnsFalse()
+    {
+        _profileService
+            .Setup(s => s.HasDefaultProfileAsync(AICapability.SpeechToText, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        var handler = CreateHandler();
+
+        var result = await handler.CanHandleAsync("audio/mpeg");
+
+        result.ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region ProcessAsync
+
+    [Fact]
+    public async Task ProcessAsync_TranscribesAudioStream_ReturnsTranscribedText()
+    {
+        const string transcription = "Hello from the audio file.";
+        _speechToTextService
+            .Setup(s => s.TranscribeAsync(
+                It.IsAny<Action<AISpeechToTextBuilder>>(),
+                It.IsAny<Stream>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SpeechToTextResponse(transcription));
+        var handler = CreateHandler();
+
+        var result = await handler.ProcessAsync(new byte[] { 1, 2, 3 }, "audio/mpeg", "recording.mp3");
+
+        result.Content.ShouldBe(transcription);
+        result.WasTruncated.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithNullTranscriptionText_ReturnsEmptyContent()
+    {
+        _speechToTextService
+            .Setup(s => s.TranscribeAsync(
+                It.IsAny<Action<AISpeechToTextBuilder>>(),
+                It.IsAny<Stream>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SpeechToTextResponse((string?)null));
+        var handler = CreateHandler();
+
+        var result = await handler.ProcessAsync(new byte[] { 1, 2, 3 }, "audio/mpeg", "recording.mp3");
+
+        result.Content.ShouldBe(string.Empty);
+    }
+
+    #endregion
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/FileProcessing/OpenXmlFileProcessingHandlerTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/FileProcessing/OpenXmlFileProcessingHandlerTests.cs
@@ -28,9 +28,9 @@ public class OpenXmlFileProcessingHandlerTests
     [InlineData("image/png", false)]
     [InlineData("text/plain", false)]
     [InlineData("application/octet-stream", false)]
-    public void CanHandle_WithMimeType_ReturnsExpected(string mimeType, bool expected)
+    public async Task CanHandleAsync_WithMimeType_ReturnsExpected(string mimeType, bool expected)
     {
-        _handler.CanHandle(mimeType).ShouldBe(expected);
+        (await _handler.CanHandleAsync(mimeType)).ShouldBe(expected);
     }
 
     #endregion


### PR DESCRIPTION
## What

Adds audio transcription to the **file-processing pipeline** (`IAIFileProcessingHandler`) — the same mechanism that already converts Word/Excel/PowerPoint uploads into text before they reach the LLM.

When an audio file is uploaded into a chat, a new `AudioTranscriptionFileProcessingHandler`:
- **Checks for a configured default speech-to-text profile** (`HasDefaultProfileAsync(AICapability.SpeechToText)`). If one is configured, it transcribes the audio via `IAISpeechToTextService` and replaces the attachment with the transcribed text.
- If **no** default STT profile is configured, it leaves the audio untouched so a natively-multimodal model can still handle it.

## Changes

- **New**: `AudioTranscriptionFileProcessingHandler` (`Umbraco.AI.Core/FileProcessing/`), registered after `OpenXmlFileProcessingHandler`.
- **Breaking**: `IAIFileProcessingHandler.CanHandle(string)` → `CanHandleAsync(string, CancellationToken)` so handler eligibility can depend on runtime state, not just the MIME type. Updated the existing `OpenXmlFileProcessingHandler` impl, the `AIFileProcessingChatClient` caller, and doc-comments.
- **Tests**: new `AudioTranscriptionFileProcessingHandlerTests`; updated `OpenXmlFileProcessingHandlerTests` and the `FakeHandler` in `AIFileProcessingChatClientTests` for the async signature.

## Breaking change

`IAIFileProcessingHandler.CanHandle(string)` is now `CanHandleAsync(string, CancellationToken)`. Custom handler implementations must update their signature (typically `=> Task.FromResult(...)`).

## Testing

- `dotnet build` clean.
- Full FileProcessing unit suite passes (33 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)