### PR TITLE
feat(automate): Always expose raw agent response as a bindable property

### DIFF
--- a/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Actions/RunAgentAction.cs
+++ b/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Actions/RunAgentAction.cs
@@ -158,7 +158,7 @@ public sealed class RunAgentAction : ActionBase<RunAgentSettings, object>
                 "Automation {AutomationId} / Run {RunId}: Agent {AgentId} responded with {MessageCount} message(s), text length {TextLength}",
                 context.AutomationId, context.RunId, settings.AgentId, response.Messages.Count, responseText.Length);
 
-            var outputData = TryParseStructuredOutput(responseText);
+            var outputData = BuildOutputData(responseText);
 
             return Success(outputData);
         }
@@ -179,11 +179,30 @@ public sealed class RunAgentAction : ActionBase<RunAgentSettings, object>
         }
     }
 
-    private static object TryParseStructuredOutput(string responseText)
+    /// <summary>
+    /// The reserved output property that always holds the agent's raw response text,
+    /// regardless of whether the agent uses a structured output schema. This guarantees
+    /// a bindable property is always available to downstream automation steps.
+    /// </summary>
+    public const string RawResponseKey = "response";
+
+    /// <summary>
+    /// Builds the action output data from the agent's raw response text.
+    /// The raw text is always exposed under the reserved <see cref="RawResponseKey"/> property.
+    /// If the response is a JSON object (structured output), its properties are merged in
+    /// alongside the raw response so both forms are bindable. The reserved raw response key
+    /// is never overwritten by a structured property of the same name.
+    /// </summary>
+    private static Dictionary<string, object?> BuildOutputData(string responseText)
     {
+        var output = new Dictionary<string, object?>
+        {
+            [RawResponseKey] = responseText ?? string.Empty,
+        };
+
         if (string.IsNullOrWhiteSpace(responseText))
         {
-            return new { response = string.Empty };
+            return output;
         }
 
         try
@@ -191,15 +210,24 @@ public sealed class RunAgentAction : ActionBase<RunAgentSettings, object>
             var parsed = JsonSerializer.Deserialize<Dictionary<string, object?>>(responseText);
             if (parsed is not null)
             {
-                return parsed;
+                foreach (var (key, value) in parsed)
+                {
+                    // Don't let a structured property clobber the reserved raw response key.
+                    if (key == RawResponseKey)
+                    {
+                        continue;
+                    }
+
+                    output[key] = value;
+                }
             }
         }
         catch (JsonException)
         {
-            // Not valid JSON -- fall through to plain text response
+            // Not valid JSON -- the raw text is already captured under RawResponseKey.
         }
 
-        return new { response = responseText };
+        return output;
     }
 
     private async Task<IEnumerable<Guid>?> ResolveServiceAccountGroupIdsAsync(ActionContext context)

--- a/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Actions/RunAgentAction.cs
+++ b/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Actions/RunAgentAction.cs
@@ -184,7 +184,7 @@ public sealed class RunAgentAction : ActionBase<RunAgentSettings, object>
     /// regardless of whether the agent uses a structured output schema. This guarantees
     /// a bindable property is always available to downstream automation steps.
     /// </summary>
-    public const string RawResponseKey = "response";
+    public const string RawResponseKey = "rawResponse";
 
     /// <summary>
     /// Builds the action output data from the agent's raw response text.

--- a/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Actions/RunAgentAction.cs
+++ b/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Actions/RunAgentAction.cs
@@ -184,7 +184,7 @@ public sealed class RunAgentAction : ActionBase<RunAgentSettings, object>
     /// regardless of whether the agent uses a structured output schema. This guarantees
     /// a bindable property is always available to downstream automation steps.
     /// </summary>
-    public const string RawResponseKey = "rawResponse";
+    public const string RawResponseKey = "response";
 
     /// <summary>
     /// Builds the action output data from the agent's raw response text.

--- a/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Helpers/AgentOutputSchemaHelper.cs
+++ b/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Helpers/AgentOutputSchemaHelper.cs
@@ -1,8 +1,10 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Json.Schema;
 using Json.Schema.Generation;
 using Umbraco.AI.Agent.Core.Agents;
 using Umbraco.AI.Agent.Extensions;
+using Umbraco.AI.Automate.Actions;
 
 namespace Umbraco.AI.Automate.Helpers;
 
@@ -13,17 +15,19 @@ internal static class AgentOutputSchemaHelper
 {
     /// <summary>
     /// Schema returned when the agent has no structured output configured.
-    /// Matches the <c>{ response: "..." }</c> shape produced by <c>TryParseStructuredOutput</c>.
+    /// Matches the <c>{ response: "..." }</c> shape produced by <c>BuildOutputData</c>.
     /// </summary>
     private static readonly JsonSchema FallbackSchema = new JsonSchemaBuilder()
         .Type(SchemaValueType.Object)
         .Properties(
-            ("response", new JsonSchemaBuilder().Type(SchemaValueType.String)))
+            (RunAgentAction.RawResponseKey, new JsonSchemaBuilder().Type(SchemaValueType.String)))
         .Build();
 
     /// <summary>
-    /// Gets the output JSON Schema for an agent. Returns the agent's configured output schema
-    /// if available, otherwise returns a fallback schema with a single <c>response</c> string property.
+    /// Gets the output JSON Schema for an agent. The raw <c>response</c> string property is always
+    /// included so a bindable property is available even when the agent has no structured output
+    /// (or returns text that doesn't match its schema). When the agent has a structured output
+    /// schema, its properties are merged alongside the raw <c>response</c> property.
     /// </summary>
     internal static async Task<JsonSchema> GetOutputSchemaAsync(
         IAIAgentService agentService,
@@ -38,6 +42,22 @@ internal static class AgentOutputSchemaHelper
             return FallbackSchema;
         }
 
-        return JsonSchema.FromText(outputSchema.Value.GetRawText());
+        // Merge the agent's structured schema with the always-present raw `response` property.
+        if (JsonNode.Parse(outputSchema.Value.GetRawText()) is not JsonObject schemaObject)
+        {
+            return FallbackSchema;
+        }
+
+        if (schemaObject["properties"] is not JsonObject properties)
+        {
+            properties = new JsonObject();
+            schemaObject["properties"] = properties;
+        }
+
+        // The reserved raw response is always a string and always takes this slot, so downstream
+        // steps can rely on `response` regardless of what the structured schema declares.
+        properties[RunAgentAction.RawResponseKey] = new JsonObject { ["type"] = "string" };
+
+        return JsonSchema.FromText(schemaObject.ToJsonString());
     }
 }

--- a/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Helpers/AgentOutputSchemaHelper.cs
+++ b/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Helpers/AgentOutputSchemaHelper.cs
@@ -15,7 +15,7 @@ internal static class AgentOutputSchemaHelper
 {
     /// <summary>
     /// Schema returned when the agent has no structured output configured.
-    /// Matches the <c>{ response: "..." }</c> shape produced by <c>BuildOutputData</c>.
+    /// Matches the <c>{ rawResponse: "..." }</c> shape produced by <c>BuildOutputData</c>.
     /// </summary>
     private static readonly JsonSchema FallbackSchema = new JsonSchemaBuilder()
         .Type(SchemaValueType.Object)
@@ -24,10 +24,10 @@ internal static class AgentOutputSchemaHelper
         .Build();
 
     /// <summary>
-    /// Gets the output JSON Schema for an agent. The raw <c>response</c> string property is always
+    /// Gets the output JSON Schema for an agent. The raw <c>rawResponse</c> string property is always
     /// included so a bindable property is available even when the agent has no structured output
     /// (or returns text that doesn't match its schema). When the agent has a structured output
-    /// schema, its properties are merged alongside the raw <c>response</c> property.
+    /// schema, its properties are merged alongside the raw <c>rawResponse</c> property.
     /// </summary>
     internal static async Task<JsonSchema> GetOutputSchemaAsync(
         IAIAgentService agentService,
@@ -55,7 +55,7 @@ internal static class AgentOutputSchemaHelper
         }
 
         // The reserved raw response is always a string and always takes this slot, so downstream
-        // steps can rely on `response` regardless of what the structured schema declares.
+        // steps can rely on `rawResponse` regardless of what the structured schema declares.
         properties[RunAgentAction.RawResponseKey] = new JsonObject { ["type"] = "string" };
 
         return JsonSchema.FromText(schemaObject.ToJsonString());

--- a/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Helpers/AgentOutputSchemaHelper.cs
+++ b/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Helpers/AgentOutputSchemaHelper.cs
@@ -15,7 +15,7 @@ internal static class AgentOutputSchemaHelper
 {
     /// <summary>
     /// Schema returned when the agent has no structured output configured.
-    /// Matches the <c>{ rawResponse: "..." }</c> shape produced by <c>BuildOutputData</c>.
+    /// Matches the <c>{ response: "..." }</c> shape produced by <c>BuildOutputData</c>.
     /// </summary>
     private static readonly JsonSchema FallbackSchema = new JsonSchemaBuilder()
         .Type(SchemaValueType.Object)
@@ -24,10 +24,10 @@ internal static class AgentOutputSchemaHelper
         .Build();
 
     /// <summary>
-    /// Gets the output JSON Schema for an agent. The raw <c>rawResponse</c> string property is always
+    /// Gets the output JSON Schema for an agent. The raw <c>response</c> string property is always
     /// included so a bindable property is available even when the agent has no structured output
     /// (or returns text that doesn't match its schema). When the agent has a structured output
-    /// schema, its properties are merged alongside the raw <c>rawResponse</c> property.
+    /// schema, its properties are merged alongside the raw <c>response</c> property.
     /// </summary>
     internal static async Task<JsonSchema> GetOutputSchemaAsync(
         IAIAgentService agentService,
@@ -55,7 +55,7 @@ internal static class AgentOutputSchemaHelper
         }
 
         // The reserved raw response is always a string and always takes this slot, so downstream
-        // steps can rely on `rawResponse` regardless of what the structured schema declares.
+        // steps can rely on `response` regardless of what the structured schema declares.
         properties[RunAgentAction.RawResponseKey] = new JsonObject { ["type"] = "string" };
 
         return JsonSchema.FromText(schemaObject.ToJsonString());

--- a/Umbraco.AI.Automate/tests/Umbraco.AI.Automate.Tests.Unit/Actions/RunAgentActionTests.cs
+++ b/Umbraco.AI.Automate/tests/Umbraco.AI.Automate.Tests.Unit/Actions/RunAgentActionTests.cs
@@ -71,6 +71,47 @@ public class RunAgentActionTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_WithPlainTextResponse_ExposesRawResponseProperty()
+    {
+        // Arrange
+        var agent = new AIAgent
+        {
+            Alias = "test-agent",
+            Name = "Test Agent",
+        };
+
+        var responseMessage = new ChatMessage(ChatRole.Assistant, "Hello from agent!");
+        var agentResponse = new AgentResponse(responseMessage);
+
+        _agentServiceMock
+            .Setup(s => s.GetAgentAsync(TestAgentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        _agentServiceMock
+            .Setup(s => s.RunAgentAsync(
+                agent.Id,
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<AIAgentExecutionOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agentResponse);
+
+        var action = CreateAction();
+        var context = CreateContext(new RunAgentSettings
+        {
+            AgentId = TestAgentId,
+            Message = "Hello",
+        });
+
+        // Act
+        var result = await action.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.Status.ShouldBe(ActionResultStatus.Success);
+        var output = result.OutputData.ShouldBeOfType<Dictionary<string, object?>>();
+        output[RunAgentAction.RawResponseKey]?.ToString().ShouldBe("Hello from agent!");
+    }
+
+    [Fact]
     public async Task ExecuteAsync_PopulatesAuditMetadataKeysOnExecutionOptions()
     {
         // Arrange
@@ -168,6 +209,10 @@ public class RunAgentActionTests
         result.Status.ShouldBe(ActionResultStatus.Success);
         var output = result.OutputData.ShouldBeOfType<Dictionary<string, object?>>();
         output["summary"]?.ToString().ShouldBe("A test summary");
+
+        // The raw response is always exposed alongside the parsed structured properties.
+        output.ShouldContainKey(RunAgentAction.RawResponseKey);
+        output[RunAgentAction.RawResponseKey]?.ToString().ShouldBe(jsonResponse);
     }
 
     [Fact]

--- a/Umbraco.AI.Automate/tests/Umbraco.AI.Automate.Tests.Unit/Helpers/AgentOutputSchemaHelperTests.cs
+++ b/Umbraco.AI.Automate/tests/Umbraco.AI.Automate.Tests.Unit/Helpers/AgentOutputSchemaHelperTests.cs
@@ -1,0 +1,69 @@
+using System.Text.Json;
+using Json.Schema;
+using Moq;
+using Shouldly;
+using Umbraco.AI.Agent.Core.Agents;
+using Umbraco.AI.Automate.Actions;
+using Umbraco.AI.Automate.Helpers;
+using Xunit;
+using AIAgent = Umbraco.AI.Agent.Core.Agents.AIAgent;
+
+namespace Umbraco.AI.Automate.Tests.Unit.Helpers;
+
+public class AgentOutputSchemaHelperTests
+{
+    private readonly Mock<IAIAgentService> _agentServiceMock = new();
+    private static readonly Guid TestAgentId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    [Fact]
+    public async Task GetOutputSchemaAsync_WithNoStructuredOutput_ReturnsRawResponseSchema()
+    {
+        // Arrange
+        var agent = new AIAgent { Alias = "a", Name = "A", Config = new AIStandardAgentConfig() };
+        _agentServiceMock
+            .Setup(s => s.GetAgentAsync(TestAgentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        // Act
+        var schema = await AgentOutputSchemaHelper.GetOutputSchemaAsync(_agentServiceMock.Object, TestAgentId);
+
+        // Assert
+        var properties = PropertyNames(schema);
+        properties.ShouldContain(RunAgentAction.RawResponseKey);
+    }
+
+    [Fact]
+    public async Task GetOutputSchemaAsync_WithStructuredOutput_IncludesRawResponseAlongsideStructuredProperties()
+    {
+        // Arrange
+        var outputSchema = JsonSerializer.Deserialize<JsonElement>(
+            """{"type":"object","properties":{"summary":{"type":"string"},"score":{"type":"integer"}}}""");
+
+        var agent = new AIAgent
+        {
+            Alias = "a",
+            Name = "A",
+            Config = new AIStandardAgentConfig { OutputSchema = outputSchema },
+        };
+
+        _agentServiceMock
+            .Setup(s => s.GetAgentAsync(TestAgentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        // Act
+        var schema = await AgentOutputSchemaHelper.GetOutputSchemaAsync(_agentServiceMock.Object, TestAgentId);
+
+        // Assert
+        var properties = PropertyNames(schema);
+        properties.ShouldContain("summary");
+        properties.ShouldContain("score");
+        properties.ShouldContain(RunAgentAction.RawResponseKey);
+    }
+
+    private static IReadOnlyCollection<string> PropertyNames(JsonSchema schema)
+    {
+        var properties = schema.GetProperties();
+        properties.ShouldNotBeNull();
+        return properties!.Keys.ToList();
+    }
+}


### PR DESCRIPTION
## Summary

The **Run AI Agent** Automate action now always exposes the agent's raw response text under a reserved `response` bindable property — in both the output schema and the output data — regardless of whether the agent uses structured output.

Previously the raw response was only available when the agent had no structured output configured. When structured output *was* configured but the model returned non-JSON (or didn't comply with its schema), the declared schema properties wouldn't line up with the actual output, leaving **nothing bindable**. Structured output properties are now merged *alongside* the always-present `response`, so both forms are bindable.

## Behavior before vs after

| Case | Before | After |
|------|--------|-------|
| No structured output | `{ response }` | `{ response }` |
| Structured, valid JSON | `{ summary, score }` (raw lost) | `{ response, summary, score }` |
| Structured configured, model returns non-JSON | schema/data mismatch — nothing bindable | `{ response }` |

## Changes

- **`RunAgentAction.cs`** — added reserved `RawResponseKey = "response"`; `BuildOutputData` always seeds output with the raw text, then merges structured props without clobbering the reserved key.
- **`AgentOutputSchemaHelper.cs`** — schema always declares `response` (string); structured schema properties are merged alongside it.

`response` is a reserved key (always the raw text string). It keeps the existing property name early testers already bind to. If a structured output schema also defines a field named `response`, the raw text takes precedence.

## Tests

All 40 Automate unit tests pass, including new coverage:
- Plain-text response exposes `response`
- Structured JSON exposes `response` alongside parsed props
- New `AgentOutputSchemaHelperTests`: schema includes `response` with and without structured output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
