### PR TITLE
fix(settings): Route editable models through the editable model service

### DIFF
--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Tests/AgentTestFeature.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Tests/AgentTestFeature.cs
@@ -33,6 +33,7 @@ public class AgentTestFeature : AITestFeatureBase<AgentTestFeatureConfig>
     /// <summary>
     /// Initializes a new instance of the <see cref="AgentTestFeature"/> class.
     /// </summary>
+    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
     public AgentTestFeature(
         IAIAgentService agentService,
         IAGUIContextConverter contextConverter,
@@ -41,6 +42,25 @@ public class AgentTestFeature : AITestFeatureBase<AgentTestFeatureConfig>
         AITestContextResolver contextResolver,
         IAIEditableModelSchemaBuilder schemaBuilder)
         : base(contextResolver, schemaBuilder)
+    {
+        _agentService = agentService;
+        _contextConverter = contextConverter;
+        _scopeProvider = scopeProvider;
+        _contributors = contributors;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentTestFeature"/> class.
+    /// </summary>
+    public AgentTestFeature(
+        IAIAgentService agentService,
+        IAGUIContextConverter contextConverter,
+        IAIRuntimeContextScopeProvider scopeProvider,
+        AIRuntimeContextContributorCollection contributors,
+        AITestContextResolver contextResolver,
+        IAIEditableModelSchemaBuilder schemaBuilder,
+        IAIEditableModelResolver resolver)
+        : base(contextResolver, schemaBuilder, resolver)
     {
         _agentService = agentService;
         _contextConverter = contextConverter;
@@ -78,8 +98,8 @@ public class AgentTestFeature : AITestFeatureBase<AgentTestFeatureConfig>
         IEnumerable<Guid>? guardrailIdsOverride,
         CancellationToken cancellationToken)
     {
-        // Get strongly-typed config
-        var config = test.GetTestFeatureConfig<AgentTestFeatureConfig>();
+        // Get strongly-typed config (resolves $Config app-settings references and validates)
+        var config = ResolveTestFeatureConfig(test);
         if (config == null)
         {
             throw new InvalidOperationException("Failed to deserialize test feature config");

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Tests/AgentTestFeature.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Tests/AgentTestFeature.cs
@@ -33,22 +33,6 @@ public class AgentTestFeature : AITestFeatureBase<AgentTestFeatureConfig>
     /// <summary>
     /// Initializes a new instance of the <see cref="AgentTestFeature"/> class.
     /// </summary>
-    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
-    public AgentTestFeature(
-        IAIAgentService agentService,
-        IAGUIContextConverter contextConverter,
-        IAIRuntimeContextScopeProvider scopeProvider,
-        AIRuntimeContextContributorCollection contributors,
-        AITestContextResolver contextResolver,
-        IAIEditableModelSchemaBuilder schemaBuilder)
-        : base(contextResolver, schemaBuilder)
-    {
-        _agentService = agentService;
-        _contextConverter = contextConverter;
-        _scopeProvider = scopeProvider;
-        _contributors = contributors;
-    }
-
     /// <summary>
     /// Initializes a new instance of the <see cref="AgentTestFeature"/> class.
     /// </summary>
@@ -57,10 +41,8 @@ public class AgentTestFeature : AITestFeatureBase<AgentTestFeatureConfig>
         IAGUIContextConverter contextConverter,
         IAIRuntimeContextScopeProvider scopeProvider,
         AIRuntimeContextContributorCollection contributors,
-        AITestContextResolver contextResolver,
-        IAIEditableModelSchemaBuilder schemaBuilder,
-        IAIEditableModelResolver resolver)
-        : base(contextResolver, schemaBuilder, resolver)
+        IAITestFeatureInfrastructure infrastructure)
+        : base(infrastructure)
     {
         _agentService = agentService;
         _contextConverter = contextConverter;

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Tests/PromptTestFeature.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Tests/PromptTestFeature.cs
@@ -22,11 +22,25 @@ public class PromptTestFeature : AITestFeatureBase<PromptTestFeatureConfig>
     /// <summary>
     /// Initializes a new instance of the <see cref="PromptTestFeature"/> class.
     /// </summary>
+    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
     public PromptTestFeature(
         IAIPromptService promptService,
         AITestContextResolver contextResolver,
         IAIEditableModelSchemaBuilder schemaBuilder)
         : base(contextResolver, schemaBuilder)
+    {
+        _promptService = promptService;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PromptTestFeature"/> class.
+    /// </summary>
+    public PromptTestFeature(
+        IAIPromptService promptService,
+        AITestContextResolver contextResolver,
+        IAIEditableModelSchemaBuilder schemaBuilder,
+        IAIEditableModelResolver resolver)
+        : base(contextResolver, schemaBuilder, resolver)
     {
         _promptService = promptService;
     }
@@ -71,8 +85,8 @@ public class PromptTestFeature : AITestFeatureBase<PromptTestFeatureConfig>
         IEnumerable<Guid>? guardrailIdsOverride,
         CancellationToken cancellationToken)
     {
-        // Deserialize test feature config
-        var config = test.GetTestFeatureConfig<PromptTestFeatureConfig>();
+        // Resolve test feature config (resolves $Config app-settings references and validates)
+        var config = ResolveTestFeatureConfig(test);
         if (config == null)
         {
             throw new InvalidOperationException("Failed to deserialize test feature config");

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Tests/PromptTestFeature.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Tests/PromptTestFeature.cs
@@ -22,25 +22,13 @@ public class PromptTestFeature : AITestFeatureBase<PromptTestFeatureConfig>
     /// <summary>
     /// Initializes a new instance of the <see cref="PromptTestFeature"/> class.
     /// </summary>
-    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
-    public PromptTestFeature(
-        IAIPromptService promptService,
-        AITestContextResolver contextResolver,
-        IAIEditableModelSchemaBuilder schemaBuilder)
-        : base(contextResolver, schemaBuilder)
-    {
-        _promptService = promptService;
-    }
-
     /// <summary>
     /// Initializes a new instance of the <see cref="PromptTestFeature"/> class.
     /// </summary>
     public PromptTestFeature(
         IAIPromptService promptService,
-        AITestContextResolver contextResolver,
-        IAIEditableModelSchemaBuilder schemaBuilder,
-        IAIEditableModelResolver resolver)
-        : base(contextResolver, schemaBuilder, resolver)
+        IAITestFeatureInfrastructure infrastructure)
+        : base(infrastructure)
     {
         _promptService = promptService;
     }

--- a/Umbraco.AI.Prompt/tests/Umbraco.AI.Prompt.Tests.Unit/Tests/PromptTestFeatureTests.cs
+++ b/Umbraco.AI.Prompt/tests/Umbraco.AI.Prompt.Tests.Unit/Tests/PromptTestFeatureTests.cs
@@ -20,8 +20,10 @@ public class PromptTestFeatureTests
 {
     private readonly PromptTestFeature _feature = new(
         Mock.Of<IAIPromptService>(),
-        new AITestContextResolver(),
-        Mock.Of<IAIEditableModelSchemaBuilder>());
+        Mock.Of<IAITestFeatureInfrastructure>(x =>
+            x.ContextResolver == new AITestContextResolver() &&
+            x.SchemaBuilder == Mock.Of<IAIEditableModelSchemaBuilder>() &&
+            x.ModelResolver == Mock.Of<IAIEditableModelResolver>()));
 
     [Fact]
     public void ExtractOutputValue_SingleOption_ReturnsDisplayValue()

--- a/Umbraco.AI/src/Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.cs
@@ -229,6 +229,7 @@ public static partial class UmbracoBuilderExtensions
         services.AddSingleton<IAIGuardrailService, AIGuardrailService>();
 
         // Guardrail evaluator infrastructure - auto-discover via [AIGuardrailEvaluator] attribute
+        services.AddSingleton<IAIGuardrailEvaluatorInfrastructure, AIGuardrailEvaluatorInfrastructure>();
         builder.AIGuardrailEvaluators()
             .Add(() => builder.TypeLoader.GetTypesWithAttribute<IAIGuardrailEvaluator, AIGuardrailEvaluatorAttribute>(cache: true));
 
@@ -290,10 +291,12 @@ public static partial class UmbracoBuilderExtensions
         services.AddHostedService<AIUsageStatisticsCleanupJob>();
 
         // Auto-discover test features via [AITestFeature] attribute
+        services.AddSingleton<IAITestFeatureInfrastructure, AITestFeatureInfrastructure>();
         builder.AITestFeatures()
             .Add(() => builder.TypeLoader.GetTypesWithAttribute<IAITestFeature, AITestFeatureAttribute>(cache: true));
 
         // Auto-discover test graders via [AITestGrader] attribute
+        services.AddSingleton<IAITestGraderInfrastructure, AITestGraderInfrastructure>();
         builder.AITestGraders()
             .Add(() => builder.TypeLoader.GetTypesWithAttribute<IAITestGrader, AITestGraderAttribute>(cache: true));
 

--- a/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/AIEditableModelResolver.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/AIEditableModelResolver.cs
@@ -24,57 +24,54 @@ internal sealed class AIEditableModelResolver : IAIEditableModelResolver
     /// <inheritdoc />
     public TModel? ResolveModel<TModel>(object? data, AIEditableModelSchema? schema = null)
         where TModel : class, new()
+        => (TModel?)ResolveModel(typeof(TModel), data, schema);
+
+    /// <inheritdoc />
+    public object? ResolveModel(Type modelType, object? data, AIEditableModelSchema? schema = null)
     {
-        // If data is null, return null (or new instance if required by validation)
+        // If data is null, return null
         if (data is null)
         {
             return null;
         }
 
-        // If already correct type, clone via JSON round-trip to avoid mutating the original object,
-        // then resolve configuration variables and validate on the copy
-        if (data is TModel)
-        {
-            var json = JsonSerializer.Serialize(data, Constants.DefaultJsonSerializerOptions);
-            var deserialized = JsonSerializer.Deserialize<TModel>(json, Constants.DefaultJsonSerializerOptions);
-            if (deserialized is not null)
-            {
-                ResolveConfigurationVariablesInObject(deserialized);
-                ValidateModel(deserialized, schema);
-            }
-            return deserialized;
-        }
+        object? deserialized;
 
         // Handle JsonElement deserialization
         if (data is JsonElement jsonElement)
         {
-            var deserialized = jsonElement.Deserialize<TModel>(Constants.DefaultJsonSerializerOptions);
-            if (deserialized is not null)
+            deserialized = jsonElement.Deserialize(modelType, Constants.DefaultJsonSerializerOptions);
+        }
+        else if (modelType.IsInstanceOfType(data))
+        {
+            // Already correct type, clone via JSON round-trip to avoid mutating the original object,
+            // then resolve configuration variables and validate on the copy
+            var json = JsonSerializer.Serialize(data, Constants.DefaultJsonSerializerOptions);
+            deserialized = JsonSerializer.Deserialize(json, modelType, Constants.DefaultJsonSerializerOptions);
+        }
+        else
+        {
+            // Try to serialize/deserialize through JSON as fallback
+            try
             {
-                ResolveConfigurationVariablesInObject(deserialized);
-                ValidateModel(deserialized, schema);
+                var json = JsonSerializer.Serialize(data, Constants.DefaultJsonSerializerOptions);
+                deserialized = JsonSerializer.Deserialize(json, modelType, Constants.DefaultJsonSerializerOptions);
             }
-            return deserialized;
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to resolve model to type {modelType.Name}",
+                    ex);
+            }
         }
 
-        // Try to serialize/deserialize through JSON as fallback
-        try
+        if (deserialized is not null)
         {
-            var json = JsonSerializer.Serialize(data, Constants.DefaultJsonSerializerOptions);
-            var deserialized = JsonSerializer.Deserialize<TModel>(json, Constants.DefaultJsonSerializerOptions);
-            if (deserialized is not null)
-            {
-                ResolveConfigurationVariablesInObject(deserialized);
-                ValidateModel(deserialized, schema);
-            }
-            return deserialized;
+            ResolveConfigurationVariablesInObject(deserialized);
+            ValidateModel(deserialized, schema);
         }
-        catch (Exception ex)
-        {
-            throw new InvalidOperationException(
-                $"Failed to resolve model to type {typeof(TModel).Name}",
-                ex);
-        }
+
+        return deserialized;
     }
 
     private void ResolveConfigurationVariablesInObject(object obj)

--- a/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/AIEditableModelResolverExtensions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/AIEditableModelResolverExtensions.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Umbraco.AI.Core.Providers;
 
 namespace Umbraco.AI.Core.EditableModels;
@@ -25,9 +26,11 @@ public static class AIEditableModelResolverExtensions
         {
             var schema = provider.GetSettingsSchema();
 
-            // Use reflection to call ResolveModel<TModel>
-            var method = resolver.GetType()
-                .GetMethod(nameof(resolver.ResolveModel))!
+            // Invoke the generic ResolveModel<TModel> overload. Selecting the generic method
+            // definition explicitly avoids an ambiguous match with the non-generic overload.
+            var method = typeof(IAIEditableModelResolver)
+                .GetMethods()
+                .Single(m => m.Name == nameof(IAIEditableModelResolver.ResolveModel) && m.IsGenericMethodDefinition)
                 .MakeGenericMethod(settingsType);
 
             return method.Invoke(resolver, [settings, schema]);

--- a/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/IAIEditableModelResolver.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/IAIEditableModelResolver.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace Umbraco.AI.Core.EditableModels;
 
 /// <summary>
@@ -17,4 +19,27 @@ public interface IAIEditableModelResolver
     /// <returns>Typed model instance, or null if data parameter was null.</returns>
     TModel? ResolveModel<TModel>(object? data, AIEditableModelSchema? schema = null)
         where TModel : class, new();
+
+    /// <summary>
+    /// Resolves a model from storage format to an instance of the specified runtime type.
+    /// This non-generic overload is used when the target type is only known at runtime, such as
+    /// grader, guardrail evaluator, and test feature configuration types.
+    /// Supports configuration variable substitution using the pattern: $ConfigKey
+    /// Validates the resolved model using the schema's validation rules when a schema is provided.
+    /// </summary>
+    /// <param name="modelType">The type of model to resolve to.</param>
+    /// <param name="data">The data object to resolve (can be JsonElement, typed object, or null).</param>
+    /// <param name="schema">Optional schema for validation. When null, no validation is performed.</param>
+    /// <returns>Resolved model instance, or null if data parameter was null.</returns>
+    object? ResolveModel(Type modelType, object? data, AIEditableModelSchema? schema = null)
+    {
+        // Default implementation delegates to the generic overload via reflection so that
+        // existing custom implementations of this interface remain backwards compatible.
+        var genericMethod = typeof(IAIEditableModelResolver)
+            .GetMethods()
+            .Single(m => m.Name == nameof(ResolveModel) && m.IsGenericMethodDefinition)
+            .MakeGenericMethod(modelType);
+
+        return genericMethod.Invoke(this, new[] { data, schema });
+    }
 }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Evaluators/AIGuardrailEvaluatorBase.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Evaluators/AIGuardrailEvaluatorBase.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text.Json;
 using Microsoft.Extensions.AI;
 using Umbraco.AI.Core.EditableModels;
 
@@ -12,6 +13,7 @@ namespace Umbraco.AI.Core.Guardrails.Evaluators;
 public abstract class AIGuardrailEvaluatorBase<TConfig> : IAIGuardrailEvaluator
 {
     private readonly Lazy<AIEditableModelSchema?> _configSchema;
+    private readonly IAIEditableModelResolver? _resolver;
 
     /// <inheritdoc />
     public string Id { get; }
@@ -38,9 +40,22 @@ public abstract class AIGuardrailEvaluatorBase<TConfig> : IAIGuardrailEvaluator
     /// </summary>
     /// <param name="schemaBuilder">The schema builder.</param>
     /// <exception cref="InvalidOperationException">Thrown if the class is missing the required attribute.</exception>
+    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver so that evaluator configuration supports app-settings ($Config) resolution and validation. This constructor will be removed in a future version.")]
     protected AIGuardrailEvaluatorBase(IAIEditableModelSchemaBuilder schemaBuilder)
+        : this(schemaBuilder, resolver: null!)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AIGuardrailEvaluatorBase{TConfig}"/> class.
+    /// </summary>
+    /// <param name="schemaBuilder">The schema builder.</param>
+    /// <param name="resolver">The editable model resolver used to resolve configuration values.</param>
+    /// <exception cref="InvalidOperationException">Thrown if the class is missing the required attribute.</exception>
+    protected AIGuardrailEvaluatorBase(IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
     {
         SchemaBuilder = schemaBuilder;
+        _resolver = resolver;
 
         var attribute = GetType().GetCustomAttribute<AIGuardrailEvaluatorAttribute>(inherit: false);
         if (attribute == null)
@@ -60,6 +75,28 @@ public abstract class AIGuardrailEvaluatorBase<TConfig> : IAIGuardrailEvaluator
     /// <inheritdoc />
     public AIEditableModelSchema? GetConfigSchema()
         => _configSchema.Value;
+
+    /// <summary>
+    /// Resolves the strongly-typed evaluator configuration from the supplied <see cref="AIGuardrailConfig"/>,
+    /// applying app-settings ($Config) resolution and schema validation through the editable model resolver.
+    /// </summary>
+    /// <param name="config">The evaluator configuration wrapper.</param>
+    /// <returns>The resolved configuration, or <c>null</c> if no configuration is supplied.</returns>
+    protected TConfig? ResolveConfig(AIGuardrailConfig config)
+    {
+        if (config.Config is not { } configElement)
+        {
+            return default;
+        }
+
+        if (_resolver is not null && ConfigType is not null)
+        {
+            return (TConfig?)_resolver.ResolveModel(ConfigType, configElement, GetConfigSchema());
+        }
+
+        // Fallback for evaluators constructed via the obsolete constructor (no resolver available).
+        return configElement.Deserialize<TConfig>(Constants.DefaultJsonSerializerOptions);
+    }
 
     /// <inheritdoc />
     public abstract Task<AIGuardrailResult> EvaluateAsync(

--- a/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Evaluators/AIGuardrailEvaluatorBase.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Evaluators/AIGuardrailEvaluatorBase.cs
@@ -1,7 +1,8 @@
 using System.Reflection;
-using System.Text.Json;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
 using Umbraco.AI.Core.EditableModels;
+using Umbraco.Cms.Core.DependencyInjection;
 
 namespace Umbraco.AI.Core.Guardrails.Evaluators;
 
@@ -13,7 +14,7 @@ namespace Umbraco.AI.Core.Guardrails.Evaluators;
 public abstract class AIGuardrailEvaluatorBase<TConfig> : IAIGuardrailEvaluator
 {
     private readonly Lazy<AIEditableModelSchema?> _configSchema;
-    private readonly IAIEditableModelResolver? _resolver;
+    private readonly IAIEditableModelResolver _resolver;
 
     /// <inheritdoc />
     public string Id { get; }
@@ -40,19 +41,23 @@ public abstract class AIGuardrailEvaluatorBase<TConfig> : IAIGuardrailEvaluator
     /// </summary>
     /// <param name="schemaBuilder">The schema builder.</param>
     /// <exception cref="InvalidOperationException">Thrown if the class is missing the required attribute.</exception>
-    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver so that evaluator configuration supports app-settings ($Config) resolution and validation. This constructor will be removed in a future version.")]
+    [Obsolete("Use the constructor that accepts an IAIGuardrailEvaluatorInfrastructure so that evaluator configuration supports app-settings ($Config) resolution and validation. This constructor will be removed in a future version.")]
     protected AIGuardrailEvaluatorBase(IAIEditableModelSchemaBuilder schemaBuilder)
-        : this(schemaBuilder, resolver: null!)
+        : this(schemaBuilder, StaticServiceProvider.Instance.GetRequiredService<IAIEditableModelResolver>())
     {
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AIGuardrailEvaluatorBase{TConfig}"/> class.
     /// </summary>
-    /// <param name="schemaBuilder">The schema builder.</param>
-    /// <param name="resolver">The editable model resolver used to resolve configuration values.</param>
+    /// <param name="infrastructure">The evaluator infrastructure dependencies.</param>
     /// <exception cref="InvalidOperationException">Thrown if the class is missing the required attribute.</exception>
-    protected AIGuardrailEvaluatorBase(IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
+    protected AIGuardrailEvaluatorBase(IAIGuardrailEvaluatorInfrastructure infrastructure)
+        : this(infrastructure.SchemaBuilder, infrastructure.ModelResolver)
+    {
+    }
+
+    private AIGuardrailEvaluatorBase(IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
     {
         SchemaBuilder = schemaBuilder;
         _resolver = resolver;
@@ -89,13 +94,7 @@ public abstract class AIGuardrailEvaluatorBase<TConfig> : IAIGuardrailEvaluator
             return default;
         }
 
-        if (_resolver is not null && ConfigType is not null)
-        {
-            return (TConfig?)_resolver.ResolveModel(ConfigType, configElement, GetConfigSchema());
-        }
-
-        // Fallback for evaluators constructed via the obsolete constructor (no resolver available).
-        return configElement.Deserialize<TConfig>(Constants.DefaultJsonSerializerOptions);
+        return (TConfig?)_resolver.ResolveModel(typeof(TConfig), configElement, GetConfigSchema());
     }
 
     /// <inheritdoc />

--- a/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Evaluators/AIGuardrailEvaluatorInfrastructure.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Evaluators/AIGuardrailEvaluatorInfrastructure.cs
@@ -1,0 +1,18 @@
+using Umbraco.AI.Core.EditableModels;
+
+namespace Umbraco.AI.Core.Guardrails.Evaluators;
+
+/// <summary>
+/// Default implementation of <see cref="IAIGuardrailEvaluatorInfrastructure"/>.
+/// </summary>
+internal sealed class AIGuardrailEvaluatorInfrastructure(
+    IAIEditableModelSchemaBuilder schemaBuilder,
+    IAIEditableModelResolver modelResolver)
+    : IAIGuardrailEvaluatorInfrastructure
+{
+    /// <inheritdoc />
+    public IAIEditableModelSchemaBuilder SchemaBuilder { get; } = schemaBuilder;
+
+    /// <inheritdoc />
+    public IAIEditableModelResolver ModelResolver { get; } = modelResolver;
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Evaluators/ContainsGuardrailEvaluator.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Evaluators/ContainsGuardrailEvaluator.cs
@@ -39,8 +39,16 @@ public class ContainsGuardrailEvaluator : AIGuardrailEvaluatorBase<ContainsGuard
     /// <inheritdoc />
     public override string Description => "Flags content that contains a specific substring";
 
+    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
     public ContainsGuardrailEvaluator(IAIEditableModelSchemaBuilder schemaBuilder)
         : base(schemaBuilder)
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ContainsGuardrailEvaluator"/> class.
+    /// </summary>
+    public ContainsGuardrailEvaluator(IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
+        : base(schemaBuilder, resolver)
     { }
 
     /// <inheritdoc />
@@ -50,7 +58,7 @@ public class ContainsGuardrailEvaluator : AIGuardrailEvaluatorBase<ContainsGuard
         AIGuardrailConfig config,
         CancellationToken cancellationToken)
     {
-        var evalConfig = config.Deserialize<ContainsGuardrailEvaluatorConfig>() ?? new ContainsGuardrailEvaluatorConfig();
+        var evalConfig = ResolveConfig(config) ?? new ContainsGuardrailEvaluatorConfig();
 
         var comparison = evalConfig.IgnoreCase
             ? StringComparison.OrdinalIgnoreCase
@@ -77,7 +85,7 @@ public class ContainsGuardrailEvaluator : AIGuardrailEvaluatorBase<ContainsGuard
         AIGuardrailConfig config,
         CancellationToken cancellationToken)
     {
-        var evalConfig = config.Deserialize<ContainsGuardrailEvaluatorConfig>() ?? new ContainsGuardrailEvaluatorConfig();
+        var evalConfig = ResolveConfig(config) ?? new ContainsGuardrailEvaluatorConfig();
 
         if (string.IsNullOrEmpty(evalConfig.SearchPattern))
         {

--- a/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Evaluators/ContainsGuardrailEvaluator.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Evaluators/ContainsGuardrailEvaluator.cs
@@ -39,16 +39,11 @@ public class ContainsGuardrailEvaluator : AIGuardrailEvaluatorBase<ContainsGuard
     /// <inheritdoc />
     public override string Description => "Flags content that contains a specific substring";
 
-    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
-    public ContainsGuardrailEvaluator(IAIEditableModelSchemaBuilder schemaBuilder)
-        : base(schemaBuilder)
-    { }
-
     /// <summary>
     /// Initializes a new instance of the <see cref="ContainsGuardrailEvaluator"/> class.
     /// </summary>
-    public ContainsGuardrailEvaluator(IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
-        : base(schemaBuilder, resolver)
+    public ContainsGuardrailEvaluator(IAIGuardrailEvaluatorInfrastructure infrastructure)
+        : base(infrastructure)
     { }
 
     /// <inheritdoc />

--- a/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Evaluators/IAIGuardrailEvaluatorInfrastructure.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Evaluators/IAIGuardrailEvaluatorInfrastructure.cs
@@ -1,0 +1,19 @@
+using Umbraco.AI.Core.EditableModels;
+
+namespace Umbraco.AI.Core.Guardrails.Evaluators;
+
+/// <summary>
+/// Defines the infrastructure components required by AI guardrail evaluators.
+/// </summary>
+public interface IAIGuardrailEvaluatorInfrastructure
+{
+    /// <summary>
+    /// Builder for editable model schemas.
+    /// </summary>
+    IAIEditableModelSchemaBuilder SchemaBuilder { get; }
+
+    /// <summary>
+    /// Resolver for converting stored configuration to typed models, with app-settings resolution.
+    /// </summary>
+    IAIEditableModelResolver ModelResolver { get; }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Evaluators/LLMGuardrailEvaluator.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Evaluators/LLMGuardrailEvaluator.cs
@@ -61,26 +61,14 @@ public class LLMGuardrailEvaluator : AIGuardrailEvaluatorBase<LLMGuardrailEvalua
     /// <inheritdoc />
     public override string Description => "Uses an LLM to evaluate content for safety, misinformation, and compliance";
 
-    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
-    public LLMGuardrailEvaluator(
-        IAIChatService chatService,
-        IAIRuntimeContextAccessor runtimeContextAccessor,
-        IAIEditableModelSchemaBuilder schemaBuilder)
-        : base(schemaBuilder)
-    {
-        _chatService = chatService;
-        _runtimeContextAccessor = runtimeContextAccessor;
-    }
-
     /// <summary>
     /// Initializes a new instance of the <see cref="LLMGuardrailEvaluator"/> class.
     /// </summary>
     public LLMGuardrailEvaluator(
         IAIChatService chatService,
         IAIRuntimeContextAccessor runtimeContextAccessor,
-        IAIEditableModelSchemaBuilder schemaBuilder,
-        IAIEditableModelResolver resolver)
-        : base(schemaBuilder, resolver)
+        IAIGuardrailEvaluatorInfrastructure infrastructure)
+        : base(infrastructure)
     {
         _chatService = chatService;
         _runtimeContextAccessor = runtimeContextAccessor;

--- a/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Evaluators/LLMGuardrailEvaluator.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Evaluators/LLMGuardrailEvaluator.cs
@@ -61,11 +61,26 @@ public class LLMGuardrailEvaluator : AIGuardrailEvaluatorBase<LLMGuardrailEvalua
     /// <inheritdoc />
     public override string Description => "Uses an LLM to evaluate content for safety, misinformation, and compliance";
 
+    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
     public LLMGuardrailEvaluator(
         IAIChatService chatService,
         IAIRuntimeContextAccessor runtimeContextAccessor,
         IAIEditableModelSchemaBuilder schemaBuilder)
         : base(schemaBuilder)
+    {
+        _chatService = chatService;
+        _runtimeContextAccessor = runtimeContextAccessor;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LLMGuardrailEvaluator"/> class.
+    /// </summary>
+    public LLMGuardrailEvaluator(
+        IAIChatService chatService,
+        IAIRuntimeContextAccessor runtimeContextAccessor,
+        IAIEditableModelSchemaBuilder schemaBuilder,
+        IAIEditableModelResolver resolver)
+        : base(schemaBuilder, resolver)
     {
         _chatService = chatService;
         _runtimeContextAccessor = runtimeContextAccessor;
@@ -78,7 +93,7 @@ public class LLMGuardrailEvaluator : AIGuardrailEvaluatorBase<LLMGuardrailEvalua
         AIGuardrailConfig config,
         CancellationToken cancellationToken)
     {
-        var evalConfig = config.Deserialize<LLMGuardrailEvaluatorConfig>() ?? new LLMGuardrailEvaluatorConfig();
+        var evalConfig = ResolveConfig(config) ?? new LLMGuardrailEvaluatorConfig();
 
         // Set the guardrail evaluation flag to prevent infinite recursion
         _runtimeContextAccessor.Context?.SetValue(Constants.ContextKeys.IsGuardrailEvaluation, true);

--- a/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Evaluators/RegexGuardrailEvaluator.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Evaluators/RegexGuardrailEvaluator.cs
@@ -50,8 +50,16 @@ public class RegexGuardrailEvaluator : AIGuardrailEvaluatorBase<RegexGuardrailEv
     /// <inheritdoc />
     public override string Description => "Flags content that matches a regular expression pattern";
 
+    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
     public RegexGuardrailEvaluator(IAIEditableModelSchemaBuilder schemaBuilder)
         : base(schemaBuilder)
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RegexGuardrailEvaluator"/> class.
+    /// </summary>
+    public RegexGuardrailEvaluator(IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
+        : base(schemaBuilder, resolver)
     { }
 
     /// <inheritdoc />
@@ -61,7 +69,7 @@ public class RegexGuardrailEvaluator : AIGuardrailEvaluatorBase<RegexGuardrailEv
         AIGuardrailConfig config,
         CancellationToken cancellationToken)
     {
-        var evalConfig = config.Deserialize<RegexGuardrailEvaluatorConfig>() ?? new RegexGuardrailEvaluatorConfig();
+        var evalConfig = ResolveConfig(config) ?? new RegexGuardrailEvaluatorConfig();
 
         if (string.IsNullOrEmpty(evalConfig.Pattern))
         {
@@ -137,7 +145,7 @@ public class RegexGuardrailEvaluator : AIGuardrailEvaluatorBase<RegexGuardrailEv
         AIGuardrailConfig config,
         CancellationToken cancellationToken)
     {
-        var evalConfig = config.Deserialize<RegexGuardrailEvaluatorConfig>() ?? new RegexGuardrailEvaluatorConfig();
+        var evalConfig = ResolveConfig(config) ?? new RegexGuardrailEvaluatorConfig();
 
         if (string.IsNullOrEmpty(evalConfig.Pattern))
         {

--- a/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Evaluators/RegexGuardrailEvaluator.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Guardrails/Evaluators/RegexGuardrailEvaluator.cs
@@ -50,16 +50,11 @@ public class RegexGuardrailEvaluator : AIGuardrailEvaluatorBase<RegexGuardrailEv
     /// <inheritdoc />
     public override string Description => "Flags content that matches a regular expression pattern";
 
-    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
-    public RegexGuardrailEvaluator(IAIEditableModelSchemaBuilder schemaBuilder)
-        : base(schemaBuilder)
-    { }
-
     /// <summary>
     /// Initializes a new instance of the <see cref="RegexGuardrailEvaluator"/> class.
     /// </summary>
-    public RegexGuardrailEvaluator(IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
-        : base(schemaBuilder, resolver)
+    public RegexGuardrailEvaluator(IAIGuardrailEvaluatorInfrastructure infrastructure)
+        : base(infrastructure)
     { }
 
     /// <inheritdoc />

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/AITestFeatureBase.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/AITestFeatureBase.cs
@@ -1,7 +1,9 @@
 using System.Reflection;
 using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
 using Umbraco.AI.Core.EditableModels;
 using Umbraco.AI.Core.RuntimeContext;
+using Umbraco.Cms.Core.DependencyInjection;
 
 namespace Umbraco.AI.Core.Tests;
 
@@ -13,7 +15,7 @@ public abstract class AITestFeatureBase<TConfig> : IAITestFeature
     where TConfig : AITestFeatureConfigBase
 {
     private readonly Lazy<AIEditableModelSchema?> _configSchema;
-    private readonly IAIEditableModelResolver? _resolver;
+    private readonly IAIEditableModelResolver _resolver;
 
     /// <inheritdoc />
     public string Id { get; }
@@ -46,20 +48,23 @@ public abstract class AITestFeatureBase<TConfig> : IAITestFeature
     /// <param name="contextResolver">The context resolver.</param>
     /// <param name="schemaBuilder">The schema builder.</param>
     /// <exception cref="InvalidOperationException">Thrown if the class is missing the required attribute.</exception>
-    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver so that test feature configuration supports app-settings ($Config) resolution and validation. This constructor will be removed in a future version.")]
+    [Obsolete("Use the constructor that accepts an IAITestFeatureInfrastructure so that test feature configuration supports app-settings ($Config) resolution and validation. This constructor will be removed in a future version.")]
     protected AITestFeatureBase(AITestContextResolver contextResolver, IAIEditableModelSchemaBuilder schemaBuilder)
-        : this(contextResolver, schemaBuilder, resolver: null!)
+        : this(contextResolver, schemaBuilder, StaticServiceProvider.Instance.GetRequiredService<IAIEditableModelResolver>())
     {
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AITestFeatureBase{TConfig}"/> class.
     /// </summary>
-    /// <param name="contextResolver">The context resolver.</param>
-    /// <param name="schemaBuilder">The schema builder.</param>
-    /// <param name="resolver">The editable model resolver used to resolve configuration values.</param>
+    /// <param name="infrastructure">The test feature infrastructure dependencies.</param>
     /// <exception cref="InvalidOperationException">Thrown if the class is missing the required attribute.</exception>
-    protected AITestFeatureBase(AITestContextResolver contextResolver, IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
+    protected AITestFeatureBase(IAITestFeatureInfrastructure infrastructure)
+        : this(infrastructure.ContextResolver, infrastructure.SchemaBuilder, infrastructure.ModelResolver)
+    {
+    }
+
+    private AITestFeatureBase(AITestContextResolver contextResolver, IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
     {
         ContextResolver = contextResolver;
         SchemaBuilder = schemaBuilder;
@@ -96,13 +101,7 @@ public abstract class AITestFeatureBase<TConfig> : IAITestFeature
             return null;
         }
 
-        if (_resolver is not null && ConfigType is not null)
-        {
-            return (TConfig?)_resolver.ResolveModel(ConfigType, configElement, GetConfigSchema());
-        }
-
-        // Fallback for features constructed via the obsolete constructor (no resolver available).
-        return configElement.Deserialize<TConfig>(Constants.DefaultJsonSerializerOptions);
+        return (TConfig?)_resolver.ResolveModel(typeof(TConfig), configElement, GetConfigSchema());
     }
 
     /// <inheritdoc />

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/AITestFeatureBase.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/AITestFeatureBase.cs
@@ -13,6 +13,7 @@ public abstract class AITestFeatureBase<TConfig> : IAITestFeature
     where TConfig : AITestFeatureConfigBase
 {
     private readonly Lazy<AIEditableModelSchema?> _configSchema;
+    private readonly IAIEditableModelResolver? _resolver;
 
     /// <inheritdoc />
     public string Id { get; }
@@ -45,10 +46,24 @@ public abstract class AITestFeatureBase<TConfig> : IAITestFeature
     /// <param name="contextResolver">The context resolver.</param>
     /// <param name="schemaBuilder">The schema builder.</param>
     /// <exception cref="InvalidOperationException">Thrown if the class is missing the required attribute.</exception>
+    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver so that test feature configuration supports app-settings ($Config) resolution and validation. This constructor will be removed in a future version.")]
     protected AITestFeatureBase(AITestContextResolver contextResolver, IAIEditableModelSchemaBuilder schemaBuilder)
+        : this(contextResolver, schemaBuilder, resolver: null!)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AITestFeatureBase{TConfig}"/> class.
+    /// </summary>
+    /// <param name="contextResolver">The context resolver.</param>
+    /// <param name="schemaBuilder">The schema builder.</param>
+    /// <param name="resolver">The editable model resolver used to resolve configuration values.</param>
+    /// <exception cref="InvalidOperationException">Thrown if the class is missing the required attribute.</exception>
+    protected AITestFeatureBase(AITestContextResolver contextResolver, IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
     {
         ContextResolver = contextResolver;
         SchemaBuilder = schemaBuilder;
+        _resolver = resolver;
 
         var attribute = GetType().GetCustomAttribute<AITestFeatureAttribute>(inherit: false);
         if (attribute == null)
@@ -66,6 +81,29 @@ public abstract class AITestFeatureBase<TConfig> : IAITestFeature
     /// <inheritdoc />
     public AIEditableModelSchema? GetConfigSchema()
         => _configSchema.Value;
+
+    /// <summary>
+    /// Resolves the strongly-typed test feature configuration from the test's stored
+    /// <see cref="AITest.TestFeatureConfig"/>, applying app-settings ($Config) resolution and schema
+    /// validation through the editable model resolver.
+    /// </summary>
+    /// <param name="test">The test whose feature configuration should be resolved.</param>
+    /// <returns>The resolved configuration, or <c>null</c> if no configuration is stored.</returns>
+    protected TConfig? ResolveTestFeatureConfig(AITest test)
+    {
+        if (test.TestFeatureConfig is not { } configElement)
+        {
+            return null;
+        }
+
+        if (_resolver is not null && ConfigType is not null)
+        {
+            return (TConfig?)_resolver.ResolveModel(ConfigType, configElement, GetConfigSchema());
+        }
+
+        // Fallback for features constructed via the obsolete constructor (no resolver available).
+        return configElement.Deserialize<TConfig>(Constants.DefaultJsonSerializerOptions);
+    }
 
     /// <inheritdoc />
     /// <remarks>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/AITestFeatureInfrastructure.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/AITestFeatureInfrastructure.cs
@@ -1,0 +1,22 @@
+using Umbraco.AI.Core.EditableModels;
+
+namespace Umbraco.AI.Core.Tests;
+
+/// <summary>
+/// Default implementation of <see cref="IAITestFeatureInfrastructure"/>.
+/// </summary>
+internal sealed class AITestFeatureInfrastructure(
+    AITestContextResolver contextResolver,
+    IAIEditableModelSchemaBuilder schemaBuilder,
+    IAIEditableModelResolver modelResolver)
+    : IAITestFeatureInfrastructure
+{
+    /// <inheritdoc />
+    public AITestContextResolver ContextResolver { get; } = contextResolver;
+
+    /// <inheritdoc />
+    public IAIEditableModelSchemaBuilder SchemaBuilder { get; } = schemaBuilder;
+
+    /// <inheritdoc />
+    public IAIEditableModelResolver ModelResolver { get; } = modelResolver;
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/AITestGraderBase.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/AITestGraderBase.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
-using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
 using Umbraco.AI.Core.EditableModels;
+using Umbraco.Cms.Core.DependencyInjection;
 
 namespace Umbraco.AI.Core.Tests;
 
@@ -11,7 +12,7 @@ namespace Umbraco.AI.Core.Tests;
 public abstract class AITestGraderBase<TConfig> : IAITestGrader
 {
     private readonly Lazy<AIEditableModelSchema?> _configSchema;
-    private readonly IAIEditableModelResolver? _resolver;
+    private readonly IAIEditableModelResolver _resolver;
 
     /// <inheritdoc />
     public string Id { get; }
@@ -38,19 +39,23 @@ public abstract class AITestGraderBase<TConfig> : IAITestGrader
     /// </summary>
     /// <param name="schemaBuilder">The schema builder.</param>
     /// <exception cref="InvalidOperationException">Thrown if the class is missing the required attribute.</exception>
-    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver so that grader configuration supports app-settings ($Config) resolution and validation. This constructor will be removed in a future version.")]
+    [Obsolete("Use the constructor that accepts an IAITestGraderInfrastructure so that grader configuration supports app-settings ($Config) resolution and validation. This constructor will be removed in a future version.")]
     protected AITestGraderBase(IAIEditableModelSchemaBuilder schemaBuilder)
-        : this(schemaBuilder, resolver: null!)
+        : this(schemaBuilder, StaticServiceProvider.Instance.GetRequiredService<IAIEditableModelResolver>())
     {
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AITestGraderBase{TConfig}"/> class.
     /// </summary>
-    /// <param name="schemaBuilder">The schema builder.</param>
-    /// <param name="resolver">The editable model resolver used to resolve configuration values.</param>
+    /// <param name="infrastructure">The grader infrastructure dependencies.</param>
     /// <exception cref="InvalidOperationException">Thrown if the class is missing the required attribute.</exception>
-    protected AITestGraderBase(IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
+    protected AITestGraderBase(IAITestGraderInfrastructure infrastructure)
+        : this(infrastructure.SchemaBuilder, infrastructure.ModelResolver)
+    {
+    }
+
+    private AITestGraderBase(IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
     {
         SchemaBuilder = schemaBuilder;
         _resolver = resolver;
@@ -85,13 +90,7 @@ public abstract class AITestGraderBase<TConfig> : IAITestGrader
             return default;
         }
 
-        if (_resolver is not null && ConfigType is not null)
-        {
-            return (TConfig?)_resolver.ResolveModel(ConfigType, configElement, GetConfigSchema());
-        }
-
-        // Fallback for graders constructed via the obsolete constructor (no resolver available).
-        return configElement.Deserialize<TConfig>(Constants.DefaultJsonSerializerOptions);
+        return (TConfig?)_resolver.ResolveModel(typeof(TConfig), configElement, GetConfigSchema());
     }
 
     /// <inheritdoc />

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/AITestGraderBase.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/AITestGraderBase.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text.Json;
 using Umbraco.AI.Core.EditableModels;
 
 namespace Umbraco.AI.Core.Tests;
@@ -10,6 +11,7 @@ namespace Umbraco.AI.Core.Tests;
 public abstract class AITestGraderBase<TConfig> : IAITestGrader
 {
     private readonly Lazy<AIEditableModelSchema?> _configSchema;
+    private readonly IAIEditableModelResolver? _resolver;
 
     /// <inheritdoc />
     public string Id { get; }
@@ -32,13 +34,26 @@ public abstract class AITestGraderBase<TConfig> : IAITestGrader
     protected IAIEditableModelSchemaBuilder SchemaBuilder { get; }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="AITestGraderBase"/> class.
+    /// Initializes a new instance of the <see cref="AITestGraderBase{TConfig}"/> class.
     /// </summary>
     /// <param name="schemaBuilder">The schema builder.</param>
     /// <exception cref="InvalidOperationException">Thrown if the class is missing the required attribute.</exception>
+    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver so that grader configuration supports app-settings ($Config) resolution and validation. This constructor will be removed in a future version.")]
     protected AITestGraderBase(IAIEditableModelSchemaBuilder schemaBuilder)
+        : this(schemaBuilder, resolver: null!)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AITestGraderBase{TConfig}"/> class.
+    /// </summary>
+    /// <param name="schemaBuilder">The schema builder.</param>
+    /// <param name="resolver">The editable model resolver used to resolve configuration values.</param>
+    /// <exception cref="InvalidOperationException">Thrown if the class is missing the required attribute.</exception>
+    protected AITestGraderBase(IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
     {
         SchemaBuilder = schemaBuilder;
+        _resolver = resolver;
 
         var attribute = GetType().GetCustomAttribute<AITestGraderAttribute>(inherit: false);
         if (attribute == null)
@@ -56,6 +71,28 @@ public abstract class AITestGraderBase<TConfig> : IAITestGrader
     /// <inheritdoc />
     public AIEditableModelSchema? GetConfigSchema()
         => _configSchema.Value;
+
+    /// <summary>
+    /// Resolves the strongly-typed grader configuration from the stored <see cref="AITestGraderConfig.Config"/>,
+    /// applying app-settings ($Config) resolution and schema validation through the editable model resolver.
+    /// </summary>
+    /// <param name="graderConfig">The stored grader configuration.</param>
+    /// <returns>The resolved configuration, or <c>null</c> if no configuration is stored.</returns>
+    protected TConfig? ResolveConfig(AITestGraderConfig graderConfig)
+    {
+        if (graderConfig.Config is not { } configElement)
+        {
+            return default;
+        }
+
+        if (_resolver is not null && ConfigType is not null)
+        {
+            return (TConfig?)_resolver.ResolveModel(ConfigType, configElement, GetConfigSchema());
+        }
+
+        // Fallback for graders constructed via the obsolete constructor (no resolver available).
+        return configElement.Deserialize<TConfig>(Constants.DefaultJsonSerializerOptions);
+    }
 
     /// <inheritdoc />
     public abstract Task<AITestGraderResult> GradeAsync(

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/AITestGraderInfrastructure.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/AITestGraderInfrastructure.cs
@@ -1,0 +1,18 @@
+using Umbraco.AI.Core.EditableModels;
+
+namespace Umbraco.AI.Core.Tests;
+
+/// <summary>
+/// Default implementation of <see cref="IAITestGraderInfrastructure"/>.
+/// </summary>
+internal sealed class AITestGraderInfrastructure(
+    IAIEditableModelSchemaBuilder schemaBuilder,
+    IAIEditableModelResolver modelResolver)
+    : IAITestGraderInfrastructure
+{
+    /// <inheritdoc />
+    public IAIEditableModelSchemaBuilder SchemaBuilder { get; } = schemaBuilder;
+
+    /// <inheritdoc />
+    public IAIEditableModelResolver ModelResolver { get; } = modelResolver;
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/ContainsGrader.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/ContainsGrader.cs
@@ -41,16 +41,11 @@ public class ContainsGrader : AITestGraderBase<ContainsGraderConfig>
     /// <summary>
     /// Initializes a new instance of the <see cref="ContainsGrader"/> class.
     /// </summary>
-    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
-    public ContainsGrader(IAIEditableModelSchemaBuilder schemaBuilder)
-        : base(schemaBuilder)
-    { }
-
     /// <summary>
     /// Initializes a new instance of the <see cref="ContainsGrader"/> class.
     /// </summary>
-    public ContainsGrader(IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
-        : base(schemaBuilder, resolver)
+    public ContainsGrader(IAITestGraderInfrastructure infrastructure)
+        : base(infrastructure)
     { }
 
     /// <inheritdoc />

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/ContainsGrader.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/ContainsGrader.cs
@@ -41,8 +41,16 @@ public class ContainsGrader : AITestGraderBase<ContainsGraderConfig>
     /// <summary>
     /// Initializes a new instance of the <see cref="ContainsGrader"/> class.
     /// </summary>
+    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
     public ContainsGrader(IAIEditableModelSchemaBuilder schemaBuilder)
         : base(schemaBuilder)
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ContainsGrader"/> class.
+    /// </summary>
+    public ContainsGrader(IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
+        : base(schemaBuilder, resolver)
     { }
 
     /// <inheritdoc />
@@ -52,11 +60,8 @@ public class ContainsGrader : AITestGraderBase<ContainsGraderConfig>
         AITestGraderConfig graderConfig,
         CancellationToken cancellationToken)
     {
-        // Deserialize configuration
-        var config = graderConfig.Config is not { } configElement
-            ? new ContainsGraderConfig()
-            : configElement.Deserialize<ContainsGraderConfig>(Constants.DefaultJsonSerializerOptions)
-                ?? new ContainsGraderConfig();
+        // Deserialize configuration (resolves $Config app-settings references and validates)
+        var config = ResolveConfig(graderConfig) ?? new ContainsGraderConfig();
 
         // Output value is already extracted by the test feature
         var actualValue = outcome.OutputValue ?? string.Empty;

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/ExactMatchGrader.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/ExactMatchGrader.cs
@@ -41,17 +41,11 @@ public class ExactMatchGrader : AITestGraderBase<ExactMatchGraderConfig>
     /// <summary>
     /// Initializes a new instance of the <see cref="ExactMatchGrader"/> class.
     /// </summary>
-    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
-    public ExactMatchGrader(IAIEditableModelSchemaBuilder schemaBuilder)
-        : base(schemaBuilder)
-    {
-    }
-
     /// <summary>
     /// Initializes a new instance of the <see cref="ExactMatchGrader"/> class.
     /// </summary>
-    public ExactMatchGrader(IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
-        : base(schemaBuilder, resolver)
+    public ExactMatchGrader(IAITestGraderInfrastructure infrastructure)
+        : base(infrastructure)
     {
     }
 

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/ExactMatchGrader.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/ExactMatchGrader.cs
@@ -41,8 +41,17 @@ public class ExactMatchGrader : AITestGraderBase<ExactMatchGraderConfig>
     /// <summary>
     /// Initializes a new instance of the <see cref="ExactMatchGrader"/> class.
     /// </summary>
+    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
     public ExactMatchGrader(IAIEditableModelSchemaBuilder schemaBuilder)
         : base(schemaBuilder)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExactMatchGrader"/> class.
+    /// </summary>
+    public ExactMatchGrader(IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
+        : base(schemaBuilder, resolver)
     {
     }
 
@@ -53,11 +62,8 @@ public class ExactMatchGrader : AITestGraderBase<ExactMatchGraderConfig>
         AITestGraderConfig graderConfig,
         CancellationToken cancellationToken)
     {
-        // Deserialize configuration
-        var config = graderConfig.Config is not { } configElement
-            ? new ExactMatchGraderConfig()
-            : configElement.Deserialize<ExactMatchGraderConfig>(Constants.DefaultJsonSerializerOptions)
-              ?? new ExactMatchGraderConfig();
+        // Deserialize configuration (resolves $Config app-settings references and validates)
+        var config = ResolveConfig(graderConfig) ?? new ExactMatchGraderConfig();
 
         // Output value is already extracted by the test feature
         var actualValue = outcome.OutputValue ?? string.Empty;

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/GuardrailGrader.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/GuardrailGrader.cs
@@ -49,23 +49,13 @@ public class GuardrailGrader : AITestGraderBase<GuardrailGraderConfig>
     /// <summary>
     /// Initializes a new instance of the <see cref="GuardrailGrader"/> class.
     /// </summary>
-    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
-    public GuardrailGrader(
-        AIGuardrailEvaluatorCollection evaluators,
-        IAIEditableModelSchemaBuilder schemaBuilder)
-        : base(schemaBuilder)
-    {
-        _evaluators = evaluators;
-    }
-
     /// <summary>
     /// Initializes a new instance of the <see cref="GuardrailGrader"/> class.
     /// </summary>
     public GuardrailGrader(
         AIGuardrailEvaluatorCollection evaluators,
-        IAIEditableModelSchemaBuilder schemaBuilder,
-        IAIEditableModelResolver resolver)
-        : base(schemaBuilder, resolver)
+        IAITestGraderInfrastructure infrastructure)
+        : base(infrastructure)
     {
         _evaluators = evaluators;
     }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/GuardrailGrader.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/GuardrailGrader.cs
@@ -49,10 +49,23 @@ public class GuardrailGrader : AITestGraderBase<GuardrailGraderConfig>
     /// <summary>
     /// Initializes a new instance of the <see cref="GuardrailGrader"/> class.
     /// </summary>
+    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
     public GuardrailGrader(
         AIGuardrailEvaluatorCollection evaluators,
         IAIEditableModelSchemaBuilder schemaBuilder)
         : base(schemaBuilder)
+    {
+        _evaluators = evaluators;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GuardrailGrader"/> class.
+    /// </summary>
+    public GuardrailGrader(
+        AIGuardrailEvaluatorCollection evaluators,
+        IAIEditableModelSchemaBuilder schemaBuilder,
+        IAIEditableModelResolver resolver)
+        : base(schemaBuilder, resolver)
     {
         _evaluators = evaluators;
     }
@@ -64,10 +77,8 @@ public class GuardrailGrader : AITestGraderBase<GuardrailGraderConfig>
         AITestGraderConfig graderConfig,
         CancellationToken cancellationToken)
     {
-        var config = graderConfig.Config is not { } configElement
-            ? new GuardrailGraderConfig()
-            : configElement.Deserialize<GuardrailGraderConfig>(Constants.DefaultJsonSerializerOptions)
-                ?? new GuardrailGraderConfig();
+        // Resolves $Config app-settings references and validates against the grader schema
+        var config = ResolveConfig(graderConfig) ?? new GuardrailGraderConfig();
 
         if (string.IsNullOrWhiteSpace(config.EvaluatorId))
         {

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/JSONSchemaGrader.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/JSONSchemaGrader.cs
@@ -43,17 +43,11 @@ public class JSONSchemaGrader : AITestGraderBase<JSONSchemaGraderConfig>
     /// <summary>
     /// Initializes a new instance of the <see cref="JSONSchemaGrader"/> class.
     /// </summary>
-    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
-    public JSONSchemaGrader(IAIEditableModelSchemaBuilder schemaBuilder)
-        : base(schemaBuilder)
-    {
-    }
-
     /// <summary>
     /// Initializes a new instance of the <see cref="JSONSchemaGrader"/> class.
     /// </summary>
-    public JSONSchemaGrader(IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
-        : base(schemaBuilder, resolver)
+    public JSONSchemaGrader(IAITestGraderInfrastructure infrastructure)
+        : base(infrastructure)
     {
     }
 

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/JSONSchemaGrader.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/JSONSchemaGrader.cs
@@ -43,8 +43,17 @@ public class JSONSchemaGrader : AITestGraderBase<JSONSchemaGraderConfig>
     /// <summary>
     /// Initializes a new instance of the <see cref="JSONSchemaGrader"/> class.
     /// </summary>
+    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
     public JSONSchemaGrader(IAIEditableModelSchemaBuilder schemaBuilder)
         : base(schemaBuilder)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JSONSchemaGrader"/> class.
+    /// </summary>
+    public JSONSchemaGrader(IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
+        : base(schemaBuilder, resolver)
     {
     }
 
@@ -55,11 +64,8 @@ public class JSONSchemaGrader : AITestGraderBase<JSONSchemaGraderConfig>
         AITestGraderConfig graderConfig,
         CancellationToken cancellationToken)
     {
-        // Deserialize configuration
-        var config = graderConfig.Config is not { } configElement
-            ? new JSONSchemaGraderConfig()
-            : configElement.Deserialize<JSONSchemaGraderConfig>(Constants.DefaultJsonSerializerOptions)
-                ?? new JSONSchemaGraderConfig();
+        // Deserialize configuration (resolves $Config app-settings references and validates)
+        var config = ResolveConfig(graderConfig) ?? new JSONSchemaGraderConfig();
 
         // Output value is already extracted by the test feature
         var actualValue = outcome.OutputValue ?? string.Empty;

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/LLMJudgeGrader.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/LLMJudgeGrader.cs
@@ -61,10 +61,23 @@ public class LLMJudgeGrader : AITestGraderBase<LLMJudgeGraderConfig>
     /// <summary>
     /// Initializes a new instance of the <see cref="LLMJudgeGrader"/> class.
     /// </summary>
+    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
     public LLMJudgeGrader(
         IAIChatService chatService,
         IAIEditableModelSchemaBuilder schemaBuilder)
         : base(schemaBuilder)
+    {
+        _chatService = chatService;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LLMJudgeGrader"/> class.
+    /// </summary>
+    public LLMJudgeGrader(
+        IAIChatService chatService,
+        IAIEditableModelSchemaBuilder schemaBuilder,
+        IAIEditableModelResolver resolver)
+        : base(schemaBuilder, resolver)
     {
         _chatService = chatService;
     }
@@ -76,11 +89,8 @@ public class LLMJudgeGrader : AITestGraderBase<LLMJudgeGraderConfig>
         AITestGraderConfig graderConfig,
         CancellationToken cancellationToken)
     {
-        // Deserialize configuration
-        var config = graderConfig.Config is not { } configElement
-            ? new LLMJudgeGraderConfig()
-            : configElement.Deserialize<LLMJudgeGraderConfig>(Constants.DefaultJsonSerializerOptions)
-                ?? new LLMJudgeGraderConfig();
+        // Deserialize configuration (resolves $Config app-settings references and validates)
+        var config = ResolveConfig(graderConfig) ?? new LLMJudgeGraderConfig();
 
         // Output value is already extracted by the test feature
         var actualValue = outcome.OutputValue ?? string.Empty;

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/LLMJudgeGrader.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/LLMJudgeGrader.cs
@@ -61,23 +61,13 @@ public class LLMJudgeGrader : AITestGraderBase<LLMJudgeGraderConfig>
     /// <summary>
     /// Initializes a new instance of the <see cref="LLMJudgeGrader"/> class.
     /// </summary>
-    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
-    public LLMJudgeGrader(
-        IAIChatService chatService,
-        IAIEditableModelSchemaBuilder schemaBuilder)
-        : base(schemaBuilder)
-    {
-        _chatService = chatService;
-    }
-
     /// <summary>
     /// Initializes a new instance of the <see cref="LLMJudgeGrader"/> class.
     /// </summary>
     public LLMJudgeGrader(
         IAIChatService chatService,
-        IAIEditableModelSchemaBuilder schemaBuilder,
-        IAIEditableModelResolver resolver)
-        : base(schemaBuilder, resolver)
+        IAITestGraderInfrastructure infrastructure)
+        : base(infrastructure)
     {
         _chatService = chatService;
     }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/RegexGrader.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/RegexGrader.cs
@@ -51,8 +51,17 @@ public class RegexGrader : AITestGraderBase<RegexGraderConfig>
     /// <summary>
     /// Initializes a new instance of the <see cref="RegexGrader"/> class.
     /// </summary>
+    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
     public RegexGrader(IAIEditableModelSchemaBuilder schemaBuilder)
         : base(schemaBuilder)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RegexGrader"/> class.
+    /// </summary>
+    public RegexGrader(IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
+        : base(schemaBuilder, resolver)
     {
     }
 
@@ -63,11 +72,8 @@ public class RegexGrader : AITestGraderBase<RegexGraderConfig>
         AITestGraderConfig graderConfig,
         CancellationToken cancellationToken)
     {
-        // Deserialize configuration
-        var config = graderConfig.Config is not { } configElement
-            ? new RegexGraderConfig()
-            : configElement.Deserialize<RegexGraderConfig>(Constants.DefaultJsonSerializerOptions)
-                ?? new RegexGraderConfig();
+        // Deserialize configuration (resolves $Config app-settings references and validates)
+        var config = ResolveConfig(graderConfig) ?? new RegexGraderConfig();
 
         // Output value is already extracted by the test feature
         var actualValue = outcome.OutputValue ?? string.Empty;

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/RegexGrader.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/RegexGrader.cs
@@ -51,17 +51,11 @@ public class RegexGrader : AITestGraderBase<RegexGraderConfig>
     /// <summary>
     /// Initializes a new instance of the <see cref="RegexGrader"/> class.
     /// </summary>
-    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
-    public RegexGrader(IAIEditableModelSchemaBuilder schemaBuilder)
-        : base(schemaBuilder)
-    {
-    }
-
     /// <summary>
     /// Initializes a new instance of the <see cref="RegexGrader"/> class.
     /// </summary>
-    public RegexGrader(IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
-        : base(schemaBuilder, resolver)
+    public RegexGrader(IAITestGraderInfrastructure infrastructure)
+        : base(infrastructure)
     {
     }
 

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/ToolCallGrader.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/ToolCallGrader.cs
@@ -52,8 +52,17 @@ public class ToolCallGrader : AITestGraderBase<ToolCallGraderConfig>
     /// <summary>
     /// Initializes a new instance of the <see cref="ToolCallGrader"/> class.
     /// </summary>
+    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
     public ToolCallGrader(IAIEditableModelSchemaBuilder schemaBuilder)
         : base(schemaBuilder)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ToolCallGrader"/> class.
+    /// </summary>
+    public ToolCallGrader(IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
+        : base(schemaBuilder, resolver)
     {
     }
 
@@ -64,11 +73,8 @@ public class ToolCallGrader : AITestGraderBase<ToolCallGraderConfig>
         AITestGraderConfig graderConfig,
         CancellationToken cancellationToken)
     {
-        // Deserialize configuration
-        var config = graderConfig.Config is not { } configElement
-            ? new ToolCallGraderConfig()
-            : configElement.Deserialize<ToolCallGraderConfig>(Constants.DefaultJsonSerializerOptions)
-                ?? new ToolCallGraderConfig();
+        // Deserialize configuration (resolves $Config app-settings references and validates)
+        var config = ResolveConfig(graderConfig) ?? new ToolCallGraderConfig();
 
         // Parse expected tools
         var expectedTools = config.ExpectedTools

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/ToolCallGrader.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/ToolCallGrader.cs
@@ -52,17 +52,11 @@ public class ToolCallGrader : AITestGraderBase<ToolCallGraderConfig>
     /// <summary>
     /// Initializes a new instance of the <see cref="ToolCallGrader"/> class.
     /// </summary>
-    [Obsolete("Use the constructor that also accepts an IAIEditableModelResolver. This constructor will be removed in a future version.")]
-    public ToolCallGrader(IAIEditableModelSchemaBuilder schemaBuilder)
-        : base(schemaBuilder)
-    {
-    }
-
     /// <summary>
     /// Initializes a new instance of the <see cref="ToolCallGrader"/> class.
     /// </summary>
-    public ToolCallGrader(IAIEditableModelSchemaBuilder schemaBuilder, IAIEditableModelResolver resolver)
-        : base(schemaBuilder, resolver)
+    public ToolCallGrader(IAITestGraderInfrastructure infrastructure)
+        : base(infrastructure)
     {
     }
 

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/IAITestFeatureInfrastructure.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/IAITestFeatureInfrastructure.cs
@@ -1,0 +1,24 @@
+using Umbraco.AI.Core.EditableModels;
+
+namespace Umbraco.AI.Core.Tests;
+
+/// <summary>
+/// Defines the infrastructure components required by AI test features.
+/// </summary>
+public interface IAITestFeatureInfrastructure
+{
+    /// <summary>
+    /// Resolver for mock entity context items.
+    /// </summary>
+    AITestContextResolver ContextResolver { get; }
+
+    /// <summary>
+    /// Builder for editable model schemas.
+    /// </summary>
+    IAIEditableModelSchemaBuilder SchemaBuilder { get; }
+
+    /// <summary>
+    /// Resolver for converting stored configuration to typed models, with app-settings resolution.
+    /// </summary>
+    IAIEditableModelResolver ModelResolver { get; }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/IAITestGraderInfrastructure.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/IAITestGraderInfrastructure.cs
@@ -1,0 +1,19 @@
+using Umbraco.AI.Core.EditableModels;
+
+namespace Umbraco.AI.Core.Tests;
+
+/// <summary>
+/// Defines the infrastructure components required by AI test graders.
+/// </summary>
+public interface IAITestGraderInfrastructure
+{
+    /// <summary>
+    /// Builder for editable model schemas.
+    /// </summary>
+    IAIEditableModelSchemaBuilder SchemaBuilder { get; }
+
+    /// <summary>
+    /// Resolver for converting stored configuration to typed models, with app-settings resolution.
+    /// </summary>
+    IAIEditableModelResolver ModelResolver { get; }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Persistence/Configuration/UmbracoBuilderExtensions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Persistence/Configuration/UmbracoBuilderExtensions.cs
@@ -56,6 +56,10 @@ public static class UmbracoBuilderExtensions
         // Connection factory for entity/domain mapping with encryption support
         builder.Services.AddSingleton<IAIConnectionFactory, AIConnectionFactory>();
 
+        // Context and guardrail factories for entity/domain mapping with encryption support
+        builder.Services.AddSingleton<IAIContextFactory, AIContextFactory>();
+        builder.Services.AddSingleton<IAIGuardrailFactory, AIGuardrailFactory>();
+
         // Replace in-memory repository with EF Core implementations (Singleton - IEFCoreScopeProvider manages scopes internally)
         builder.Services.AddSingleton<IAIConnectionRepository, EFCoreAIConnectionRepository>();
         builder.Services.AddSingleton<IAIProfileRepository, EFCoreAIProfileRepository>();

--- a/Umbraco.AI/src/Umbraco.AI.Persistence/Context/AIContextFactory.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Persistence/Context/AIContextFactory.cs
@@ -1,20 +1,28 @@
-using System.Text.Json;
-using Umbraco.AI.Core;
 using Umbraco.AI.Core.Contexts;
+using Umbraco.AI.Core.Contexts.ResourceTypes;
+using Umbraco.AI.Core.EditableModels;
 
 namespace Umbraco.AI.Persistence.Context;
 
 /// <summary>
 /// Factory for mapping between <see cref="AIContext"/> domain models and <see cref="AIContextEntity"/> database entities.
+/// Handles encryption/decryption of sensitive resource settings during the mapping process.
 /// </summary>
-internal static class AIContextFactory
+internal sealed class AIContextFactory : IAIContextFactory
 {
-    /// <summary>
-    /// Creates an <see cref="AIContext"/> domain model from a database entity.
-    /// </summary>
-    /// <param name="entity">The database entity.</param>
-    /// <returns>The domain model.</returns>
-    public static AIContext BuildDomain(AIContextEntity entity)
+    private readonly IAIEditableModelSerializer _serializer;
+    private readonly AIContextResourceTypeCollection _resourceTypes;
+
+    public AIContextFactory(
+        IAIEditableModelSerializer serializer,
+        AIContextResourceTypeCollection resourceTypes)
+    {
+        _serializer = serializer;
+        _resourceTypes = resourceTypes;
+    }
+
+    /// <inheritdoc />
+    public AIContext BuildDomain(AIContextEntity entity)
     {
         return new AIContext
         {
@@ -36,17 +44,12 @@ internal static class AIContextFactory
     /// <summary>
     /// Creates an <see cref="AIContextResource"/> domain model from a database entity.
     /// </summary>
-    /// <param name="entity">The database entity.</param>
-    /// <returns>The domain model.</returns>
-    public static AIContextResource BuildResourceDomain(AIContextResourceEntity entity)
+    private AIContextResource BuildResourceDomain(AIContextResourceEntity entity)
     {
-        object? settings = null;
-        if (!string.IsNullOrEmpty(entity.Settings))
-        {
-            // Settings are stored as JSON, deserialize to dynamic object
-            // The actual typed deserialization happens at the service layer
-            settings = JsonSerializer.Deserialize<JsonElement>(entity.Settings, Constants.DefaultJsonSerializerOptions);
-        }
+        // Settings are stored as JSON with sensitive fields encrypted.
+        // The serializer decrypts any encrypted values; typed deserialization (and
+        // configuration variable resolution) happens later at the service/resource-type layer.
+        object? settings = _serializer.Deserialize(entity.Settings);
 
         return new AIContextResource
         {
@@ -60,12 +63,8 @@ internal static class AIContextFactory
         };
     }
 
-    /// <summary>
-    /// Creates an <see cref="AIContextEntity"/> database entity from a domain model.
-    /// </summary>
-    /// <param name="context">The domain model.</param>
-    /// <returns>The database entity.</returns>
-    public static AIContextEntity BuildEntity(AIContext context)
+    /// <inheritdoc />
+    public AIContextEntity BuildEntity(AIContext context)
     {
         return new AIContextEntity
         {
@@ -83,13 +82,8 @@ internal static class AIContextFactory
         };
     }
 
-    /// <summary>
-    /// Creates an <see cref="AIContextResourceEntity"/> database entity from a domain model.
-    /// </summary>
-    /// <param name="resource">The domain model.</param>
-    /// <param name="contextId">The parent context ID.</param>
-    /// <returns>The database entity.</returns>
-    public static AIContextResourceEntity BuildResourceEntity(AIContextResource resource, Guid contextId)
+    /// <inheritdoc />
+    public AIContextResourceEntity BuildResourceEntity(AIContextResource resource, Guid contextId)
     {
         return new AIContextResourceEntity
         {
@@ -99,17 +93,13 @@ internal static class AIContextFactory
             Name = resource.Name,
             Description = resource.Description,
             SortOrder = resource.SortOrder,
-            Settings = resource.Settings is null ? string.Empty : JsonSerializer.Serialize(resource.Settings, Constants.DefaultJsonSerializerOptions),
+            Settings = SerializeSettings(resource),
             InjectionMode = (int)resource.InjectionMode
         };
     }
 
-    /// <summary>
-    /// Updates an existing <see cref="AIContextEntity"/> with values from a domain model.
-    /// </summary>
-    /// <param name="entity">The entity to update.</param>
-    /// <param name="context">The domain model with updated values.</param>
-    public static void UpdateEntity(AIContextEntity entity, AIContext context)
+    /// <inheritdoc />
+    public void UpdateEntity(AIContextEntity entity, AIContext context)
     {
         entity.Alias = context.Alias;
         entity.Name = context.Name;
@@ -120,18 +110,31 @@ internal static class AIContextFactory
         // DateCreated and CreatedByUserId are intentionally not updated
     }
 
-    /// <summary>
-    /// Updates an existing <see cref="AIContextResourceEntity"/> with values from a domain model.
-    /// </summary>
-    /// <param name="entity">The entity to update.</param>
-    /// <param name="resource">The domain model with updated values.</param>
-    public static void UpdateResourceEntity(AIContextResourceEntity entity, AIContextResource resource)
+    /// <inheritdoc />
+    public void UpdateResourceEntity(AIContextResourceEntity entity, AIContextResource resource)
     {
         entity.ResourceTypeId = resource.ResourceTypeId;
         entity.Name = resource.Name;
         entity.Description = resource.Description;
         entity.SortOrder = resource.SortOrder;
-        entity.Settings = resource.Settings is null ? string.Empty : JsonSerializer.Serialize(resource.Settings, Constants.DefaultJsonSerializerOptions);
+        entity.Settings = SerializeSettings(resource);
         entity.InjectionMode = (int)resource.InjectionMode;
     }
+
+    /// <summary>
+    /// Serializes a resource's settings, encrypting sensitive fields based on the resource type schema.
+    /// </summary>
+    private string SerializeSettings(AIContextResource resource)
+    {
+        if (resource.Settings is null)
+        {
+            return string.Empty;
+        }
+
+        var schema = GetSettingsSchema(resource.ResourceTypeId);
+        return _serializer.Serialize(resource.Settings, schema) ?? string.Empty;
+    }
+
+    private AIEditableModelSchema? GetSettingsSchema(string resourceTypeId)
+        => _resourceTypes.GetById(resourceTypeId)?.GetSettingsSchema();
 }

--- a/Umbraco.AI/src/Umbraco.AI.Persistence/Context/EFCoreAIContextRepository.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Persistence/Context/EFCoreAIContextRepository.cs
@@ -11,13 +11,15 @@ namespace Umbraco.AI.Persistence.Context;
 internal class EFCoreAIContextRepository : IAIContextRepository
 {
     private readonly IEFCoreScopeProvider<UmbracoAIDbContext> _scopeProvider;
+    private readonly IAIContextFactory _factory;
 
     /// <summary>
     /// Initializes a new instance of <see cref="EFCoreAIContextRepository"/>.
     /// </summary>
-    public EFCoreAIContextRepository(IEFCoreScopeProvider<UmbracoAIDbContext> scopeProvider)
+    public EFCoreAIContextRepository(IEFCoreScopeProvider<UmbracoAIDbContext> scopeProvider, IAIContextFactory factory)
     {
         _scopeProvider = scopeProvider;
+        _factory = factory;
     }
 
     /// <inheritdoc />
@@ -31,7 +33,7 @@ internal class EFCoreAIContextRepository : IAIContextRepository
                 .FirstOrDefaultAsync(c => c.Id == id, cancellationToken));
 
         scope.Complete();
-        return entity is null ? null : AIContextFactory.BuildDomain(entity);
+        return entity is null ? null : _factory.BuildDomain(entity);
     }
 
     /// <inheritdoc />
@@ -45,7 +47,7 @@ internal class EFCoreAIContextRepository : IAIContextRepository
                 .FirstOrDefaultAsync(c => c.Alias.ToLower() == alias.ToLower(), cancellationToken));
 
         scope.Complete();
-        return entity is null ? null : AIContextFactory.BuildDomain(entity);
+        return entity is null ? null : _factory.BuildDomain(entity);
     }
 
     /// <inheritdoc />
@@ -59,7 +61,7 @@ internal class EFCoreAIContextRepository : IAIContextRepository
                 .ToListAsync(cancellationToken));
 
         scope.Complete();
-        return entities.Select(AIContextFactory.BuildDomain);
+        return entities.Select(_factory.BuildDomain);
     }
 
     /// <inheritdoc />
@@ -94,7 +96,7 @@ internal class EFCoreAIContextRepository : IAIContextRepository
         });
 
         scope.Complete();
-        return (result.items.Select(AIContextFactory.BuildDomain), result.total);
+        return (result.items.Select(_factory.BuildDomain), result.total);
     }
 
     /// <inheritdoc />
@@ -116,7 +118,7 @@ internal class EFCoreAIContextRepository : IAIContextRepository
                 context.CreatedByUserId = userId;
                 context.ModifiedByUserId = userId;
 
-                AIContextEntity newEntity = AIContextFactory.BuildEntity(context);
+                AIContextEntity newEntity = _factory.BuildEntity(context);
                 db.Contexts.Add(newEntity);
             }
             else
@@ -127,7 +129,7 @@ internal class EFCoreAIContextRepository : IAIContextRepository
                 context.DateModified = DateTime.UtcNow;
                 context.ModifiedByUserId = userId;
 
-                AIContextFactory.UpdateEntity(existing, context);
+                _factory.UpdateEntity(existing, context);
 
                 // Handle resources: remove deleted, update existing, add new
                 var existingResourceIds = existing.Resources.Select(r => r.Id).ToHashSet();
@@ -146,11 +148,11 @@ internal class EFCoreAIContextRepository : IAIContextRepository
                     if (existingResourceIds.Contains(resource.Id))
                     {
                         var existingResource = existing.Resources.First(r => r.Id == resource.Id);
-                        AIContextFactory.UpdateResourceEntity(existingResource, resource);
+                        _factory.UpdateResourceEntity(existingResource, resource);
                     }
                     else
                     {
-                        var newResource = AIContextFactory.BuildResourceEntity(resource, context.Id);
+                        var newResource = _factory.BuildResourceEntity(resource, context.Id);
                         db.ContextResources.Add(newResource);
                     }
                 }

--- a/Umbraco.AI/src/Umbraco.AI.Persistence/Context/IAIContextFactory.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Persistence/Context/IAIContextFactory.cs
@@ -1,0 +1,50 @@
+using Umbraco.AI.Core.Contexts;
+
+namespace Umbraco.AI.Persistence.Context;
+
+/// <summary>
+/// Factory for mapping between <see cref="AIContext"/> domain models and <see cref="AIContextEntity"/> database entities.
+/// Handles encryption/decryption of sensitive resource settings during the mapping process.
+/// </summary>
+internal interface IAIContextFactory
+{
+    /// <summary>
+    /// Creates an <see cref="AIContext"/> domain model from a database entity.
+    /// Sensitive resource settings are automatically decrypted.
+    /// </summary>
+    /// <param name="entity">The database entity.</param>
+    /// <returns>The domain model with decrypted resource settings.</returns>
+    AIContext BuildDomain(AIContextEntity entity);
+
+    /// <summary>
+    /// Creates an <see cref="AIContextEntity"/> database entity from a domain model.
+    /// Sensitive resource settings are automatically encrypted based on the resource type schema.
+    /// </summary>
+    /// <param name="context">The domain model.</param>
+    /// <returns>The database entity with encrypted resource settings.</returns>
+    AIContextEntity BuildEntity(AIContext context);
+
+    /// <summary>
+    /// Creates an <see cref="AIContextResourceEntity"/> database entity from a domain model.
+    /// Sensitive settings are automatically encrypted based on the resource type schema.
+    /// </summary>
+    /// <param name="resource">The domain model.</param>
+    /// <param name="contextId">The parent context ID.</param>
+    /// <returns>The database entity with encrypted settings.</returns>
+    AIContextResourceEntity BuildResourceEntity(AIContextResource resource, Guid contextId);
+
+    /// <summary>
+    /// Updates an existing <see cref="AIContextEntity"/> with values from a domain model.
+    /// </summary>
+    /// <param name="entity">The entity to update.</param>
+    /// <param name="context">The domain model with updated values.</param>
+    void UpdateEntity(AIContextEntity entity, AIContext context);
+
+    /// <summary>
+    /// Updates an existing <see cref="AIContextResourceEntity"/> with values from a domain model.
+    /// Sensitive settings are automatically encrypted based on the resource type schema.
+    /// </summary>
+    /// <param name="entity">The entity to update.</param>
+    /// <param name="resource">The domain model with updated values.</param>
+    void UpdateResourceEntity(AIContextResourceEntity entity, AIContextResource resource);
+}

--- a/Umbraco.AI/src/Umbraco.AI.Persistence/Guardrails/AIGuardrailFactory.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Persistence/Guardrails/AIGuardrailFactory.cs
@@ -1,15 +1,28 @@
-using System.Text.Json;
-using Umbraco.AI.Core;
+using Umbraco.AI.Core.EditableModels;
 using Umbraco.AI.Core.Guardrails;
+using Umbraco.AI.Core.Guardrails.Evaluators;
 
 namespace Umbraco.AI.Persistence.Guardrails;
 
 /// <summary>
 /// Factory for mapping between <see cref="AIGuardrail"/> domain models and <see cref="AIGuardrailEntity"/> database entities.
+/// Handles encryption/decryption of sensitive evaluator configuration during the mapping process.
 /// </summary>
-internal static class AIGuardrailFactory
+internal sealed class AIGuardrailFactory : IAIGuardrailFactory
 {
-    public static AIGuardrail BuildDomain(AIGuardrailEntity entity)
+    private readonly IAIEditableModelSerializer _serializer;
+    private readonly AIGuardrailEvaluatorCollection _evaluators;
+
+    public AIGuardrailFactory(
+        IAIEditableModelSerializer serializer,
+        AIGuardrailEvaluatorCollection evaluators)
+    {
+        _serializer = serializer;
+        _evaluators = evaluators;
+    }
+
+    /// <inheritdoc />
+    public AIGuardrail BuildDomain(AIGuardrailEntity entity)
     {
         return new AIGuardrail
         {
@@ -28,13 +41,12 @@ internal static class AIGuardrailFactory
         };
     }
 
-    public static AIGuardrailRule BuildRuleDomain(AIGuardrailRuleEntity entity)
+    private AIGuardrailRule BuildRuleDomain(AIGuardrailRuleEntity entity)
     {
-        JsonElement? config = null;
-        if (!string.IsNullOrEmpty(entity.Config))
-        {
-            config = JsonSerializer.Deserialize<JsonElement>(entity.Config, Constants.DefaultJsonSerializerOptions);
-        }
+        // Config is stored as JSON with sensitive fields encrypted. The serializer decrypts any
+        // encrypted values; typed deserialization (and configuration variable resolution) happens
+        // later when the evaluator runs.
+        var config = _serializer.Deserialize(entity.Config);
 
         return new AIGuardrailRule
         {
@@ -48,7 +60,8 @@ internal static class AIGuardrailFactory
         };
     }
 
-    public static AIGuardrailEntity BuildEntity(AIGuardrail guardrail)
+    /// <inheritdoc />
+    public AIGuardrailEntity BuildEntity(AIGuardrail guardrail)
     {
         return new AIGuardrailEntity
         {
@@ -66,7 +79,8 @@ internal static class AIGuardrailFactory
         };
     }
 
-    public static AIGuardrailRuleEntity BuildRuleEntity(AIGuardrailRule rule, Guid guardrailId)
+    /// <inheritdoc />
+    public AIGuardrailRuleEntity BuildRuleEntity(AIGuardrailRule rule, Guid guardrailId)
     {
         return new AIGuardrailRuleEntity
         {
@@ -76,12 +90,13 @@ internal static class AIGuardrailFactory
             Name = rule.Name,
             Phase = (int)rule.Phase,
             Action = (int)rule.Action,
-            Config = rule.Config is null ? null : JsonSerializer.Serialize(rule.Config, Constants.DefaultJsonSerializerOptions),
+            Config = SerializeConfig(rule),
             SortOrder = rule.SortOrder,
         };
     }
 
-    public static void UpdateEntity(AIGuardrailEntity entity, AIGuardrail guardrail)
+    /// <inheritdoc />
+    public void UpdateEntity(AIGuardrailEntity entity, AIGuardrail guardrail)
     {
         entity.Alias = guardrail.Alias;
         entity.Name = guardrail.Name;
@@ -90,13 +105,31 @@ internal static class AIGuardrailFactory
         entity.Version = guardrail.Version;
     }
 
-    public static void UpdateRuleEntity(AIGuardrailRuleEntity entity, AIGuardrailRule rule)
+    /// <inheritdoc />
+    public void UpdateRuleEntity(AIGuardrailRuleEntity entity, AIGuardrailRule rule)
     {
         entity.EvaluatorId = rule.EvaluatorId;
         entity.Name = rule.Name;
         entity.Phase = (int)rule.Phase;
         entity.Action = (int)rule.Action;
-        entity.Config = rule.Config is null ? null : JsonSerializer.Serialize(rule.Config, Constants.DefaultJsonSerializerOptions);
+        entity.Config = SerializeConfig(rule);
         entity.SortOrder = rule.SortOrder;
     }
+
+    /// <summary>
+    /// Serializes a rule's configuration, encrypting sensitive fields based on the evaluator schema.
+    /// </summary>
+    private string? SerializeConfig(AIGuardrailRule rule)
+    {
+        if (rule.Config is null)
+        {
+            return null;
+        }
+
+        var schema = GetConfigSchema(rule.EvaluatorId);
+        return _serializer.Serialize(rule.Config, schema);
+    }
+
+    private AIEditableModelSchema? GetConfigSchema(string evaluatorId)
+        => _evaluators.GetById(evaluatorId)?.GetConfigSchema();
 }

--- a/Umbraco.AI/src/Umbraco.AI.Persistence/Guardrails/EFCoreAIGuardrailRepository.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Persistence/Guardrails/EFCoreAIGuardrailRepository.cs
@@ -10,10 +10,12 @@ namespace Umbraco.AI.Persistence.Guardrails;
 internal class EFCoreAIGuardrailRepository : IAIGuardrailRepository
 {
     private readonly IEFCoreScopeProvider<UmbracoAIDbContext> _scopeProvider;
+    private readonly IAIGuardrailFactory _factory;
 
-    public EFCoreAIGuardrailRepository(IEFCoreScopeProvider<UmbracoAIDbContext> scopeProvider)
+    public EFCoreAIGuardrailRepository(IEFCoreScopeProvider<UmbracoAIDbContext> scopeProvider, IAIGuardrailFactory factory)
     {
         _scopeProvider = scopeProvider;
+        _factory = factory;
     }
 
     /// <inheritdoc />
@@ -27,7 +29,7 @@ internal class EFCoreAIGuardrailRepository : IAIGuardrailRepository
                 .FirstOrDefaultAsync(g => g.Id == id, cancellationToken));
 
         scope.Complete();
-        return entity is null ? null : AIGuardrailFactory.BuildDomain(entity);
+        return entity is null ? null : _factory.BuildDomain(entity);
     }
 
     /// <inheritdoc />
@@ -41,7 +43,7 @@ internal class EFCoreAIGuardrailRepository : IAIGuardrailRepository
                 .FirstOrDefaultAsync(g => g.Alias.ToLower() == alias.ToLower(), cancellationToken));
 
         scope.Complete();
-        return entity is null ? null : AIGuardrailFactory.BuildDomain(entity);
+        return entity is null ? null : _factory.BuildDomain(entity);
     }
 
     /// <inheritdoc />
@@ -55,7 +57,7 @@ internal class EFCoreAIGuardrailRepository : IAIGuardrailRepository
                 .ToListAsync(cancellationToken));
 
         scope.Complete();
-        return entities.Select(AIGuardrailFactory.BuildDomain);
+        return entities.Select(_factory.BuildDomain);
     }
 
     /// <inheritdoc />
@@ -90,7 +92,7 @@ internal class EFCoreAIGuardrailRepository : IAIGuardrailRepository
         });
 
         scope.Complete();
-        return (result.items.Select(AIGuardrailFactory.BuildDomain), result.total);
+        return (result.items.Select(_factory.BuildDomain), result.total);
     }
 
     /// <inheritdoc />
@@ -106,7 +108,7 @@ internal class EFCoreAIGuardrailRepository : IAIGuardrailRepository
                 .ToListAsync(cancellationToken));
 
         scope.Complete();
-        return entities.Select(AIGuardrailFactory.BuildDomain);
+        return entities.Select(_factory.BuildDomain);
     }
 
     /// <inheritdoc />
@@ -128,7 +130,7 @@ internal class EFCoreAIGuardrailRepository : IAIGuardrailRepository
                 guardrail.CreatedByUserId = userId;
                 guardrail.ModifiedByUserId = userId;
 
-                AIGuardrailEntity newEntity = AIGuardrailFactory.BuildEntity(guardrail);
+                AIGuardrailEntity newEntity = _factory.BuildEntity(guardrail);
                 db.Guardrails.Add(newEntity);
             }
             else
@@ -138,7 +140,7 @@ internal class EFCoreAIGuardrailRepository : IAIGuardrailRepository
                 guardrail.DateModified = DateTime.UtcNow;
                 guardrail.ModifiedByUserId = userId;
 
-                AIGuardrailFactory.UpdateEntity(existing, guardrail);
+                _factory.UpdateEntity(existing, guardrail);
 
                 // Handle rules: remove deleted, update existing, add new
                 var existingRuleIds = existing.Rules.Select(r => r.Id).ToHashSet();
@@ -157,11 +159,11 @@ internal class EFCoreAIGuardrailRepository : IAIGuardrailRepository
                     if (existingRuleIds.Contains(rule.Id))
                     {
                         var existingRule = existing.Rules.First(r => r.Id == rule.Id);
-                        AIGuardrailFactory.UpdateRuleEntity(existingRule, rule);
+                        _factory.UpdateRuleEntity(existingRule, rule);
                     }
                     else
                     {
-                        var newRule = AIGuardrailFactory.BuildRuleEntity(rule, guardrail.Id);
+                        var newRule = _factory.BuildRuleEntity(rule, guardrail.Id);
                         db.GuardrailRules.Add(newRule);
                     }
                 }

--- a/Umbraco.AI/src/Umbraco.AI.Persistence/Guardrails/IAIGuardrailFactory.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Persistence/Guardrails/IAIGuardrailFactory.cs
@@ -1,0 +1,50 @@
+using Umbraco.AI.Core.Guardrails;
+
+namespace Umbraco.AI.Persistence.Guardrails;
+
+/// <summary>
+/// Factory for mapping between <see cref="AIGuardrail"/> domain models and <see cref="AIGuardrailEntity"/> database entities.
+/// Handles encryption/decryption of sensitive evaluator configuration during the mapping process.
+/// </summary>
+internal interface IAIGuardrailFactory
+{
+    /// <summary>
+    /// Creates an <see cref="AIGuardrail"/> domain model from a database entity.
+    /// Sensitive rule configuration values are automatically decrypted.
+    /// </summary>
+    /// <param name="entity">The database entity.</param>
+    /// <returns>The domain model with decrypted rule configuration.</returns>
+    AIGuardrail BuildDomain(AIGuardrailEntity entity);
+
+    /// <summary>
+    /// Creates an <see cref="AIGuardrailEntity"/> database entity from a domain model.
+    /// Sensitive rule configuration values are automatically encrypted based on the evaluator schema.
+    /// </summary>
+    /// <param name="guardrail">The domain model.</param>
+    /// <returns>The database entity with encrypted rule configuration.</returns>
+    AIGuardrailEntity BuildEntity(AIGuardrail guardrail);
+
+    /// <summary>
+    /// Creates an <see cref="AIGuardrailRuleEntity"/> database entity from a domain model.
+    /// Sensitive configuration values are automatically encrypted based on the evaluator schema.
+    /// </summary>
+    /// <param name="rule">The domain model.</param>
+    /// <param name="guardrailId">The parent guardrail ID.</param>
+    /// <returns>The database entity with encrypted configuration.</returns>
+    AIGuardrailRuleEntity BuildRuleEntity(AIGuardrailRule rule, Guid guardrailId);
+
+    /// <summary>
+    /// Updates an existing <see cref="AIGuardrailEntity"/> with values from a domain model.
+    /// </summary>
+    /// <param name="entity">The entity to update.</param>
+    /// <param name="guardrail">The domain model with updated values.</param>
+    void UpdateEntity(AIGuardrailEntity entity, AIGuardrail guardrail);
+
+    /// <summary>
+    /// Updates an existing <see cref="AIGuardrailRuleEntity"/> with values from a domain model.
+    /// Sensitive configuration values are automatically encrypted based on the evaluator schema.
+    /// </summary>
+    /// <param name="entity">The entity to update.</param>
+    /// <param name="rule">The domain model with updated values.</param>
+    void UpdateRuleEntity(AIGuardrailRuleEntity entity, AIGuardrailRule rule);
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Middleware/AIGuardrailChatClientTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Middleware/AIGuardrailChatClientTests.cs
@@ -27,11 +27,14 @@ public class AIGuardrailChatClientTests
     }
 
     /// <summary>
-    /// Creates a real editable model resolver backed by empty configuration so evaluator
-    /// configuration is deserialized (and $Config references resolved) through the supported path.
+    /// Creates evaluator infrastructure with a real editable model resolver backed by empty
+    /// configuration so evaluator configuration is deserialized (and $Config references resolved)
+    /// through the supported path.
     /// </summary>
-    private static IAIEditableModelResolver CreateResolver()
-        => new AIEditableModelResolver(new ConfigurationBuilder().Build());
+    private static IAIGuardrailEvaluatorInfrastructure CreateEvaluatorInfrastructure()
+        => new AIGuardrailEvaluatorInfrastructure(
+            new Mock<IAIEditableModelSchemaBuilder>().Object,
+            new AIEditableModelResolver(new ConfigurationBuilder().Build()));
 
     #region Pre-Generate Redaction
 
@@ -47,7 +50,7 @@ public class AIGuardrailChatClientTests
             .WithConfig(new { pattern = @"\d{3}-\d{2}-\d{4}", ignoreCase = false })
             .Build();
 
-        var evaluator = new RegexGuardrailEvaluator(new Mock<IAIEditableModelSchemaBuilder>().Object, CreateResolver());
+        var evaluator = new RegexGuardrailEvaluator(CreateEvaluatorInfrastructure());
 
         var resolved = new AIResolvedGuardrails
         {
@@ -96,7 +99,7 @@ public class AIGuardrailChatClientTests
             .WithConfig(new { searchPattern = "secret-value", ignoreCase = true })
             .Build();
 
-        var evaluator = new ContainsGuardrailEvaluator(new Mock<IAIEditableModelSchemaBuilder>().Object, CreateResolver());
+        var evaluator = new ContainsGuardrailEvaluator(CreateEvaluatorInfrastructure());
 
         var resolved = new AIResolvedGuardrails
         {
@@ -151,8 +154,8 @@ public class AIGuardrailChatClientTests
             .WithConfig(new { pattern = @"\d+", ignoreCase = false })
             .Build();
 
-        var containsEvaluator = new ContainsGuardrailEvaluator(new Mock<IAIEditableModelSchemaBuilder>().Object, CreateResolver());
-        var regexEvaluator = new RegexGuardrailEvaluator(new Mock<IAIEditableModelSchemaBuilder>().Object, CreateResolver());
+        var containsEvaluator = new ContainsGuardrailEvaluator(CreateEvaluatorInfrastructure());
+        var regexEvaluator = new RegexGuardrailEvaluator(CreateEvaluatorInfrastructure());
 
         var resolved = new AIResolvedGuardrails
         {
@@ -205,8 +208,8 @@ public class AIGuardrailChatClientTests
             .WithConfig(new { searchPattern = "data here", ignoreCase = true })
             .Build();
 
-        var regexEvaluator = new RegexGuardrailEvaluator(new Mock<IAIEditableModelSchemaBuilder>().Object, CreateResolver());
-        var containsEvaluator = new ContainsGuardrailEvaluator(new Mock<IAIEditableModelSchemaBuilder>().Object, CreateResolver());
+        var regexEvaluator = new RegexGuardrailEvaluator(CreateEvaluatorInfrastructure());
+        var containsEvaluator = new ContainsGuardrailEvaluator(CreateEvaluatorInfrastructure());
 
         var resolved = new AIResolvedGuardrails
         {
@@ -255,7 +258,7 @@ public class AIGuardrailChatClientTests
             .WithConfig(new { searchPattern = "secret", ignoreCase = false })
             .Build();
 
-        var evaluator = new ContainsGuardrailEvaluator(new Mock<IAIEditableModelSchemaBuilder>().Object, CreateResolver());
+        var evaluator = new ContainsGuardrailEvaluator(CreateEvaluatorInfrastructure());
 
         var resolved = new AIResolvedGuardrails
         {

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Middleware/AIGuardrailChatClientTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Middleware/AIGuardrailChatClientTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Umbraco.AI.Core.EditableModels;
 using Umbraco.AI.Core.Guardrails;
@@ -25,6 +26,13 @@ public class AIGuardrailChatClientTests
         _runtimeContextAccessorMock.Setup(x => x.Context).Returns((AIRuntimeContext?)null);
     }
 
+    /// <summary>
+    /// Creates a real editable model resolver backed by empty configuration so evaluator
+    /// configuration is deserialized (and $Config references resolved) through the supported path.
+    /// </summary>
+    private static IAIEditableModelResolver CreateResolver()
+        => new AIEditableModelResolver(new ConfigurationBuilder().Build());
+
     #region Pre-Generate Redaction
 
     [Fact]
@@ -39,7 +47,7 @@ public class AIGuardrailChatClientTests
             .WithConfig(new { pattern = @"\d{3}-\d{2}-\d{4}", ignoreCase = false })
             .Build();
 
-        var evaluator = new RegexGuardrailEvaluator(new Mock<IAIEditableModelSchemaBuilder>().Object);
+        var evaluator = new RegexGuardrailEvaluator(new Mock<IAIEditableModelSchemaBuilder>().Object, CreateResolver());
 
         var resolved = new AIResolvedGuardrails
         {
@@ -88,7 +96,7 @@ public class AIGuardrailChatClientTests
             .WithConfig(new { searchPattern = "secret-value", ignoreCase = true })
             .Build();
 
-        var evaluator = new ContainsGuardrailEvaluator(new Mock<IAIEditableModelSchemaBuilder>().Object);
+        var evaluator = new ContainsGuardrailEvaluator(new Mock<IAIEditableModelSchemaBuilder>().Object, CreateResolver());
 
         var resolved = new AIResolvedGuardrails
         {
@@ -143,8 +151,8 @@ public class AIGuardrailChatClientTests
             .WithConfig(new { pattern = @"\d+", ignoreCase = false })
             .Build();
 
-        var containsEvaluator = new ContainsGuardrailEvaluator(new Mock<IAIEditableModelSchemaBuilder>().Object);
-        var regexEvaluator = new RegexGuardrailEvaluator(new Mock<IAIEditableModelSchemaBuilder>().Object);
+        var containsEvaluator = new ContainsGuardrailEvaluator(new Mock<IAIEditableModelSchemaBuilder>().Object, CreateResolver());
+        var regexEvaluator = new RegexGuardrailEvaluator(new Mock<IAIEditableModelSchemaBuilder>().Object, CreateResolver());
 
         var resolved = new AIResolvedGuardrails
         {
@@ -197,8 +205,8 @@ public class AIGuardrailChatClientTests
             .WithConfig(new { searchPattern = "data here", ignoreCase = true })
             .Build();
 
-        var regexEvaluator = new RegexGuardrailEvaluator(new Mock<IAIEditableModelSchemaBuilder>().Object);
-        var containsEvaluator = new ContainsGuardrailEvaluator(new Mock<IAIEditableModelSchemaBuilder>().Object);
+        var regexEvaluator = new RegexGuardrailEvaluator(new Mock<IAIEditableModelSchemaBuilder>().Object, CreateResolver());
+        var containsEvaluator = new ContainsGuardrailEvaluator(new Mock<IAIEditableModelSchemaBuilder>().Object, CreateResolver());
 
         var resolved = new AIResolvedGuardrails
         {
@@ -247,7 +255,7 @@ public class AIGuardrailChatClientTests
             .WithConfig(new { searchPattern = "secret", ignoreCase = false })
             .Build();
 
-        var evaluator = new ContainsGuardrailEvaluator(new Mock<IAIEditableModelSchemaBuilder>().Object);
+        var evaluator = new ContainsGuardrailEvaluator(new Mock<IAIEditableModelSchemaBuilder>().Object, CreateResolver());
 
         var resolved = new AIResolvedGuardrails
         {

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Repositories/EFCoreAIContextRepositoryTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Repositories/EFCoreAIContextRepositoryTests.cs
@@ -1,5 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using Umbraco.AI.Core.Contexts;
+using Umbraco.AI.Core.Contexts.ResourceTypes;
+using Umbraco.AI.Core.EditableModels;
+using Umbraco.AI.Core.Security;
 using Umbraco.AI.Persistence;
 using Umbraco.AI.Persistence.Context;
 using Umbraco.AI.Tests.Common.Builders;
@@ -19,7 +22,10 @@ public class EFCoreAIContextRepositoryTests : IClassFixture<EFCoreTestFixture>
     private EFCoreAIContextRepository CreateRepository(UmbracoAIDbContext context)
     {
         var scopeProvider = new TestEFCoreScopeProvider(() => context);
-        return new EFCoreAIContextRepository(scopeProvider);
+        var serializer = new AIEditableModelSerializer(new Mock<IAISensitiveFieldProtector>().Object);
+        var resourceTypes = new AIContextResourceTypeCollection(() => Array.Empty<IAIContextResourceType>());
+        var factory = new AIContextFactory(serializer, resourceTypes);
+        return new EFCoreAIContextRepository(scopeProvider, factory);
     }
 
     #region GetByIdAsync


### PR DESCRIPTION
All models using [AIField] attributes are now serialised and deserialised
through the editable model service so they consistently support sensitive
field encryption (IAIEditableModelSerializer) and app-settings ($Config)
resolution (IAIEditableModelResolver).

Previously several editable models bypassed the service:

- Context resource settings and guardrail rule configs were persisted with
  raw System.Text.Json, so [AIField(IsSensitive=true)] values were stored in
  plaintext. The context and guardrail factories are now DI services that
  encrypt/decrypt via IAIEditableModelSerializer using the resource type /
  evaluator schema.
- Graders, guardrail evaluators, and test features deserialised their typed
  config with raw System.Text.Json at runtime, so $Config references were not
  resolved and validation was skipped. They now resolve config through
  IAIEditableModelResolver via shared helpers on their base classes.

Changes are backwards compatible: a non-generic ResolveModel(Type, ...)
overload is added to IAIEditableModelResolver as a default interface method,
and the grader/evaluator/test-feature base classes (and built-in
implementations) gain new constructors that accept the resolver while the
previous constructors are retained and marked [Obsolete].