### PR TITLE
fix(core): bind multimodal chat contentParts via $type discriminator

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/Chat/Models/ChatRequestModel.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/Chat/Models/ChatRequestModel.cs
@@ -44,7 +44,7 @@ public class ChatMessageModel
 /// <summary>
 /// Base class for multimodal chat content parts.
 /// </summary>
-[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "$type")]
 [JsonDerivedType(typeof(TextChatContentPartModel), "text")]
 [JsonDerivedType(typeof(BinaryChatContentPartModel), "binary")]
 public abstract class ChatContentPartModel;

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Api/Management/Chat/ChatContentPartModelTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Api/Management/Chat/ChatContentPartModelTests.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using Shouldly;
+using Umbraco.AI.Web.Api.Management.Chat.Models;
+using Xunit;
+
+namespace Umbraco.AI.Tests.Unit.Api.Management.Chat;
+
+/// <summary>
+/// Guards the polymorphic JSON contract for multimodal chat content parts.
+/// The discriminator must be "$type" so it matches the published OpenAPI schema and the
+/// convention used by the other polymorphic management models (e.g. profile settings);
+/// a mismatch makes every <c>contentParts</c> request fail model binding with
+/// "must specify a type discriminator".
+/// Uses camelCase options to mirror the management API's JSON configuration.
+/// </summary>
+public class ChatContentPartModelTests
+{
+    private static readonly JsonSerializerOptions Options =
+        new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    [Fact]
+    public void Deserializes_text_part_from_dollar_type_discriminator()
+    {
+        const string json = """{"$type":"text","text":"hello"}""";
+
+        var part = JsonSerializer.Deserialize<ChatContentPartModel>(json, Options);
+
+        var text = part.ShouldBeOfType<TextChatContentPartModel>();
+        text.Text.ShouldBe("hello");
+    }
+
+    [Fact]
+    public void Deserializes_binary_part_from_dollar_type_discriminator()
+    {
+        const string json = """{"$type":"binary","mimeType":"image/png","data":"aGk="}""";
+
+        var part = JsonSerializer.Deserialize<ChatContentPartModel>(json, Options);
+
+        var binary = part.ShouldBeOfType<BinaryChatContentPartModel>();
+        binary.MimeType.ShouldBe("image/png");
+        binary.Data.ShouldBe("aGk=");
+    }
+
+    [Fact]
+    public void Serializes_text_part_with_dollar_type_discriminator()
+    {
+        ChatContentPartModel part = new TextChatContentPartModel { Text = "hello" };
+
+        var json = JsonSerializer.Serialize(part, Options);
+
+        using var document = JsonDocument.Parse(json);
+        document.RootElement.GetProperty("$type").GetString().ShouldBe("text");
+    }
+
+    [Fact]
+    public void Round_trips_a_message_with_mixed_content_parts()
+    {
+        var message = new ChatMessageModel
+        {
+            Role = "user",
+            ContentParts =
+            [
+                new TextChatContentPartModel { Text = "describe this" },
+                new BinaryChatContentPartModel { MimeType = "image/png", Data = "aGk=" }
+            ]
+        };
+
+        var json = JsonSerializer.Serialize(message, Options);
+        var roundTripped = JsonSerializer.Deserialize<ChatMessageModel>(json, Options);
+
+        roundTripped.ShouldNotBeNull();
+        roundTripped!.ContentParts.ShouldNotBeNull();
+        roundTripped.ContentParts!.Count.ShouldBe(2);
+        var text = roundTripped.ContentParts[0].ShouldBeOfType<TextChatContentPartModel>();
+        text.Text.ShouldBe("describe this");
+        roundTripped.ContentParts[1].ShouldBeOfType<BinaryChatContentPartModel>();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #190.

`POST /umbraco/ai/management/api/v1/chat/complete` rejected any message using the multimodal `contentParts` array with HTTP 400 — *"The JSON payload for polymorphic interface or abstract type 'ChatContentPartModel' must specify a type discriminator"* — even when a correct `$type` discriminator was supplied as the first property (as the OpenAPI schema documents). The deprecated `content` string kept working, so multimodal/vision input through this endpoint was impossible.

## Root cause

`ChatContentPartModel` declared its discriminator as `type`:

```csharp
[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
```

while the generated OpenAPI schema advertises `$type`, and the only other polymorphic management model — `ProfileSettingsModel` — uses `$type` (and binds correctly). So clients following the schema send `$type`, which the runtime serializer (configured for `type`) does not recognise, producing the 400.

## Changes

- `Umbraco.AI.Web/Api/Management/Chat/Models/ChatRequestModel.cs`: change the `ChatContentPartModel` discriminator from `type` to `$type`, matching the OpenAPI contract and the existing `ProfileSettingsModel` convention.
- `tests/Umbraco.AI.Tests.Unit/Api/Management/Chat/ChatContentPartModelTests.cs`: add round-trip tests for the text and binary content parts (deserialize from `$type`, serialize to `$type`, mixed-parts message round-trip), using camelCase options to mirror the management API JSON configuration.

## Testing

```
dotnet test Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Umbraco.AI.Tests.Unit.csproj \
  --filter "FullyQualifiedName~ChatContentPartModelTests"
# Passed: 4
```

The new tests fail against the previous `type` discriminator (deserialization throws "must specify a type discriminator") and pass with the fix.
