### PR TITLE
fix(core): return 422 for guardrail-blocked chat completions instead of 500

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/Chat/Controllers/CompleteChatController.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/Chat/Controllers/CompleteChatController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.AI;
 using Umbraco.AI.Core.Chat;
+using Umbraco.AI.Core.Guardrails;
 using Umbraco.AI.Core.InlineChat;
 using Umbraco.AI.Core.Profiles;
 using Umbraco.AI.Extensions;
@@ -50,6 +51,7 @@ public class CompleteChatController : ChatControllerBase
     [ProducesResponseType(typeof(ChatResponseModel), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<IActionResult> CompleteChat(
         [FromHeader] IdOrAlias? profileIdOrAlias,
         ChatRequestModel requestModel,
@@ -82,6 +84,27 @@ public class CompleteChatController : ChatControllerBase
             }, messages, cancellationToken);
 
             return Ok(_umbracoMapper.Map<ChatResponseModel>(response));
+        }
+        catch (AIGuardrailBlockedException ex)
+        {
+            // A guardrail policy refused the input or the generated response. This is a
+            // deliberate policy outcome, not a server fault, so surface it as a structured
+            // 422 (with the phase and flagged rules) instead of letting it become a 500.
+            var phase = ex.EvaluationResult.Phase == AIGuardrailPhase.PreGenerate ? "input" : "response";
+            var problemDetails = new ProblemDetails
+            {
+                Title = "Chat blocked by guardrail policy",
+                Detail = ex.Message,
+                Status = StatusCodes.Status422UnprocessableEntity
+            };
+            problemDetails.Extensions["phase"] = phase;
+            problemDetails.Extensions["flaggedRules"] = ex.EvaluationResult.RuleResults
+                .Where(r => r.EvaluatorResult.Flagged)
+                .Select(r => string.IsNullOrWhiteSpace(r.Rule.GuardrailName)
+                    ? r.Rule.Name
+                    : $"{r.Rule.GuardrailName} > {r.Rule.Name}")
+                .ToList();
+            return UnprocessableEntity(problemDetails);
         }
         catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
         {

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Api/Management/Chat/CompleteChatControllerGuardrailTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Api/Management/Chat/CompleteChatControllerGuardrailTests.cs
@@ -1,0 +1,96 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.AI;
+using Moq;
+using Shouldly;
+using Umbraco.AI.Core.Chat;
+using Umbraco.AI.Core.Guardrails;
+using Umbraco.AI.Core.Guardrails.Evaluators;
+using Umbraco.AI.Core.InlineChat;
+using Umbraco.AI.Core.Profiles;
+using Umbraco.AI.Web.Api.Management.Chat.Controllers;
+using Umbraco.AI.Web.Api.Management.Chat.Models;
+using Umbraco.Cms.Core.Mapping;
+using Xunit;
+
+namespace Umbraco.AI.Tests.Unit.Api.Management.Chat;
+
+/// <summary>
+/// Verifies that a guardrail-blocked chat completion is surfaced as a structured 422
+/// response rather than propagating <see cref="AIGuardrailBlockedException"/> as an
+/// unhandled HTTP 500.
+/// </summary>
+public class CompleteChatControllerGuardrailTests
+{
+    private readonly Mock<IAIChatService> _chatServiceMock = new();
+    private readonly Mock<IAIProfileService> _profileServiceMock = new();
+    private readonly Mock<IUmbracoMapper> _mapperMock = new();
+    private readonly CompleteChatController _controller;
+
+    public CompleteChatControllerGuardrailTests()
+    {
+        _controller = new CompleteChatController(
+            _chatServiceMock.Object,
+            _profileServiceMock.Object,
+            _mapperMock.Object);
+    }
+
+    [Fact]
+    public async Task CompleteChat_WhenGuardrailBlocks_Returns422WithProblemDetails()
+    {
+#pragma warning disable CS0618 // Content is obsolete — convenient for the test request
+        var requestModel = new ChatRequestModel
+        {
+            Messages = [new ChatMessageModel { Role = "user", Content = "hello" }]
+        };
+#pragma warning restore CS0618
+
+        _mapperMock
+            .Setup(x => x.MapEnumerable<ChatMessageModel, ChatMessage>(It.IsAny<IEnumerable<ChatMessageModel>>()))
+            .Returns([new ChatMessage(ChatRole.User, "hello")]);
+
+        var evaluationResult = new AIGuardrailEvaluationResult
+        {
+            Action = AIGuardrailAction.Block,
+            Phase = AIGuardrailPhase.PostGenerate,
+            RuleResults =
+            [
+                new AIGuardrailRuleResult
+                {
+                    Rule = new AIGuardrailRule
+                    {
+                        EvaluatorId = "contains",
+                        Name = "Block secret",
+                        GuardrailName = "Test policy"
+                    },
+                    EvaluatorResult = new AIGuardrailResult
+                    {
+                        EvaluatorId = "contains",
+                        Flagged = true,
+                        Reason = "matched forbidden term"
+                    }
+                }
+            ]
+        };
+
+        _chatServiceMock
+            .Setup(x => x.GetChatResponseAsync(
+                It.IsAny<Action<AIChatBuilder>>(),
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new AIGuardrailBlockedException(evaluationResult));
+
+        var result = await _controller.CompleteChat(null, requestModel);
+
+        var unprocessable = result.ShouldBeOfType<UnprocessableEntityObjectResult>();
+        unprocessable.StatusCode.ShouldBe(StatusCodes.Status422UnprocessableEntity);
+
+        var problemDetails = unprocessable.Value.ShouldBeOfType<ProblemDetails>();
+        problemDetails.Title.ShouldBe("Chat blocked by guardrail policy");
+        problemDetails.Status.ShouldBe(StatusCodes.Status422UnprocessableEntity);
+        problemDetails.Extensions["phase"].ShouldBe("response");
+
+        var flaggedRules = problemDetails.Extensions["flaggedRules"].ShouldBeAssignableTo<IEnumerable<string>>();
+        flaggedRules!.ShouldContain("Test policy > Block secret");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #189.

When a guardrail policy blocks the input or the generated response, `AIGuardrailChatClient` throws `AIGuardrailBlockedException`. `CompleteChatController` did not handle it, so it propagated as an unhandled **HTTP 500** (developer exception page). Clients — including Copilot — could not distinguish a policy block from a genuine server fault, even though `AIAuditLogService` already records the request with status **Blocked**.

## Changes

- `Umbraco.AI.Web/Api/Management/Chat/Controllers/CompleteChatController.cs`: catch `AIGuardrailBlockedException` and return a **422 Unprocessable Entity** `ProblemDetails`, mirroring the controller's existing `ProblemDetails` error handling. The response body carries:
  - `title`: "Chat blocked by guardrail policy"
  - `detail`: the exception's human-readable message
  - `phase`: `"input"` or `"response"`
  - `flaggedRules`: the guardrail/rule names that flagged the content
- Added `[ProducesResponseType(typeof(ProblemDetails), 422)]` to the action.
- `tests/Umbraco.AI.Tests.Unit/Api/Management/Chat/CompleteChatControllerGuardrailTests.cs`: new test asserting a blocked completion returns 422 `ProblemDetails` with the phase and flagged rules.

## Notes

- 422 was chosen because a guardrail block is a deliberate policy outcome on an otherwise valid request (not a malformed-request 4xx or a 5xx fault). Happy to switch to a 200 response carrying a `blocked` flag on `ChatResponseModel` instead if the team prefers representing it as a normal outcome — let me know.
- The same exception can surface from other entry points (streaming chat, prompt execution, agent runs). This PR fixes the endpoint reported in #189; a shared exception filter could cover the rest in a follow-up if desired.

## Testing

```
dotnet test Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Umbraco.AI.Tests.Unit.csproj \
  --filter "FullyQualifiedName~CompleteChatControllerGuardrailTests"
# Passed: 1
```
