### PR TITLE
fix(frontend): Reload collection once after delete to prevent stale rows

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/audit-log/repository/detail/audit-log-detail.repository.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/audit-log/repository/detail/audit-log-detail.repository.ts
@@ -18,8 +18,7 @@ export class UaiAuditLogDetailRepository extends UmbDetailRepositoryBase<UaiAudi
     override async delete(unique: string) {
         const result = await super.delete(unique);
         if (!result.error) {
-            // Notify that a trace was deleted (collection reload is owned by the delete action,
-            // so a bulk delete refreshes the collection once instead of once per item).
+            // Notify listeners of the deletion. Collection and tree reloads are requested by the delete action.
             dispatchActionEvent(this, UaiEntityActionEvent.deleted(unique, UAI_AUDIT_LOG_ENTITY_TYPE));
         }
         return result;

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/audit-log/repository/detail/audit-log-detail.repository.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/audit-log/repository/detail/audit-log-detail.repository.ts
@@ -1,10 +1,9 @@
 import { UmbDetailRepositoryBase } from "@umbraco-cms/backoffice/repository";
 import type { UmbControllerHost } from "@umbraco-cms/backoffice/controller-api";
-import { UmbRequestReloadChildrenOfEntityEvent } from "@umbraco-cms/backoffice/entity-action";
 import { UaiAuditLogDetailServerDataSource } from "./audit-log-detail.server.data-source.ts";
 import { UAI_AUDIT_LOG_DETAIL_STORE_CONTEXT } from "./audit-log-detail.store.ts";
 import type { UaiAuditLogDetailModel } from "../../types.js";
-import { UAI_AUDIT_LOG_ENTITY_TYPE, UAI_AUDIT_LOG_ROOT_ENTITY_TYPE } from "../../entity.js";
+import { UAI_AUDIT_LOG_ENTITY_TYPE } from "../../entity.js";
 import { UaiEntityActionEvent, dispatchActionEvent } from "../../../core/index.js";
 
 /**
@@ -19,15 +18,9 @@ export class UaiAuditLogDetailRepository extends UmbDetailRepositoryBase<UaiAudi
     override async delete(unique: string) {
         const result = await super.delete(unique);
         if (!result.error) {
-            // Notify that a trace was deleted so collections can refresh
+            // Notify that a trace was deleted (collection reload is owned by the delete action,
+            // so a bulk delete refreshes the collection once instead of once per item).
             dispatchActionEvent(this, UaiEntityActionEvent.deleted(unique, UAI_AUDIT_LOG_ENTITY_TYPE));
-            dispatchActionEvent(
-                this,
-                new UmbRequestReloadChildrenOfEntityEvent({
-                    entityType: UAI_AUDIT_LOG_ROOT_ENTITY_TYPE,
-                    unique: null,
-                }),
-            );
         }
         return result;
     }

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/connection/repository/detail/connection-detail.repository.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/connection/repository/detail/connection-detail.repository.ts
@@ -43,14 +43,8 @@ export class UaiConnectionDetailRepository extends UmbDetailRepositoryBase<UaiCo
     override async delete(unique: string) {
         const result = await super.delete(unique);
         if (!result.error) {
+            // Collection reload is owned by the delete action so a bulk delete refreshes once.
             dispatchActionEvent(this, UaiEntityActionEvent.deleted(unique, UAI_CONNECTION_ENTITY_TYPE));
-            dispatchActionEvent(
-                this,
-                new UmbRequestReloadChildrenOfEntityEvent({
-                    entityType: UAI_CONNECTION_ROOT_ENTITY_TYPE,
-                    unique: null,
-                }),
-            );
         }
         return result;
     }

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/connection/repository/detail/connection-detail.repository.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/connection/repository/detail/connection-detail.repository.ts
@@ -43,7 +43,7 @@ export class UaiConnectionDetailRepository extends UmbDetailRepositoryBase<UaiCo
     override async delete(unique: string) {
         const result = await super.delete(unique);
         if (!result.error) {
-            // Collection reload is owned by the delete action so a bulk delete refreshes once.
+            // Notify listeners of the deletion. Collection and tree reloads are requested by the delete action.
             dispatchActionEvent(this, UaiEntityActionEvent.deleted(unique, UAI_CONNECTION_ENTITY_TYPE));
         }
         return result;

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/context/repository/detail/context-detail.repository.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/context/repository/detail/context-detail.repository.ts
@@ -43,7 +43,7 @@ export class UaiContextDetailRepository extends UmbDetailRepositoryBase<UaiConte
     override async delete(unique: string) {
         const result = await super.delete(unique);
         if (!result.error) {
-            // Collection reload is owned by the delete action so a bulk delete refreshes once.
+            // Notify listeners of the deletion. Collection and tree reloads are requested by the delete action.
             dispatchActionEvent(this, UaiEntityActionEvent.deleted(unique, UAI_CONTEXT_ENTITY_TYPE));
         }
         return result;

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/context/repository/detail/context-detail.repository.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/context/repository/detail/context-detail.repository.ts
@@ -43,14 +43,8 @@ export class UaiContextDetailRepository extends UmbDetailRepositoryBase<UaiConte
     override async delete(unique: string) {
         const result = await super.delete(unique);
         if (!result.error) {
+            // Collection reload is owned by the delete action so a bulk delete refreshes once.
             dispatchActionEvent(this, UaiEntityActionEvent.deleted(unique, UAI_CONTEXT_ENTITY_TYPE));
-            dispatchActionEvent(
-                this,
-                new UmbRequestReloadChildrenOfEntityEvent({
-                    entityType: UAI_CONTEXT_ROOT_ENTITY_TYPE,
-                    unique: null,
-                }),
-            );
         }
         return result;
     }

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/core/entity-action/delete/delete.action.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/core/entity-action/delete/delete.action.ts
@@ -1,9 +1,9 @@
-import { UmbEntityActionBase } from "@umbraco-cms/backoffice/entity-action";
+import { UmbEntityActionBase, UmbRequestReloadStructureForEntityEvent } from "@umbraco-cms/backoffice/entity-action";
 import { umbConfirmModal } from "@umbraco-cms/backoffice/modal";
 import { umbPeekError } from "@umbraco-cms/backoffice/notification";
+import { UMB_ACTION_EVENT_CONTEXT } from "@umbraco-cms/backoffice/action";
 import type { UmbDetailRepository } from "@umbraco-cms/backoffice/repository";
 import type { UmbControllerHost } from "@umbraco-cms/backoffice/controller-api";
-import { UMB_COLLECTION_CONTEXT } from "@umbraco-cms/backoffice/collection";
 
 /**
  * Configuration for the delete action.
@@ -57,9 +57,15 @@ export abstract class UaiDeleteActionBase extends UmbEntityActionBase<never> {
             throw error;
         }
 
-        // The repository dispatches the entity-deleted event; the action owns the collection
-        // reload. When invoked outside a collection (e.g. a workspace) this is a no-op.
-        const collectionContext = await this.getContext(UMB_COLLECTION_CONTEXT);
-        collectionContext?.loadCollection();
+        // Request a reload for this entity via the action event context (as CMS's
+        // UmbDeleteEntityAction does). Any collection, tree or structure consumer listening for
+        // the entity refreshes itself.
+        const eventContext = await this.getContext(UMB_ACTION_EVENT_CONTEXT);
+        eventContext?.dispatchEvent(
+            new UmbRequestReloadStructureForEntityEvent({
+                unique: this.args.unique,
+                entityType: this.args.entityType,
+            }),
+        );
     }
 }

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/core/entity-action/delete/delete.action.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/core/entity-action/delete/delete.action.ts
@@ -3,6 +3,7 @@ import { umbConfirmModal } from "@umbraco-cms/backoffice/modal";
 import { umbPeekError } from "@umbraco-cms/backoffice/notification";
 import type { UmbDetailRepository } from "@umbraco-cms/backoffice/repository";
 import type { UmbControllerHost } from "@umbraco-cms/backoffice/controller-api";
+import { UMB_COLLECTION_CONTEXT } from "@umbraco-cms/backoffice/collection";
 
 /**
  * Configuration for the delete action.
@@ -56,6 +57,9 @@ export abstract class UaiDeleteActionBase extends UmbEntityActionBase<never> {
             throw error;
         }
 
-        // Event is dispatched by the repository after successful delete
+        // The repository dispatches the entity-deleted event; the action owns the collection
+        // reload. When invoked outside a collection (e.g. a workspace) this is a no-op.
+        const collectionContext = await this.getContext(UMB_COLLECTION_CONTEXT);
+        collectionContext?.loadCollection();
     }
 }

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/core/entity-bulk-action/delete/bulk-delete.action.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/core/entity-bulk-action/delete/bulk-delete.action.ts
@@ -4,6 +4,7 @@ import { umbPeekError } from "@umbraco-cms/backoffice/notification";
 import { UmbLocalizationController } from "@umbraco-cms/backoffice/localization-api";
 import type { UmbDetailRepository } from "@umbraco-cms/backoffice/repository";
 import type { UmbControllerHost } from "@umbraco-cms/backoffice/controller-api";
+import { UMB_COLLECTION_CONTEXT } from "@umbraco-cms/backoffice/collection";
 
 /**
  * Configuration for the bulk delete action.
@@ -58,7 +59,15 @@ export abstract class UaiBulkDeleteActionBase extends UmbEntityBulkActionBase<ne
                     message: problemDetails.detail ?? problemDetails.title ?? "An item could not be deleted.",
                 });
             }
-            // Event is dispatched by the repository for each successful delete
+            // The repository dispatches the entity-deleted event per item.
         }
+
+        // Refresh the collection once, after every delete has completed. The repository no longer
+        // reloads per item: N items used to fire N uncancelled, racing reloads, so an early
+        // (pre-delete) response could resolve last and leave deleted rows on screen. Clearing the
+        // selection also dismisses the now-stale bulk-action selection toolbar.
+        const collectionContext = await this.getContext(UMB_COLLECTION_CONTEXT);
+        collectionContext?.selection.clearSelection();
+        collectionContext?.loadCollection();
     }
 }

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/core/entity-bulk-action/delete/bulk-delete.action.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/core/entity-bulk-action/delete/bulk-delete.action.ts
@@ -1,10 +1,15 @@
 import { UmbEntityBulkActionBase } from "@umbraco-cms/backoffice/entity-bulk-action";
+import {
+    UmbRequestReloadChildrenOfEntityEvent,
+    UmbRequestReloadStructureForEntityEvent,
+} from "@umbraco-cms/backoffice/entity-action";
 import { umbConfirmModal } from "@umbraco-cms/backoffice/modal";
 import { umbPeekError } from "@umbraco-cms/backoffice/notification";
 import { UmbLocalizationController } from "@umbraco-cms/backoffice/localization-api";
+import { UMB_ACTION_EVENT_CONTEXT } from "@umbraco-cms/backoffice/action";
+import { UMB_ENTITY_CONTEXT } from "@umbraco-cms/backoffice/entity";
 import type { UmbDetailRepository } from "@umbraco-cms/backoffice/repository";
 import type { UmbControllerHost } from "@umbraco-cms/backoffice/controller-api";
-import { UMB_COLLECTION_CONTEXT } from "@umbraco-cms/backoffice/collection";
 
 /**
  * Configuration for the bulk delete action.
@@ -62,12 +67,17 @@ export abstract class UaiBulkDeleteActionBase extends UmbEntityBulkActionBase<ne
             // The repository dispatches the entity-deleted event per item.
         }
 
-        // Refresh the collection once, after every delete has completed. The repository no longer
-        // reloads per item: N items used to fire N uncancelled, racing reloads, so an early
-        // (pre-delete) response could resolve last and leave deleted rows on screen. Clearing the
-        // selection also dismisses the now-stale bulk-action selection toolbar.
-        const collectionContext = await this.getContext(UMB_COLLECTION_CONTEXT);
-        collectionContext?.selection.clearSelection();
-        collectionContext?.loadCollection();
+        // Request one reload of the parent's children and structure via the action event context
+        // (as CMS's UmbDeleteEntityBulkAction does). Every collection, tree and structure consumer
+        // refreshes once; the collection's action-executed handler clears the selection toolbar.
+        const entityContext = await this.getContext(UMB_ENTITY_CONTEXT);
+        const eventContext = await this.getContext(UMB_ACTION_EVENT_CONTEXT);
+        const entityType = entityContext?.getEntityType();
+        const unique = entityContext?.getUnique();
+        if (eventContext && entityType && unique !== undefined) {
+            const args = { entityType, unique };
+            eventContext.dispatchEvent(new UmbRequestReloadChildrenOfEntityEvent(args));
+            eventContext.dispatchEvent(new UmbRequestReloadStructureForEntityEvent(args));
+        }
     }
 }

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/guardrail/repository/detail/guardrail-detail.repository.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/guardrail/repository/detail/guardrail-detail.repository.ts
@@ -43,7 +43,7 @@ export class UaiGuardrailDetailRepository extends UmbDetailRepositoryBase<UaiGua
     override async delete(unique: string) {
         const result = await super.delete(unique);
         if (!result.error) {
-            // Collection reload is owned by the delete action so a bulk delete refreshes once.
+            // Notify listeners of the deletion. Collection and tree reloads are requested by the delete action.
             dispatchActionEvent(this, UaiEntityActionEvent.deleted(unique, UAI_GUARDRAIL_ENTITY_TYPE));
         }
         return result;

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/guardrail/repository/detail/guardrail-detail.repository.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/guardrail/repository/detail/guardrail-detail.repository.ts
@@ -43,14 +43,8 @@ export class UaiGuardrailDetailRepository extends UmbDetailRepositoryBase<UaiGua
     override async delete(unique: string) {
         const result = await super.delete(unique);
         if (!result.error) {
+            // Collection reload is owned by the delete action so a bulk delete refreshes once.
             dispatchActionEvent(this, UaiEntityActionEvent.deleted(unique, UAI_GUARDRAIL_ENTITY_TYPE));
-            dispatchActionEvent(
-                this,
-                new UmbRequestReloadChildrenOfEntityEvent({
-                    entityType: UAI_GUARDRAIL_ROOT_ENTITY_TYPE,
-                    unique: null,
-                }),
-            );
         }
         return result;
     }

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/repository/detail/profile-detail.repository.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/repository/detail/profile-detail.repository.ts
@@ -43,7 +43,7 @@ export class UaiProfileDetailRepository extends UmbDetailRepositoryBase<UaiProfi
     override async delete(unique: string) {
         const result = await super.delete(unique);
         if (!result.error) {
-            // Collection reload is owned by the delete action so a bulk delete refreshes once.
+            // Notify listeners of the deletion. Collection and tree reloads are requested by the delete action.
             dispatchActionEvent(this, UaiEntityActionEvent.deleted(unique, UAI_PROFILE_ENTITY_TYPE));
         }
         return result;

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/repository/detail/profile-detail.repository.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/repository/detail/profile-detail.repository.ts
@@ -43,14 +43,8 @@ export class UaiProfileDetailRepository extends UmbDetailRepositoryBase<UaiProfi
     override async delete(unique: string) {
         const result = await super.delete(unique);
         if (!result.error) {
+            // Collection reload is owned by the delete action so a bulk delete refreshes once.
             dispatchActionEvent(this, UaiEntityActionEvent.deleted(unique, UAI_PROFILE_ENTITY_TYPE));
-            dispatchActionEvent(
-                this,
-                new UmbRequestReloadChildrenOfEntityEvent({
-                    entityType: UAI_PROFILE_ROOT_ENTITY_TYPE,
-                    unique: null,
-                }),
-            );
         }
         return result;
     }

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/repository/detail/test-detail.repository.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/repository/detail/test-detail.repository.ts
@@ -43,7 +43,7 @@ export class UaiTestDetailRepository extends UmbDetailRepositoryBase<UaiTestDeta
     override async delete(unique: string) {
         const result = await super.delete(unique);
         if (!result.error) {
-            // Collection reload is owned by the delete action so a bulk delete refreshes once.
+            // Notify listeners of the deletion. Collection and tree reloads are requested by the delete action.
             dispatchActionEvent(this, UaiEntityActionEvent.deleted(unique, UAI_TEST_ENTITY_TYPE));
         }
         return result;

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/repository/detail/test-detail.repository.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/test/repository/detail/test-detail.repository.ts
@@ -43,14 +43,8 @@ export class UaiTestDetailRepository extends UmbDetailRepositoryBase<UaiTestDeta
     override async delete(unique: string) {
         const result = await super.delete(unique);
         if (!result.error) {
+            // Collection reload is owned by the delete action so a bulk delete refreshes once.
             dispatchActionEvent(this, UaiEntityActionEvent.deleted(unique, UAI_TEST_ENTITY_TYPE));
-            dispatchActionEvent(
-                this,
-                new UmbRequestReloadChildrenOfEntityEvent({
-                    entityType: UAI_TEST_ROOT_ENTITY_TYPE,
-                    unique: null,
-                }),
-            );
         }
         return result;
     }


### PR DESCRIPTION
## Summary

Fixes #197.

Bulk-deleting multiple rows in an AI collection (most visibly the Traces / audit-log view) left some of the deleted rows on screen after the refresh, and sometimes left the `umb-collection-selection-actions` selection toolbar visible.

## Root cause

Each detail repository dispatched a `UmbRequestReloadChildrenOfEntityEvent` inside `delete()`. The shared bulk delete action deletes items one at a time, so deleting N rows dispatched N reload events. The CMS collection context handles that event by calling `_requestCollection()` directly, bypassing its own debounced `loadCollection()`. The result is N uncancelled, concurrent collection fetches that can resolve out of order: an early pre-delete response can resolve last and overwrite the final state, leaving deleted rows visible.
The selection was also never cleared deterministically.

## Changes

- The six detail repositories (audit-log, profile, connection, guardrail, context, test) no longer dispatch the reload event in `delete()`. They still dispatch the entity-deleted event.
- `UaiDeleteActionBase` (single) and `UaiBulkDeleteActionBase` (bulk) now own the reload: they call the collection context's debounced `loadCollection()` once after the delete(s) complete. The bulk base also clears the selection.
- A bulk delete therefore triggers a single, final reload instead of one peritem, which removes the race. This mirrors the pattern already used by the existing test and test-run delete actions.

## Testing

Verified manually in the demo site against the Traces view (SQLite):
- Seeded around 60 audit-log rows across mixed statuses, providers and models.
- Selected multiple rows and bulk-deleted: all selected rows are removed in a single refresh and the selection toolbar is dismissed.
- Single delete from a collection still refreshes the list. Delete invoked outside a collection (for example a workspace) is a safe no-op for the reload via the optional-chaining guard.

There is no frontend unit-test harness in this package, so this was validated by `npm run build` and manual verification.
