### PR TITLE
chore(deps): Promote Umbraco.Deploy.Infrastructure to 18.0.0 stable

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,13 +23,9 @@
     <PackageVersion Include="Umbraco.Cms.Persistence.EFCore.Sqlite" Version="[18.0.0, 18.999.999)" />
   </ItemGroup>
 
-  <!-- Umbraco Deploy.
-       Umbraco.Deploy.Infrastructure has no stable v18 yet (latest is 18.0.0-rc3); the v17 line
-       caps Umbraco.Cms.Api.Management at < 18.0.0, which an rc CMS satisfied but stable 18.0.0
-       does not. Floor on the 18.x RC so the Deploy products can consume the now-stable CMS 18
-       and automatically pick up Umbraco.Deploy.Infrastructure 18 stable once it ships. -->
+  <!-- Umbraco Deploy. -->
   <ItemGroup>
-    <PackageVersion Include="Umbraco.Deploy.Infrastructure" Version="[18.0.0-rc3, 18.999.999)" />
+    <PackageVersion Include="Umbraco.Deploy.Infrastructure" Version="[18.0.0, 18.999.999)" />
   </ItemGroup>
 
   <!-- Umbraco Automate -->

--- a/NuGet.config
+++ b/NuGet.config
@@ -27,6 +27,8 @@
       <package pattern="Umbraco.Cms.*" />
       <package pattern="Umbraco.Automate" />
       <package pattern="Umbraco.Automate.*" />
+      <package pattern="Umbraco.Deploy" />
+      <package pattern="Umbraco.Deploy.*" />
     </packageSource>
     <!-- Umbraco Nightly: continuous nightly Automate builds. -->
     <packageSource key="Umbraco Nightly">


### PR DESCRIPTION
## Summary

- Bump `Umbraco.Deploy.Infrastructure` floor from `[18.0.0-rc3, 18.999.999)` to `[18.0.0, 18.999.999)` now that Deploy 18.0.0 stable has shipped on the MyGet prereleases feed.
- Restore the `Umbraco.Deploy*` patterns in `NuGet.config`'s MyGet Prereleases source mapping. They were dropped when the mapping was tightened to side-step Umbraco.Code republishing, but Deploy 18 stable isn't on nuget.org yet so restore needs MyGet for that package family.

## Test plan

- [x] `dotnet restore Umbraco.AI.slnx --force-evaluate` — clean
- [x] `dotnet build Umbraco.AI.slnx --no-restore` — 0 errors
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)