### PR TITLE
fix(prompt): Property Action always reads from left pane in split-view

### DIFF
--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/prompt/property-actions/prompt-insert.property-action.ts
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/prompt/property-actions/prompt-insert.property-action.ts
@@ -241,23 +241,31 @@ export class UaiPromptInsertPropertyAction extends UmbPropertyActionBase<UaiProm
 
         const contextItems: UaiPromptContextItem[] = [];
 
+        // Derive the active variant from the property context so split-view serializes
+        // the correct pane's values. The property context's variantId reflects the pane
+        // the action was triggered from; without this, getActiveVariants()[0] always wins.
+        const variantId = this.#propertyContext?.getVariantId?.();
+        const activeVariant = variantId
+            ? { culture: variantId.culture ?? null, segment: variantId.segment ?? null }
+            : undefined;
+
         try {
             if (this.#isBlockWorkspace) {
-                // Block: serialize block as element context
+                // Block: serialize block as element context (block derives its own variant via getVariantId)
                 const serializedElement = await adapter.serializeForLlm(this.#workspaceContext);
                 contextItems.push(createElementContextItem(serializedElement));
 
-                // Serialize parent document as entity context
+                // Serialize parent document as entity context, passing the active variant override
                 if (this.#parentDocumentContext) {
                     const docAdapter = await resolveEntityAdapterByType("document");
                     if (docAdapter?.canHandle(this.#parentDocumentContext)) {
-                        const serializedEntity = await docAdapter.serializeForLlm(this.#parentDocumentContext);
+                        const serializedEntity = await docAdapter.serializeForLlm(this.#parentDocumentContext, activeVariant);
                         contextItems.push(createEntityContextItem(serializedEntity));
                     }
                 }
             } else {
-                // Document/media: serialize as entity context (as before)
-                const serializedEntity = await adapter.serializeForLlm(this.#workspaceContext);
+                // Document/media: serialize as entity context, passing the active variant override
+                const serializedEntity = await adapter.serializeForLlm(this.#workspaceContext, activeVariant);
                 contextItems.push(createEntityContextItem(serializedEntity));
             }
         } catch {

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/prompt/tiptap/prompts-tiptap-toolbar.element.ts
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/prompt/tiptap/prompts-tiptap-toolbar.element.ts
@@ -63,6 +63,7 @@ export class UaiPromptsTiptapToolbarElement extends UmbLitElement {
 
     #propertyAlias: string | null = null;
     #propertyEditorUiAlias: string | null = null;
+    #propertyContext?: typeof UMB_PROPERTY_CONTEXT.TYPE;
     #contentTypeAliases: string[] = [];
     #workspaceContext?: WorkspaceContextLike;
     #parentDocumentContext?: WorkspaceContextLike;
@@ -74,6 +75,7 @@ export class UaiPromptsTiptapToolbarElement extends UmbLitElement {
 
         this.consumeContext(UMB_PROPERTY_CONTEXT, (context) => {
             if (!context) return;
+            this.#propertyContext = context;
             this.#propertyAlias = context.getAlias() ?? null;
             this.observe(context.editorManifest, (manifest) => {
                 this.#propertyEditorUiAlias = manifest?.alias ?? null;
@@ -324,26 +326,34 @@ export class UaiPromptsTiptapToolbarElement extends UmbLitElement {
 
         const contextItems: UaiPromptContextItem[] = [];
 
+        // Derive the active variant from the property context so split-view serializes
+        // the correct pane's values. The property context's variantId reflects the pane
+        // the toolbar lives in; without this, getActiveVariants()[0] always wins.
+        const variantId = this.#propertyContext?.getVariantId?.();
+        const activeVariant = variantId
+            ? { culture: variantId.culture ?? null, segment: variantId.segment ?? null }
+            : undefined;
+
         try {
             const adapter = await resolveEntityAdapterByType(entityType);
             if (!adapter?.canHandle(this.#workspaceContext)) return undefined;
 
             if (this.#isBlockWorkspace) {
-                // Block: serialize block as element context
+                // Block: serialize block as element context (block derives its own variant via getVariantId)
                 const serializedElement = await adapter.serializeForLlm(this.#workspaceContext);
                 contextItems.push(createElementContextItem(serializedElement));
 
-                // Serialize parent document as entity context
+                // Serialize parent document as entity context, passing the active variant override
                 if (this.#parentDocumentContext) {
                     const docAdapter = await resolveEntityAdapterByType('document');
                     if (docAdapter?.canHandle(this.#parentDocumentContext)) {
-                        const serializedEntity = await docAdapter.serializeForLlm(this.#parentDocumentContext);
+                        const serializedEntity = await docAdapter.serializeForLlm(this.#parentDocumentContext, activeVariant);
                         contextItems.push(createEntityContextItem(serializedEntity));
                     }
                 }
             } else {
-                // Document/media: serialize as entity context
-                const serializedEntity = await adapter.serializeForLlm(this.#workspaceContext);
+                // Document/media: serialize as entity context, passing the active variant override
+                const serializedEntity = await adapter.serializeForLlm(this.#workspaceContext, activeVariant);
                 contextItems.push(createEntityContextItem(serializedEntity));
             }
         } catch {

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/adapters/document.adapter.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/adapters/document.adapter.ts
@@ -85,11 +85,8 @@ interface DocumentWorkspaceContextLike {
 /**
  * Resolve the active variant from the workspace's split-view manager.
  * Returns null when none can be determined (invariant document, missing API,
- * mocked context). When multiple variants are focused (split view), the first
- * is used since the AI prompt is triggered against a single editing context.
- *
- * TODO: revisit when invoking from the second pane of a split view —
- * `getActiveVariants()[0]` always picks the leftmost pane today.
+ * mocked context). Falls back to the first active variant when the caller
+ * does not supply an override (single-pane editing, invariant content).
  */
 function getActiveVariant(ctx: DocumentWorkspaceContextLike): ActiveVariantInfo | null {
     const active = ctx.splitView?.getActiveVariants?.();
@@ -218,13 +215,16 @@ export class UaiDocumentAdapter implements UaiEntityAdapterApi {
      * for properties that don't vary, so prompt template variables like
      * `{{header}}` resolve to the active culture's value.
      */
-    async serializeForLlm(workspaceContext: unknown): Promise<UaiSerializedEntity> {
+    async serializeForLlm(
+        workspaceContext: unknown,
+        activeVariant?: { culture: string | null; segment: string | null },
+    ): Promise<UaiSerializedEntity> {
         const ctx = workspaceContext as DocumentWorkspaceContextLike;
 
         const unique = ctx.getUnique();
         const contentType = ctx.getContentTypeUnique();
         const values = ctx.getValues() ?? [];
-        const active = getActiveVariant(ctx);
+        const active = activeVariant ?? getActiveVariant(ctx);
 
         // Pick the active variant's name when available so the LLM sees the
         // name from the variant the editor is on, matching the property values.

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/types.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/types.ts
@@ -165,8 +165,13 @@ export interface UaiEntityAdapterApi extends UmbApi {
 
     /**
      * Serialize the entity for LLM context.
+     * @param activeVariant When provided, overrides variant detection in the adapter so values are
+     * read from the correct culture/segment (e.g. the right pane in split-view).
      */
-    serializeForLlm(workspaceContext: unknown): Promise<UaiSerializedEntity>;
+    serializeForLlm(
+        workspaceContext: unknown,
+        activeVariant?: { culture: string | null; segment: string | null },
+    ): Promise<UaiSerializedEntity>;
 
     /**
      * Apply a value change to the workspace (staged, not persisted).


### PR DESCRIPTION
## Summary

- Fixes #202 — Property Actions and TipTap toolbar prompts always serialized property values from the **left pane** in split-view, so `{{currentValue}}` resolved the wrong culture when the action was triggered from the right pane
- Root cause was `getActiveVariants()[0]` in `document.adapter.ts` always picking the leftmost variant (there was already a TODO acknowledging this)
- The property context already knows the correct pane via `getVariantId()` — we now forward that as an `activeVariant` override into `serializeForLlm`

## Changes

- `entity-adapter/types.ts` — added optional `activeVariant` param to `serializeForLlm` interface; backward-compatible (existing adapters ignore it)
- `adapters/document.adapter.ts` — `serializeForLlm` uses the override when provided, falls back to `getActiveVariants()[0]` for non-split-view cases
- `prompt-insert.property-action.ts` — reads `propertyContext.getVariantId()` and passes it to `serializeForLlm`
- `prompts-tiptap-toolbar.element.ts` — same fix; now also stores `#propertyContext` (previously only `#propertyAlias` was kept)

Block and media adapters are unaffected — the block adapter derives its variant from `getVariantId()` directly and TypeScript allows omitting an optional parameter in an implementation.

## Test plan

- [x] Create a multi-language document (e.g. EN + DE) with a TextBox or TextArea property, enter different values per culture
- [x] Add a prompt using `{{currentValue}}` (e.g. "Translate this to French: {{currentValue}}")
- [x] Open the document in split-view with DE on the left and EN on the right
- [x] Trigger the Property Action on the EN (right) field — confirm AI receives the EN value, not DE
- [x] Trigger the Property Action on the DE (left) field — confirm AI receives the DE value
- [x] Repeat above for a TipTap rich text field using the toolbar prompt dropdown
- [x] Verify single-pane editing still works correctly (invariant + culture-variant content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)