### PR TITLE
fix(api,agent): Honor [JsonStringEnumMemberName] in OpenAPI enum schemas (v17)

### DIFF
--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Client/src/api/types.gen.ts
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Client/src/api/types.gen.ts
@@ -25,7 +25,7 @@ export type AGUIMessageModel = {
     error?: string | null;
 };
 
-export type AGUIMessageRoleModel = 'User' | 'Assistant' | 'System' | 'Tool' | 'Developer' | 'Activity' | 'Reasoning';
+export type AGUIMessageRoleModel = 'user' | 'assistant' | 'system' | 'tool' | 'developer' | 'activity' | 'reasoning';
 
 export type AGUIResumeEntryModel = {
     interruptId: string;
@@ -33,7 +33,7 @@ export type AGUIResumeEntryModel = {
     payload?: unknown;
 };
 
-export type AGUIResumeStatusModel = 'Resolved' | 'Cancelled';
+export type AGUIResumeStatusModel = 'resolved' | 'cancelled';
 
 export type AGUIRunRequestModel = {
     threadId: string;

--- a/Umbraco.AI/src/Umbraco.AI.Web/Api/Common/Configuration/JsonStringEnumMemberNameSchemaFilter.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Web/Api/Common/Configuration/JsonStringEnumMemberNameSchemaFilter.cs
@@ -1,0 +1,75 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using Microsoft.OpenApi;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Umbraco.AI.Web.Api.Common.Configuration;
+
+/// <summary>
+/// Rewrites string-enum schema values to honor <see cref="JsonStringEnumMemberNameAttribute"/>,
+/// so the generated OpenAPI document (and downstream TypeScript clients) advertise the actual
+/// wire values rather than the .NET member names.
+/// </summary>
+/// <remarks>
+/// Swashbuckle derives string-enum schema values from the .NET enum member names and ignores
+/// <c>[JsonStringEnumMemberName]</c>, even though the runtime (<see cref="JsonStringEnumConverter{TEnum}"/>)
+/// serializes and deserializes using the attribute values. The result is a schema that lists values
+/// the server will reject: under ASP.NET's case-sensitive Web JSON binding, sending the advertised
+/// <c>"Resolved"</c> for an enum whose wire value is <c>"resolved"</c> yields a 400. This filter closes
+/// that gap by replacing each string-enum schema's values with the member-name overrides.
+///
+/// Only string enums are touched: integer enums (no <see cref="JsonStringEnumConverter{TEnum}"/>)
+/// produce numeric <c>enum</c> entries and are left alone, and <c>[Flags]</c> string enums produce no
+/// <c>enum</c> array (the value is an open-ended set) so there is nothing to rewrite. The wire value is
+/// the attribute name when present, otherwise the member name — matching the converter's behavior when
+/// no naming policy is configured.
+/// </remarks>
+internal sealed class JsonStringEnumMemberNameSchemaFilter : ISchemaFilter
+{
+    public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
+    {
+        // Only the concrete schema is mutable; the interface exposes Enum read-only.
+        if (schema is OpenApiSchema concrete)
+        {
+            RewriteEnumValues(concrete, context.Type);
+        }
+    }
+
+    /// <summary>
+    /// Replaces a string-enum schema's values with the <see cref="JsonStringEnumMemberNameAttribute"/>
+    /// wire values. No-op for non-enum types, integer enums, and enums without an <c>enum</c> array.
+    /// </summary>
+    internal static void RewriteEnumValues(OpenApiSchema schema, Type type)
+    {
+        // Only string enums carry an enum value list to correct.
+        if (schema.Enum is not { Count: > 0 } values)
+        {
+            return;
+        }
+
+        Type enumType = Nullable.GetUnderlyingType(type) ?? type;
+        if (enumType.IsEnum == false)
+        {
+            return;
+        }
+
+        // Integer enums serialize as numbers; leave their numeric enum entries untouched.
+        if (values.Any(value => value is JsonValue node && node.GetValueKind() == JsonValueKind.String) == false)
+        {
+            return;
+        }
+
+        // Mutate the existing list in place rather than reassigning schema.Enum: Swashbuckle/
+        // Microsoft.OpenApi retain the original list reference, so a reassignment is silently
+        // discarded (the original list is what gets serialized).
+        FieldInfo[] fields = enumType.GetFields(BindingFlags.Public | BindingFlags.Static);
+        values.Clear();
+        foreach (FieldInfo field in fields)
+        {
+            var memberName = field.GetCustomAttribute<JsonStringEnumMemberNameAttribute>()?.Name ?? field.Name;
+            values.Add(JsonValue.Create(memberName));
+        }
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Web/Configuration/UmbracoBuilderExtensions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Web/Configuration/UmbracoBuilderExtensions.cs
@@ -141,6 +141,20 @@ public static class UmbracoBuilderExtensions
             });
         }
 
+        // Swashbuckle derives string-enum schema values from the .NET member names and ignores
+        // [JsonStringEnumMemberName], so generated clients advertise values the server rejects under
+        // case-sensitive binding. Rewrite them to the wire values. Registered via PostConfigure so it
+        // runs after Umbraco's own EnumSchemaFilter (Umbraco.Cms.Api.Common), which otherwise reassigns
+        // the enum list from member names and would clobber our rewrite. The filter is unscoped (enum
+        // schemas are shared across documents) and de-duped (this method runs once per product).
+        builder.Services.PostConfigure<SwaggerGenOptions>(options =>
+        {
+            if (options.SchemaFilterDescriptors.Any(d => d.Type == typeof(JsonStringEnumMemberNameSchemaFilter)) == false)
+            {
+                options.SchemaFilter<JsonStringEnumMemberNameSchemaFilter>();
+            }
+        });
+
         builder.Services.AddSingleton<IOperationIdHandler, UmbracoAIApiOperationIdHandler>();
         builder.Services.AddSingleton<ISchemaIdHandler, UmbracoAIApiSchemaIdHandler>();
 

--- a/Umbraco.AI/src/Umbraco.AI.Web/Umbraco.AI.Web.csproj
+++ b/Umbraco.AI/src/Umbraco.AI.Web/Umbraco.AI.Web.csproj
@@ -18,6 +18,9 @@
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
             <_Parameter1>Umbraco.AI.Startup</_Parameter1>
         </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Umbraco.AI.Tests.Unit</_Parameter1>
+        </AssemblyAttribute>
     </ItemGroup>
 
     <ItemGroup>

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Api/Common/Configuration/JsonStringEnumMemberNameSchemaFilterTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Api/Common/Configuration/JsonStringEnumMemberNameSchemaFilterTests.cs
@@ -1,0 +1,112 @@
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using Microsoft.OpenApi;
+using Shouldly;
+using Umbraco.AI.Web.Api.Common.Configuration;
+
+namespace Umbraco.AI.Tests.Unit.Api.Common.Configuration;
+
+public class JsonStringEnumMemberNameSchemaFilterTests
+{
+    [JsonConverter(typeof(JsonStringEnumConverter<StringEnum>))]
+    private enum StringEnum
+    {
+        [JsonStringEnumMemberName("resolved")]
+        Resolved,
+
+        [JsonStringEnumMemberName("cancelled")]
+        Cancelled,
+
+        // No attribute — should fall back to the member name.
+        Pending
+    }
+
+    private enum IntEnum
+    {
+        First,
+        Second
+    }
+
+    [Fact]
+    public void RewriteEnumValues_StringEnum_ReplacesWithWireValues()
+    {
+        // Arrange — mirror what Swashbuckle emits: PascalCase member names.
+        var schema = new OpenApiSchema
+        {
+            Enum = ["Resolved", "Cancelled", "Pending"]
+        };
+
+        // Act
+        JsonStringEnumMemberNameSchemaFilter.RewriteEnumValues(schema, typeof(StringEnum));
+
+        // Assert
+        schema.Enum!.Select(node => node!.GetValue<string>())
+            .ShouldBe(["resolved", "cancelled", "Pending"]);
+    }
+
+    [Fact]
+    public void RewriteEnumValues_MutatesInPlace_PreservingListReference()
+    {
+        // Swashbuckle/Microsoft.OpenApi retain the original list reference, so the filter must
+        // mutate it in place rather than reassign schema.Enum. Verify the same instance is kept.
+        var schema = new OpenApiSchema
+        {
+            Enum = ["Resolved", "Cancelled", "Pending"]
+        };
+        IList<JsonNode> original = schema.Enum!;
+
+        JsonStringEnumMemberNameSchemaFilter.RewriteEnumValues(schema, typeof(StringEnum));
+
+        schema.Enum.ShouldBeSameAs(original);
+    }
+
+    [Fact]
+    public void RewriteEnumValues_NullableStringEnum_ReplacesWithWireValues()
+    {
+        var schema = new OpenApiSchema
+        {
+            Enum = ["Resolved", "Cancelled", "Pending"]
+        };
+
+        JsonStringEnumMemberNameSchemaFilter.RewriteEnumValues(schema, typeof(StringEnum?));
+
+        schema.Enum!.Select(node => node!.GetValue<string>())
+            .ShouldBe(["resolved", "cancelled", "Pending"]);
+    }
+
+    [Fact]
+    public void RewriteEnumValues_IntegerEnum_LeavesNumericValuesUntouched()
+    {
+        var schema = new OpenApiSchema
+        {
+            Enum = [0, 1]
+        };
+
+        JsonStringEnumMemberNameSchemaFilter.RewriteEnumValues(schema, typeof(IntEnum));
+
+        schema.Enum!.Select(node => node!.GetValue<int>()).ShouldBe([0, 1]);
+    }
+
+    [Fact]
+    public void RewriteEnumValues_NonEnumType_IsNoOp()
+    {
+        var schema = new OpenApiSchema
+        {
+            Enum = ["a", "b"]
+        };
+
+        JsonStringEnumMemberNameSchemaFilter.RewriteEnumValues(schema, typeof(string));
+
+        schema.Enum!.Select(node => node!.GetValue<string>()).ShouldBe(["a", "b"]);
+    }
+
+    [Fact]
+    public void RewriteEnumValues_SchemaWithoutEnum_IsNoOp()
+    {
+        var schema = new OpenApiSchema();
+
+        Should.NotThrow(() => JsonStringEnumMemberNameSchemaFilter.RewriteEnumValues(schema, typeof(StringEnum)));
+
+        schema.Enum.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Backports the [JsonStringEnumMemberName] OpenAPI fix from #209 to the **v17** line.

On v17 (Swashbuckle), the OpenAPI schema derives string-enum values from the .NET **member names** and ignores `[JsonStringEnumMemberName]`, so the generated TypeScript client advertises PascalCase values the server rejects under ASP.NET's case-sensitive Web JSON binding:

```ts
// before — does NOT match the wire, causes 400s
AGUIResumeStatusModel = 'Resolved' | 'Cancelled';
AGUIMessageRoleModel  = 'User' | 'Assistant' | ...;
```

Verified live against a running v17 site: the served `ai-agent-management` doc now emits the lowercase wire values, and the message models remain intact.

## Changes

- **New `JsonStringEnumMemberNameSchemaFilter`** (`Umbraco.AI.Web/Api/Common/Configuration`) — a Swashbuckle `ISchemaFilter` that rewrites string-enum schema values to their `[JsonStringEnumMemberName]` wire names. Skips integer and `[Flags]` enums; falls back to the member name when no attribute is present.
- **Registered via `PostConfigure<SwaggerGenOptions>`** — the key detail: Umbraco.Cms.Api.Common ships its own `EnumSchemaFilter` that reassigns the enum list from member names. Registering in `Configure` runs ours *before* Umbraco's, which clobbers the result; `PostConfigure` appends ours last so it wins.
- The filter **mutates the enum list in place** — reassigning `schema.Enum` is silently discarded because Swashbuckle/Microsoft.OpenApi retain the original list reference.
- **6 unit tests** (`InternalsVisibleTo` added for the test assembly), including a guard that the list reference is preserved.
- **Regenerated agent client** — `AGUIMessageRoleModel` / `AGUIResumeStatusModel` now use lowercase wire values. (Unrelated pre-existing client drift from a full regen was reverted; this PR carries only the enum-relevant client change.)

## Notes

- **v18 needs no equivalent fix** — its toolchain (`Microsoft.AspNetCore.OpenApi`) already honors `[JsonStringEnumMemberName]`. See #209 for the full cross-version analysis.
- Branch is named `feature/...` (no `v17/` prefix) because the v17 pre-push hook predates the version-prefix restructure and only accepts the older convention — flagged separately.

Refs #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)