### PR TITLE
fix(api): Honor JSON converters in OpenAPI schema generation

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Web/Api/Common/Configuration/ConfigureUmbracoAIHttpJsonOptions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Web/Api/Common/Configuration/ConfigureUmbracoAIHttpJsonOptions.cs
@@ -1,0 +1,82 @@
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Http.Json;
+using Microsoft.Extensions.Options;
+
+namespace Umbraco.AI.Web.Api.Common.Configuration;
+
+/// <summary>
+/// Bridges the named MVC <see cref="Microsoft.AspNetCore.Mvc.JsonOptions"/> for a single Umbraco AI
+/// management document into the matching named HTTP <see cref="JsonOptions"/>, so OpenAPI schema
+/// generation uses the same serializer settings (converters, naming policy, type-info resolver) as the
+/// wire.
+/// </summary>
+/// <remarks>
+/// Microsoft.AspNetCore.OpenApi generates schemas from the document's named HTTP <see cref="JsonOptions"/>,
+/// not the MVC options that drive controller serialization
+/// (see <see href="https://github.com/dotnet/aspnetcore/issues/66340"/>). Umbraco CMS works around this for
+/// its own document via <c>ConfigureUmbracoBackofficeHttpJsonOptions</c>, but that bridge is hard-scoped to
+/// the back-office document, so every Umbraco AI document (Core, Agent, Prompt, …) needs its own.
+///
+/// Without it, the named HTTP options are empty and schema generation falls back to defaults: enums that
+/// rely on the globally-registered <see cref="JsonStringEnumConverter"/> (rather than a type-level
+/// <c>[JsonConverter]</c>) are emitted as <c>integer</c> even though the wire value is a string — and the
+/// same mismatch affects every other custom converter (e.g. <c>IdOrAlias</c>, the UTC date converters).
+/// One instance is registered per document name; <see cref="ReplaceOpenApiSchemaService"/> (wired by the
+/// back-office document builder when <c>WithJsonOptions(documentName)</c> is set) then reads these options
+/// during schema generation.
+/// </remarks>
+internal sealed class ConfigureUmbracoAIHttpJsonOptions : IConfigureNamedOptions<JsonOptions>
+{
+    private readonly string _documentName;
+    private readonly IOptionsMonitor<Microsoft.AspNetCore.Mvc.JsonOptions> _mvcJsonOptions;
+
+    public ConfigureUmbracoAIHttpJsonOptions(
+        string documentName,
+        IOptionsMonitor<Microsoft.AspNetCore.Mvc.JsonOptions> mvcJsonOptions)
+    {
+        _documentName = documentName;
+        _mvcJsonOptions = mvcJsonOptions;
+    }
+
+    public void Configure(JsonOptions options) => Configure(Options.DefaultName, options);
+
+    public void Configure(string? name, JsonOptions options)
+    {
+        // Named options resolve this for every name; only mirror the document this instance owns.
+        if (name != _documentName)
+        {
+            return;
+        }
+
+        Microsoft.AspNetCore.Mvc.JsonOptions mvcOptions = _mvcJsonOptions.Get(_documentName);
+
+        // Copy only the string-enum converter. The framework special-cases JsonStringEnumConverter and
+        // renders a proper string enum schema (honoring [JsonStringEnumMemberName]); without it in the
+        // schema-generation options, enums relying on the globally-registered converter (rather than a
+        // type-level [JsonConverter]) are emitted as `integer`.
+        //
+        // We deliberately do NOT copy our other custom converters. Unlike the enum converter, an
+        // arbitrary JsonConverter makes its target type opaque to schema generation — e.g. copying the
+        // UTC DateTime converters drops `type: string` from date schemas (clients then see `unknown`),
+        // and IdOrAlias/Type are already handled via their own mechanisms. Leaving them out keeps those
+        // schemas as the framework's native, correct output.
+        foreach (JsonConverter converter in mvcOptions.JsonSerializerOptions.Converters)
+        {
+            if (converter is JsonStringEnumConverter)
+            {
+                options.SerializerOptions.Converters.Add(converter);
+            }
+        }
+
+        options.SerializerOptions.PropertyNamingPolicy = mvcOptions.JsonSerializerOptions.PropertyNamingPolicy;
+
+        // Emit 32/64-bit integers as numeric types instead of the framework default (a string with a
+        // numeric pattern), matching v17 and the pre-regression v18 clients.
+        options.SerializerOptions.NumberHandling = JsonNumberHandling.Strict;
+
+        // NOTE: we deliberately do NOT copy the MVC TypeInfoResolver. It carries an
+        // AlphabetizeProperties modifier used for deterministic wire output; applying it to schema
+        // generation would re-order every schema's properties alphabetically, diverging from the
+        // declaration order the generated clients have always used (v17 and pre-regression v18).
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Web/Api/Common/Configuration/UmbracoAIUmbracoBuilderExtensions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Web/Api/Common/Configuration/UmbracoAIUmbracoBuilderExtensions.cs
@@ -2,7 +2,9 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Umbraco.AI.Core.Serialization;
+using Umbraco.AI.Web.Api.Common.Configuration;
 using Umbraco.AI.Web.Api.Common.Json;
 using Umbraco.Cms.Api.Common.DependencyInjection;
 using Umbraco.Cms.Core.DependencyInjection;
@@ -43,6 +45,15 @@ public static class UmbracoAIUmbracoBuilderExtensions
 
                 configure?.Invoke(options.JsonSerializerOptions);
             });
+
+        // Mirror the relevant MVC JSON options above into the matching named HTTP JsonOptions, which is
+        // what Microsoft.AspNetCore.OpenApi uses for schema generation (via the back-office document
+        // builder's ReplaceOpenApiSchemaService). Without this, schema generation ignores our global
+        // string-enum converter and emits affected enums as `integer`. See ConfigureUmbracoAIHttpJsonOptions.
+        builder.Services.AddSingleton<IConfigureOptions<Microsoft.AspNetCore.Http.Json.JsonOptions>>(
+            sp => new ConfigureUmbracoAIHttpJsonOptions(
+                appName,
+                sp.GetRequiredService<IOptionsMonitor<Microsoft.AspNetCore.Mvc.JsonOptions>>()));
 
         return builder;
     }

--- a/Umbraco.AI/src/Umbraco.AI.Web/Umbraco.AI.Web.csproj
+++ b/Umbraco.AI/src/Umbraco.AI.Web/Umbraco.AI.Web.csproj
@@ -21,6 +21,9 @@
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
             <_Parameter1>Umbraco.AI.Startup</_Parameter1>
         </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Umbraco.AI.Tests.Unit</_Parameter1>
+        </AssemblyAttribute>
     </ItemGroup>
 
     <ItemGroup>

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Api/Common/Configuration/ConfigureUmbracoAIHttpJsonOptionsTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Api/Common/Configuration/ConfigureUmbracoAIHttpJsonOptionsTests.cs
@@ -1,0 +1,83 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Options;
+using Moq;
+using Shouldly;
+using Umbraco.AI.Web.Api.Common.Configuration;
+using HttpJsonOptions = Microsoft.AspNetCore.Http.Json.JsonOptions;
+using MvcJsonOptions = Microsoft.AspNetCore.Mvc.JsonOptions;
+
+namespace Umbraco.AI.Tests.Unit.Api.Common.Configuration;
+
+public class ConfigureUmbracoAIHttpJsonOptionsTests
+{
+    private const string DocumentName = "ai-management";
+
+    private sealed class DummyConverter : JsonConverter<int>
+    {
+        public override int Read(ref Utf8JsonReader reader, Type t, JsonSerializerOptions o) => 0;
+        public override void Write(Utf8JsonWriter writer, int value, JsonSerializerOptions o) { }
+    }
+
+    private static ConfigureUmbracoAIHttpJsonOptions CreateSut(MvcJsonOptions mvcOptions)
+    {
+        var monitor = new Mock<IOptionsMonitor<MvcJsonOptions>>();
+        monitor.Setup(m => m.Get(DocumentName)).Returns(mvcOptions);
+        return new ConfigureUmbracoAIHttpJsonOptions(DocumentName, monitor.Object);
+    }
+
+    [Fact]
+    public void Configure_MatchingDocument_CopiesEnumConverterAndSetsStrictNumbers()
+    {
+        // Arrange — MVC options carry both the string-enum converter and an unrelated custom converter.
+        var mvc = new MvcJsonOptions();
+        mvc.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        mvc.JsonSerializerOptions.Converters.Add(new DummyConverter());
+        mvc.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+
+        var sut = CreateSut(mvc);
+        var http = new HttpJsonOptions();
+
+        // Act
+        sut.Configure(DocumentName, http);
+
+        // Assert — the enum converter is copied; the unrelated converter is NOT (it would make its
+        // target type opaque in schema generation); numbers are strict; naming policy is mirrored.
+        http.SerializerOptions.Converters.OfType<JsonStringEnumConverter>().ShouldHaveSingleItem();
+        http.SerializerOptions.Converters.OfType<DummyConverter>().ShouldBeEmpty();
+        http.SerializerOptions.NumberHandling.ShouldBe(JsonNumberHandling.Strict);
+        http.SerializerOptions.PropertyNamingPolicy.ShouldBe(JsonNamingPolicy.CamelCase);
+    }
+
+    [Fact]
+    public void Configure_DoesNotCopyTypeInfoResolver()
+    {
+        // The MVC resolver alphabetizes properties for deterministic wire output; copying it would
+        // re-order every schema, diverging from the declaration order clients have always used.
+        var mvc = new MvcJsonOptions();
+        mvc.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        mvc.JsonSerializerOptions.TypeInfoResolver =
+            new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver();
+
+        var sut = CreateSut(mvc);
+        var http = new HttpJsonOptions();
+
+        sut.Configure(DocumentName, http);
+
+        http.SerializerOptions.TypeInfoResolver.ShouldNotBe(mvc.JsonSerializerOptions.TypeInfoResolver);
+    }
+
+    [Fact]
+    public void Configure_NonMatchingDocument_IsNoOp()
+    {
+        var mvc = new MvcJsonOptions();
+        mvc.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+
+        var sut = CreateSut(mvc);
+        var http = new HttpJsonOptions();
+
+        sut.Configure("some-other-document", http);
+
+        http.SerializerOptions.Converters.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the v18 OpenAPI enum regression (and the related numeric one) across **all** AI management documents — Core, Agent, Prompt, Search, etc. This is the canonical v18 fix for #209.

On v18, `Microsoft.AspNetCore.OpenApi` generates schemas from a document's named **HTTP** `JsonOptions`, not the **MVC** `JsonOptions` that drive controller serialization ([dotnet/aspnetcore#66340](https://github.com/dotnet/aspnetcore/issues/66340)). Our documents register their converters (the global `JsonStringEnumConverter`, etc.) only on the MVC options, so schema generation ignored them — emitting:

- enums that rely on the global converter (no type-level `[JsonConverter]`) as **`integer`** instead of strings — e.g. `AIPromptDisplayModeModel` became `number`, mismatching the wire and 400-prone;
- 64-bit integers as **string-with-pattern** instead of numbers.

Both diverge from v17 (Swashbuckle), where the schema correctly used the MVC serializer settings.

## Fix

Add `ConfigureUmbracoAIHttpJsonOptions` (an `IConfigureNamedOptions<Http.Json.JsonOptions>`, mirroring CMS's own `ConfigureUmbracoBackofficeHttpJsonOptions`), registered **per document** inside `AddJsonOptions`. It bridges the MVC options into the named HTTP options that CMS's `ReplaceOpenApiSchemaService` reads during schema generation. Because the registration lives in `AddJsonOptions`, every product going through `WithUmbracoAIManagementApi` is covered automatically.

It deliberately copies **only** what's safe and correct:
- ✅ the `JsonStringEnumConverter` — the framework special-cases it into a proper string-enum schema (honoring `[JsonStringEnumMemberName]`);
- ✅ `NumberHandling.Strict` — emits `int32`/`int64` as numerics, matching v17;
- ❌ **not** the other custom converters — an arbitrary converter makes its target type *opaque* to schema generation (copying the UTC date converters drops `type: string`, so clients see `unknown`);
- ❌ **not** the `TypeInfoResolver` — it carries an `AlphabetizeProperties` modifier that would reorder every schema, diverging from the declaration order clients have always used.

## Validation

Verified end-to-end against a running site for all three documents, compared to **v17** (the correct baseline), value-only (ignoring property order):

| | v17 | v18 before | v18 + fix |
|---|---|---|---|
| `AIPromptDisplayModeModel` | string | `number` ❌ | string ✅ |
| `int32`/`int64` (`total`, `version`) | `number` | `number \| string` ❌ | `number` ✅ |
| dates (`dateCreated`) | `string` | `string` | `string` ✅ |
| property order | declaration | declaration | declaration ✅ |

Order-insensitive value diff (no-fix → fix): **1 enum fix, 98 number fixes, 0 date changes, 0 properties added/removed, 0 unexpected changes**.

3 unit tests added (`InternalsVisibleTo` for the test assembly).

## Notes

- The generated clients are **not** regenerated here — the agent client can't be cleanly regenerated until #216 (custom-`[JsonConverter]` object types like `AGUIMessage` lose their schema), and a core/prompt regen also pulls a hey-api version bump better handled separately.

Refs #209. Related: #216 (converter-typed object schemas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)