### PR TITLE
fix(agent): Make AGUIMessage introspectable so OpenAPI emits its model

### DIFF
--- a/Umbraco.AI.Agent/src/Umbraco.AI.AGUI/Models/AGUIMessage.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.AGUI/Models/AGUIMessage.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Umbraco.AI.AGUI.Models;
@@ -7,7 +6,12 @@ namespace Umbraco.AI.AGUI.Models;
 /// Represents a message in the AG-UI protocol.
 /// Supports both plain string content and multimodal content parts (AG-UI multimodal messages draft).
 /// </summary>
-[JsonConverter(typeof(AGUIMessageJsonConverter))]
+/// <remarks>
+/// This is a plain POCO so Microsoft.AspNetCore.OpenApi can introspect it (and the types reachable only
+/// through it — <see cref="AGUIToolCall"/>, <see cref="AGUIMessageRole"/>, …). The only non-trivial field,
+/// <c>content</c> (string or multimodal array), is handled by a property-level converter on
+/// <see cref="RawContent"/> rather than a type-level converter on the whole message.
+/// </remarks>
 public sealed class AGUIMessage
 {
     /// <summary>
@@ -23,19 +27,68 @@ public sealed class AGUIMessage
     public AGUIMessageRole Role { get; set; }
 
     /// <summary>
-    /// Gets or sets the message content as plain text.
-    /// When <see cref="ContentParts"/> is set, this is derived from text content parts.
+    /// Gets or sets the wire representation of the <c>content</c> field (a JSON string or a multimodal
+    /// array). Prefer <see cref="Content"/> / <see cref="ContentParts"/> to read or write content.
     /// </summary>
     [JsonPropertyName("content")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Content { get; set; }
+    public AGUIMessageContent? RawContent { get; set; }
 
     /// <summary>
-    /// Gets or sets the multimodal content parts.
-    /// When set, the message contains mixed text and binary content (AG-UI multimodal messages draft).
+    /// Gets or sets the message content as plain text. When <see cref="ContentParts"/> is set, this is
+    /// derived from the text content parts. Backed by <see cref="RawContent"/>.
     /// </summary>
     [JsonIgnore]
-    public IList<AGUIInputContent>? ContentParts { get; set; }
+    public string? Content
+    {
+        get => RawContent?.Text;
+        set
+        {
+            if (value is null)
+            {
+                if (RawContent is not null)
+                {
+                    RawContent.Text = null;
+                    if (RawContent.Parts is null)
+                    {
+                        RawContent = null;
+                    }
+                }
+
+                return;
+            }
+
+            (RawContent ??= new AGUIMessageContent()).Text = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the multimodal content parts. When set, the content serializes as a JSON array.
+    /// Backed by <see cref="RawContent"/>.
+    /// </summary>
+    [JsonIgnore]
+    public IList<AGUIInputContent>? ContentParts
+    {
+        get => RawContent?.Parts;
+        set
+        {
+            if (value is null)
+            {
+                if (RawContent is not null)
+                {
+                    RawContent.Parts = null;
+                    if (RawContent.Text is null)
+                    {
+                        RawContent = null;
+                    }
+                }
+
+                return;
+            }
+
+            (RawContent ??= new AGUIMessageContent()).Parts = value;
+        }
+    }
 
     /// <summary>
     /// Gets or sets the optional name (for tool messages).
@@ -72,180 +125,4 @@ public sealed class AGUIMessage
     [JsonPropertyName("error")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Error { get; set; }
-}
-
-/// <summary>
-/// Custom JSON converter for <see cref="AGUIMessage"/> that handles the AG-UI multimodal messages draft.
-/// The <c>content</c> field can be either a JSON string or a JSON array of <see cref="AGUIInputContent"/> parts.
-/// </summary>
-internal sealed class AGUIMessageJsonConverter : JsonConverter<AGUIMessage>
-{
-    public override AGUIMessage? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-    {
-        if (reader.TokenType != JsonTokenType.StartObject)
-            throw new JsonException("Expected StartObject token for AGUIMessage.");
-
-        string? id = null;
-        var role = default(AGUIMessageRole);
-        string? content = null;
-        IList<AGUIInputContent>? contentParts = null;
-        string? name = null;
-        string? encryptedValue = null;
-        IEnumerable<AGUIToolCall>? toolCalls = null;
-        string? toolCallId = null;
-        string? error = null;
-
-        while (reader.Read())
-        {
-            if (reader.TokenType == JsonTokenType.EndObject)
-                break;
-
-            if (reader.TokenType != JsonTokenType.PropertyName)
-                throw new JsonException("Expected PropertyName token.");
-
-            var propertyName = reader.GetString();
-            reader.Read();
-
-            switch (propertyName)
-            {
-                case "id":
-                    id = reader.TokenType == JsonTokenType.Null ? null : reader.GetString();
-                    break;
-
-                case "role":
-                    role = JsonSerializer.Deserialize<AGUIMessageRole>(ref reader, options);
-                    break;
-
-                case "content":
-                    ReadContent(ref reader, ref content, ref contentParts, options);
-                    break;
-
-                case "name":
-                    name = reader.TokenType == JsonTokenType.Null ? null : reader.GetString();
-                    break;
-
-                case "encryptedValue":
-                    encryptedValue = reader.TokenType == JsonTokenType.Null ? null : reader.GetString();
-                    break;
-
-                case "toolCalls":
-                    toolCalls = reader.TokenType == JsonTokenType.Null
-                        ? null
-                        : JsonSerializer.Deserialize<List<AGUIToolCall>>(ref reader, options);
-                    break;
-
-                case "toolCallId":
-                    toolCallId = reader.TokenType == JsonTokenType.Null ? null : reader.GetString();
-                    break;
-
-                case "error":
-                    error = reader.TokenType == JsonTokenType.Null ? null : reader.GetString();
-                    break;
-
-                default:
-                    // Skip unknown properties
-                    reader.Skip();
-                    break;
-            }
-        }
-
-        if (id is null)
-        {
-            throw new JsonException("AGUIMessage 'id' is required by the AG-UI spec.");
-        }
-
-        return new AGUIMessage
-        {
-            Id = id,
-            Role = role,
-            Content = content,
-            ContentParts = contentParts,
-            Name = name,
-            EncryptedValue = encryptedValue,
-            ToolCalls = toolCalls,
-            ToolCallId = toolCallId,
-            Error = error,
-        };
-    }
-
-    private static void ReadContent(
-        ref Utf8JsonReader reader,
-        ref string? content,
-        ref IList<AGUIInputContent>? contentParts,
-        JsonSerializerOptions options)
-    {
-        switch (reader.TokenType)
-        {
-            case JsonTokenType.String:
-                // Plain string content (backward compatible)
-                content = reader.GetString();
-                break;
-
-            case JsonTokenType.StartArray:
-                // Multimodal content parts array
-                var parts = JsonSerializer.Deserialize<List<AGUIInputContent>>(ref reader, options);
-                contentParts = parts;
-                // Derive text content from text parts for backward compatibility
-                content = parts != null
-                    ? string.Join("", parts.OfType<AGUITextInputContent>().Select(t => t.Text))
-                    : null;
-                break;
-
-            case JsonTokenType.Null:
-                content = null;
-                break;
-
-            default:
-                throw new JsonException($"Unexpected token type {reader.TokenType} for 'content' property.");
-        }
-    }
-
-    public override void Write(Utf8JsonWriter writer, AGUIMessage value, JsonSerializerOptions options)
-    {
-        writer.WriteStartObject();
-
-        writer.WriteString("id", value.Id);
-
-        writer.WritePropertyName("role");
-        JsonSerializer.Serialize(writer, value.Role, options);
-
-        // Write content as array when ContentParts is set, otherwise as string
-        if (value.ContentParts != null)
-        {
-            writer.WritePropertyName("content");
-            JsonSerializer.Serialize(writer, value.ContentParts, options);
-        }
-        else if (value.Content != null)
-        {
-            writer.WriteString("content", value.Content);
-        }
-
-        if (value.Name != null)
-        {
-            writer.WriteString("name", value.Name);
-        }
-
-        if (value.EncryptedValue != null)
-        {
-            writer.WriteString("encryptedValue", value.EncryptedValue);
-        }
-
-        if (value.ToolCalls != null)
-        {
-            writer.WritePropertyName("toolCalls");
-            JsonSerializer.Serialize(writer, value.ToolCalls, options);
-        }
-
-        if (value.ToolCallId != null)
-        {
-            writer.WriteString("toolCallId", value.ToolCallId);
-        }
-
-        if (value.Error != null)
-        {
-            writer.WriteString("error", value.Error);
-        }
-
-        writer.WriteEndObject();
-    }
 }

--- a/Umbraco.AI.Agent/src/Umbraco.AI.AGUI/Models/AGUIMessageContent.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.AGUI/Models/AGUIMessageContent.cs
@@ -1,0 +1,85 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Umbraco.AI.AGUI.Models;
+
+/// <summary>
+/// Serialization shape of an <see cref="AGUIMessage"/>'s <c>content</c> field, which per the AG-UI
+/// multimodal messages draft is either a plain JSON string or a JSON array of
+/// <see cref="AGUIInputContent"/> parts.
+/// </summary>
+/// <remarks>
+/// This type carries the string-or-array handling in a <em>property-level</em> converter, so that
+/// <see cref="AGUIMessage"/> itself stays a plain POCO that Microsoft.AspNetCore.OpenApi can introspect
+/// (otherwise a type-level converter makes the whole message — and every type only reachable through it —
+/// opaque, dropping their schemas). Prefer <see cref="AGUIMessage.Content"/> and
+/// <see cref="AGUIMessage.ContentParts"/> to read or write content; this type is the wire representation.
+/// </remarks>
+[JsonConverter(typeof(AGUIMessageContentJsonConverter))]
+public sealed class AGUIMessageContent
+{
+    /// <summary>
+    /// Gets or sets the plain-text content. When the content is a multimodal array, this is derived
+    /// from the text parts for backward compatibility.
+    /// </summary>
+    public string? Text { get; set; }
+
+    /// <summary>
+    /// Gets or sets the multimodal content parts. When set, the content serializes as a JSON array.
+    /// </summary>
+    public IList<AGUIInputContent>? Parts { get; set; }
+
+    /// <summary>
+    /// Derives a plain-text representation by concatenating the text parts.
+    /// </summary>
+    internal static string DeriveText(IList<AGUIInputContent> parts)
+        => string.Join("", parts.OfType<AGUITextInputContent>().Select(t => t.Text));
+}
+
+/// <summary>
+/// Reads/writes <see cref="AGUIMessageContent"/> as the AG-UI <c>content</c> field — a JSON string or a
+/// JSON array of <see cref="AGUIInputContent"/> parts.
+/// </summary>
+internal sealed class AGUIMessageContentJsonConverter : JsonConverter<AGUIMessageContent>
+{
+    public override AGUIMessageContent? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.Null:
+                return null;
+
+            case JsonTokenType.String:
+                return new AGUIMessageContent { Text = reader.GetString() };
+
+            case JsonTokenType.StartArray:
+                var parts = JsonSerializer.Deserialize<List<AGUIInputContent>>(ref reader, options);
+                return new AGUIMessageContent
+                {
+                    Parts = parts,
+                    // Derive text from text parts for backward compatibility with string-only consumers.
+                    Text = parts is not null ? AGUIMessageContent.DeriveText(parts) : null,
+                };
+
+            default:
+                throw new JsonException($"Unexpected token type {reader.TokenType} for 'content'.");
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, AGUIMessageContent value, JsonSerializerOptions options)
+    {
+        // Write the array form when parts are present, otherwise the string form (matching the AG-UI spec).
+        if (value.Parts is not null)
+        {
+            JsonSerializer.Serialize(writer, value.Parts, options);
+        }
+        else if (value.Text is not null)
+        {
+            writer.WriteStringValue(value.Text);
+        }
+        else
+        {
+            writer.WriteNullValue();
+        }
+    }
+}

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/AGUI/AGUIMessageSchemaTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/AGUI/AGUIMessageSchemaTests.cs
@@ -1,0 +1,82 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Shouldly;
+using Umbraco.AI.AGUI.Models;
+using Xunit;
+
+namespace Umbraco.AI.Agent.Tests.Unit.AGUI;
+
+/// <summary>
+/// Guards for #216: AGUIMessage must stay a plain POCO (no type-level converter) so OpenAPI can
+/// introspect it, while the Content/ContentParts accessors keep their behavior over the backing
+/// <see cref="AGUIMessageContent"/>.
+/// </summary>
+public class AGUIMessageSchemaTests
+{
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public void AGUIMessage_HasNoTypeLevelConverter()
+    {
+        // A type-level [JsonConverter] makes the whole message (and every type only reachable through
+        // it) opaque to Microsoft.AspNetCore.OpenApi. Keeping it off is the fix for #216.
+        typeof(AGUIMessage).GetCustomAttribute<JsonConverterAttribute>().ShouldBeNull();
+    }
+
+    [Fact]
+    public void Content_And_ContentParts_ShareBackingContent()
+    {
+        var message = new AGUIMessage { Id = "1", Role = AGUIMessageRole.User };
+
+        message.Content = "hello";
+        message.ContentParts = [new AGUITextInputContent { Text = "world" }];
+
+        // Both accessors read from the same backing AGUIMessageContent.
+        message.Content.ShouldBe("hello");
+        message.ContentParts.ShouldNotBeNull();
+        message.ContentParts.Count.ShouldBe(1);
+        message.RawContent.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void ClearingOneAccessor_PreservesTheOther()
+    {
+        var message = new AGUIMessage
+        {
+            Id = "1",
+            Role = AGUIMessageRole.User,
+            Content = "hello",
+            ContentParts = [new AGUITextInputContent { Text = "world" }],
+        };
+
+        message.Content = null;
+
+        message.Content.ShouldBeNull();
+        message.ContentParts.ShouldNotBeNull(); // parts retained
+        message.RawContent.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void ClearingBothAccessors_NullsBackingContent()
+    {
+        var message = new AGUIMessage { Id = "1", Role = AGUIMessageRole.User, Content = "hello" };
+
+        message.Content = null;
+
+        message.RawContent.ShouldBeNull();
+    }
+
+    [Fact]
+    public void StringContent_RoundTripsThroughBackingProperty()
+    {
+        var message = new AGUIMessage { Id = "1", Role = AGUIMessageRole.User, Content = "hi" };
+
+        var json = JsonSerializer.Serialize(message, Options);
+        var roundTripped = JsonSerializer.Deserialize<AGUIMessage>(json, Options);
+
+        json.ShouldContain("\"content\":\"hi\"");
+        roundTripped!.Content.ShouldBe("hi");
+        roundTripped.ContentParts.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Closes #216. Restores the typed `AGUIMessageModel` (and the sub-models that vanished with it) in the v18 OpenAPI schema.

`AGUIMessage` had a **type-level** `[JsonConverter]` whose only real job was handling the `content` field being either a JSON string or a multimodal array. Under `Microsoft.AspNetCore.OpenApi`, a custom type-level converter makes the type **opaque** — so no `AGUIMessageModel` schema was generated, the types reachable only through it (`AGUIToolCall`, `AGUIFunctionCall`, `AGUIMessageRole`) disappeared too, and `AGUIRunRequestModel.messages` became an untyped array. A client regen would drop those types and break the transport.

## Fix (property-level converter)

Move the string-or-array handling down to the `content` field so the message itself is a plain, introspectable POCO:

- **New `AGUIMessageContent`** value-type (`Text` + `Parts`) carrying a **property-level** `AGUIMessageContentJsonConverter` with the exact read/write + text-derivation logic from the old converter.
- **`AGUIMessage`** is now a plain POCO (old `AGUIMessageJsonConverter` deleted). The `content` field serializes via a backing `RawContent` property; the public **`Content` (string) / `ContentParts` (IList) API is unchanged** — kept as convenience accessors over the backing content, so **no consumer or test churn**.

## Result (verified against a running site)

OpenAPI now emits:
- `AGUIMessageModel` — `{ id, role: AGUIMessageRoleModel, content?, name?, encryptedValue?, toolCalls?: Array<AGUIToolCallModel>, toolCallId?, error? }`
- `AGUIToolCallModel`, `AGUIFunctionCallModel`, and the `AGUIMessageRoleModel` string enum
- `AGUIRunRequestModel.messages` → `Array<AGUIMessageModel>`

`content` stays loosely typed (`unknown`) — intrinsic, since it's genuinely string-or-array; the transport handles it.

## Validation

- **All 86 existing AGUI tests pass unchanged** — proving wire behavior (string/array content, round-trips, multimodal, file processing) is preserved.
- **5 new guard tests** — `AGUIMessage` has no type-level converter (the regression guard), Content/ContentParts accessor coordination, and round-trip.
- Confirmed `generate-client:agent` regenerates `AGUIMessageModel` et al. correctly and satisfies the transport's imports.

## Notes

- **Client not regenerated here** (backend-only, matching #217). The consolidated client regen — which also picks up #217's enum/number fixes and the pinned hey-api output — is best as one separate commit once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)