### PR TITLE
feat(agent): Backend tool HITL approval (backport of #212 to v17)

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -5,7 +5,7 @@
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 
 # Handle release/hotfix branches - commit staged manifest if present
-if echo "$current_branch" | grep -qE '^(release|hotfix)/'; then
+if echo "$current_branch" | grep -qE '^v[0-9]+/(release|hotfix)/'; then
     # Check if release-manifest.json is staged but not committed
     if git diff --cached --name-only | grep -q "^release-manifest.json$"; then
         echo "📝 Committing staged release-manifest.json after merge to $current_branch..."
@@ -19,8 +19,8 @@ if echo "$current_branch" | grep -qE '^(release|hotfix)/'; then
     exit 0
 fi
 
-# Handle long-term branches (main/dev/support) - remove manifest
-if [ "$current_branch" = "main" ] || [ "$current_branch" = "dev" ] || echo "$current_branch" | grep -q "^support/"; then
+# Handle long-term branches (vN/main, vN/dev) - remove manifest
+if echo "$current_branch" | grep -qE '^v[0-9]+/(main|dev)$'; then
     # Check if release-manifest.json exists
     if [ -f "release-manifest.json" ]; then
         echo "🧹 Cleaning up release-manifest.json after merge to $current_branch..."

--- a/.githooks/post-merge.ps1
+++ b/.githooks/post-merge.ps1
@@ -6,7 +6,7 @@ $ErrorActionPreference = "SilentlyContinue"
 $currentBranch = git rev-parse --abbrev-ref HEAD 2>$null
 
 # Handle release/hotfix branches - commit staged manifest if present
-if ($currentBranch -match '^(release|hotfix)/') {
+if ($currentBranch -match '^v\d+/(release|hotfix)/') {
     # Check if release-manifest.json is staged but not committed
     $stagedFiles = git diff --cached --name-only 2>$null
     if ($stagedFiles -and ($stagedFiles -split "`n" | Where-Object { $_ -eq "release-manifest.json" })) {
@@ -21,8 +21,8 @@ if ($currentBranch -match '^(release|hotfix)/') {
     exit 0
 }
 
-# Handle long-term branches (main/dev/support) - remove manifest
-if ($currentBranch -eq "main" -or $currentBranch -eq "dev" -or $currentBranch -match "^support/") {
+# Handle long-term branches (vN/main, vN/dev) - remove manifest
+if ($currentBranch -match '^v\d+/(main|dev)$') {
     # Check if release-manifest.json exists
     $manifestFile = Join-Path $PSScriptRoot ".." "release-manifest.json"
     if (Test-Path $manifestFile) {

--- a/.githooks/pre-merge-commit
+++ b/.githooks/pre-merge-commit
@@ -5,7 +5,7 @@
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 
 # Only run on release or hotfix branches
-if ! echo "$current_branch" | grep -qE "^(release|hotfix)/"; then
+if ! echo "$current_branch" | grep -qE "^v[0-9]+/(release|hotfix)/"; then
     exit 0
 fi
 

--- a/.githooks/pre-merge-commit.ps1
+++ b/.githooks/pre-merge-commit.ps1
@@ -6,7 +6,7 @@ $ErrorActionPreference = "Stop"
 $currentBranch = git rev-parse --abbrev-ref HEAD 2>$null
 
 # Only run on release or hotfix branches
-if ($currentBranch -notmatch '^(release|hotfix)/') {
+if ($currentBranch -notmatch '^v\d+/(release|hotfix)/') {
     exit 0
 }
 

--- a/.githooks/pre-push.ps1
+++ b/.githooks/pre-push.ps1
@@ -1,10 +1,11 @@
 # Pre-push hook to validate branch naming conventions for Umbraco.AI monorepo
 # Valid patterns:
-#   - main
-#   - dev
-#   - feature/<anything>
-#   - release/<anything>
-#   - hotfix/<anything>
+#   - v<N>/dev
+#   - v<N>/main
+#   - v<N>/feature/<anything>
+#   - v<N>/release/<anything>
+#   - v<N>/hotfix/<anything>
+#   - claude/<anything>
 
 $ErrorActionPreference = "Stop"
 
@@ -16,14 +17,13 @@ if ([string]::IsNullOrEmpty($currentBranch)) {
     exit 1
 }
 
-# Allow main and dev branches
-if ($currentBranch -eq "main" -or $currentBranch -eq "dev") {
-    exit 0
-}
-
 # Check if branch matches valid patterns
 $validBranch = $false
-if ($currentBranch -match "^(feature|claude|release|hotfix|support)/.+") {
+if ($currentBranch -match "^v\d+/(dev|main)$") {
+    $validBranch = $true
+} elseif ($currentBranch -match "^v\d+/(feature|release|hotfix)/.+") {
+    $validBranch = $true
+} elseif ($currentBranch -match "^claude/.+") {
     $validBranch = $true
 }
 
@@ -33,16 +33,18 @@ if (-not $validBranch) {
     Write-Host "========================================" -ForegroundColor Red
     Write-Host ""
     Write-Host "Branch names must follow one of these patterns:"
-    Write-Host "  main"
-    Write-Host "  dev"
-    Write-Host "  feature/<anything>"
-    Write-Host "  release/<anything>"
-    Write-Host "  hotfix/<anything>"
+    Write-Host "  v<N>/dev"
+    Write-Host "  v<N>/main"
+    Write-Host "  v<N>/feature/<anything>"
+    Write-Host "  v<N>/release/<anything>"
+    Write-Host "  v<N>/hotfix/<anything>"
+    Write-Host "  claude/<anything>"
     Write-Host ""
     Write-Host "Examples:"
-    Write-Host "  feature/add-caching"
-    Write-Host "  release/2026.01"
-    Write-Host "  hotfix/2026.01.1"
+    Write-Host "  v18/dev"
+    Write-Host "  v18/feature/add-caching"
+    Write-Host "  v17/release/2026.01"
+    Write-Host "  v17/hotfix/2026.01.1"
     Write-Host "========================================" -ForegroundColor Red
     exit 1
 }

--- a/.githooks/pre-push.sh
+++ b/.githooks/pre-push.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 # Pre-push hook to validate branch naming conventions for Umbraco.AI monorepo
 # Valid patterns:
-#   - main
-#   - dev
-#   - feature/<anything>
-#   - release/<anything>
-#   - hotfix/<anything>
+#   - v<N>/dev
+#   - v<N>/main
+#   - v<N>/feature/<anything>
+#   - v<N>/release/<anything>
+#   - v<N>/hotfix/<anything>
+#   - claude/<anything>
 
 # Get current branch name
 current_branch=$(git symbolic-ref --short HEAD 2>/dev/null)
@@ -15,14 +16,13 @@ if [ -z "$current_branch" ]; then
     exit 1
 fi
 
-# Allow main and dev branches
-if [ "$current_branch" = "main" ] || [ "$current_branch" = "dev" ]; then
-    exit 0
-fi
-
 # Check if branch matches valid patterns
 valid_branch=false
-if [[ $current_branch =~ ^(feature|claude|release|hotfix|support)/.+ ]]; then
+if [[ $current_branch =~ ^v[0-9]+/(dev|main)$ ]]; then
+    valid_branch=true
+elif [[ $current_branch =~ ^v[0-9]+/(feature|release|hotfix)/.+ ]]; then
+    valid_branch=true
+elif [[ $current_branch =~ ^claude/.+ ]]; then
     valid_branch=true
 fi
 
@@ -32,16 +32,18 @@ if [ "$valid_branch" = false ]; then
     echo "========================================" >&2
     echo "" >&2
     echo "Branch names must follow one of these patterns:" >&2
-    echo "  main" >&2
-    echo "  dev" >&2
-    echo "  feature/<anything>" >&2
-    echo "  release/<anything>" >&2
-    echo "  hotfix/<anything>" >&2
+    echo "  v<N>/dev" >&2
+    echo "  v<N>/main" >&2
+    echo "  v<N>/feature/<anything>" >&2
+    echo "  v<N>/release/<anything>" >&2
+    echo "  v<N>/hotfix/<anything>" >&2
+    echo "  claude/<anything>" >&2
     echo "" >&2
     echo "Examples:" >&2
-    echo "  feature/add-caching" >&2
-    echo "  release/2026.01" >&2
-    echo "  hotfix/2026.01.1" >&2
+    echo "  v18/dev" >&2
+    echo "  v18/feature/add-caching" >&2
+    echo "  v17/release/2026.01" >&2
+    echo "  v17/hotfix/2026.01.1" >&2
     echo "========================================" >&2
     exit 1
 fi

--- a/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/services/run.controller.ts
+++ b/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/services/run.controller.ts
@@ -242,10 +242,42 @@ export class UaiRunController extends UmbControllerBase {
                     // Text complete
                 },
                 onToolCallStart: (info) => {
+                    let messages = [...this.#messages.value];
+
+                    // A backend HITL approval call is emitted once on the initial run (shown
+                    // pending while awaiting approval) and AGAIN on the resume run once it
+                    // actually executes. Correlate by tool call id so the existing entry
+                    // transitions in place — matching the single-entry frontend-tool behaviour —
+                    // rather than appending a duplicate card.
+                    const existingIndex = messages.findIndex(
+                        (m) => m.role === "assistant" && m.toolCalls?.some((tc) => tc.id === info.id),
+                    );
+
+                    if (existingIndex !== -1) {
+                        const existing = messages[existingIndex];
+                        // A denied approval call is already marked "error"; don't revive it to
+                        // "executing" if the resume stream happens to re-surface the call.
+                        const nextStatus = (tc: UaiToolCallInfo): UaiToolCallStatus =>
+                            tc.status === "error" ? "error" : "executing";
+                        messages[existingIndex] = {
+                            ...existing,
+                            toolCalls: existing.toolCalls!.map((tc) =>
+                                tc.id === info.id ? { ...tc, status: nextStatus(tc) } : tc,
+                            ),
+                        };
+                        this.#currentAssistantMessageId = existing.id;
+                        const existingCall = existing.toolCalls!.find((tc) => tc.id === info.id);
+                        this.#currentToolCalls = [
+                            ...this.#currentToolCalls.filter((tc) => tc.id !== info.id),
+                            { ...info, status: existingCall ? nextStatus(existingCall) : "executing" },
+                        ];
+                        this.#messages.next(messages);
+                        this.#agentState.next({ status: "executing", currentStep: `Calling ${info.name}...` });
+                        return;
+                    }
+
                     const toolCall: UaiToolCallInfo = { ...info, status: "pending" };
                     this.#currentToolCalls = [...this.#currentToolCalls, toolCall];
-
-                    let messages = [...this.#messages.value];
 
                     if (!this.#currentAssistantMessageId) {
                         const newMessage: UaiChatMessage = {
@@ -314,9 +346,32 @@ export class UaiRunController extends UmbControllerBase {
         this.#messages.next(messages);
     }
 
+    /**
+     * Sets the status (and optional result) of a tool call by id, wherever it lives in the
+     * conversation. Used to mark a denied backend-approval call as errored at decision time.
+     */
+    #setToolCallStatus(toolCallId: string, status: UaiToolCallStatus, result?: string): void {
+        const patch = (tc: UaiToolCallInfo): UaiToolCallInfo =>
+            tc.id === toolCallId ? { ...tc, status, ...(result !== undefined ? { result } : {}) } : tc;
+
+        this.#currentToolCalls = this.#currentToolCalls.map(patch);
+        this.#messages.next(
+            this.#messages.value.map((msg) =>
+                msg.role === "assistant" && msg.toolCalls?.some((tc) => tc.id === toolCallId)
+                    ? { ...msg, toolCalls: msg.toolCalls.map(patch) }
+                    : msg,
+            ),
+        );
+    }
+
     #handleServerToolResult(toolCallId: string, result: string): void {
+        // Preserve a denied approval call's "error" status — don't let the resume stream's
+        // result flip it to a completed tick.
+        const nextStatus = (tc: UaiToolCallInfo): UaiToolCallStatus =>
+            tc.status === "error" ? "error" : "completed";
+
         this.#currentToolCalls = this.#currentToolCalls.map((tc) =>
-            tc.id === toolCallId ? { ...tc, status: "completed", result } : tc,
+            tc.id === toolCallId ? { ...tc, status: nextStatus(tc), result } : tc,
         );
 
         const updated = this.#messages.value.map((msg) => {
@@ -324,7 +379,7 @@ export class UaiRunController extends UmbControllerBase {
                 return {
                     ...msg,
                     toolCalls: msg.toolCalls.map((tc) =>
-                        tc.id === toolCallId ? { ...tc, status: "completed" as const, result } : tc,
+                        tc.id === toolCallId ? { ...tc, status: nextStatus(tc), result } : tc,
                     ),
                 };
             }
@@ -358,7 +413,7 @@ export class UaiRunController extends UmbControllerBase {
         }
 
         if (event.outcome === "interrupt" && event.interrupt) {
-            const context = this.#createInterruptContext(assistantMessageId);
+            const context = this.#createInterruptContext(assistantMessageId, event.interrupt);
             if (this.#handlerRegistry.handle(event.interrupt, context)) {
                 return;
             }
@@ -367,9 +422,9 @@ export class UaiRunController extends UmbControllerBase {
         this.#agentState.next(undefined);
     }
 
-    #createInterruptContext(assistantMessageId: string | null): UaiInterruptContext {
+    #createInterruptContext(assistantMessageId: string | null, interrupt?: UaiInterruptInfo): UaiInterruptContext {
         return {
-            resume: (response?: unknown) => this.#resumeRun(response),
+            resume: (response?: unknown) => this.#resumeRun(response, interrupt),
             setAgentState: (state?: UaiAgentState) => this.#agentState.next(state),
             lastAssistantMessageId: assistantMessageId ?? this.#currentAssistantMessageId ?? undefined,
             messages: this.#messages.value,
@@ -387,7 +442,41 @@ export class UaiRunController extends UmbControllerBase {
         this.#agentState.next(undefined);
     }
 
-    #resumeRun(response?: unknown): void {
+    #resumeRun(response?: unknown, interrupt?: UaiInterruptInfo): void {
+        // Backend human_approval interrupts resume via an AG-UI resume entry — NOT a chat
+        // message. The decision payload ({ approved: bool }) is correlated server-side by
+        // the interrupt id ("approval:<callId>"); the pending tool call is already replayed
+        // in the assistant message history, so we must not inject the raw decision as a
+        // user turn (it would pollute the conversation and skip the resume path entirely).
+        if (interrupt?.reason === "human_approval") {
+            const payload = typeof response === "string" ? safeParseJson(response) : response;
+            const approved = (payload as { approved?: boolean } | null)?.approved === true;
+
+            // On denial, mark the pending approval tool-call entry as errored (red) so it matches
+            // the frontend-tool deny UX (#handleToolResult maps a denied result to "error", not a
+            // completed tick). The run still resumes so the model is told it was denied and can
+            // respond; the guards in onToolCallStart / #handleServerToolResult keep the resume
+            // stream from flipping this back to executing/completed.
+            if (!approved) {
+                const toolCallId =
+                    (interrupt.payload?.toolCallId as string | undefined) ??
+                    (interrupt.id.startsWith("approval:") ? interrupt.id.slice("approval:".length) : undefined);
+                if (toolCallId) {
+                    this.#setToolCallStatus(toolCallId, "error", "Approval denied");
+                }
+            }
+
+            this.#agentState.next({ status: "thinking" });
+            const frontendTools = this.#frontendToolManager?.frontendTools ?? [];
+            this.#client?.sendMessage(this.#messages.value, frontendTools, this.#pendingContext, [
+                { interruptId: interrupt.id, status: "resolved", payload },
+            ]);
+            return;
+        }
+
+        // Frontend tool_call / generic resume: the tool result is already appended to the
+        // message history (#handleToolResult), so re-sending the messages resumes the run.
+        // A non-undefined response is surfaced as a user turn (legacy input-interrupt path).
         if (response !== undefined) {
             const userMessage: UaiChatMessage = {
                 id: crypto.randomUUID(),

--- a/Umbraco.AI.Agent/Umbraco.AI.Agent.slnx
+++ b/Umbraco.AI.Agent/Umbraco.AI.Agent.slnx
@@ -5,6 +5,7 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/Tests/">
+    <Project Path="tests/Umbraco.AI.Agent.Tests.Integration/Umbraco.AI.Agent.Tests.Integration.csproj" />
     <Project Path="tests/Umbraco.AI.Agent.Tests.Unit/Umbraco.AI.Agent.Tests.Unit.csproj" />
   </Folder>
   <Project Path="src/Umbraco.AI.Agent.Core/Umbraco.AI.Agent.Core.csproj" />

--- a/Umbraco.AI.Agent/src/Umbraco.AI.AGUI/Streaming/AGUIEventEmitter.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.AGUI/Streaming/AGUIEventEmitter.cs
@@ -30,6 +30,7 @@ public sealed class AGUIEventEmitter
     private readonly string _runId;
     private readonly HashSet<string> _emittedToolCallIds = new();
     private readonly HashSet<string> _frontendToolCallIds = new();
+    private readonly List<(string InterruptId, string ToolCallId, string ToolName, string ArgsJson)> _approvalInterrupts = new();
 
     private string _currentMessageId;
     private string? _lastGeneratedCallId;
@@ -65,6 +66,11 @@ public sealed class AGUIEventEmitter
     /// Gets whether any frontend tool calls have been emitted.
     /// </summary>
     public bool HasFrontendToolCalls => _frontendToolCallIds.Count > 0;
+
+    /// <summary>
+    /// Gets whether any backend tool approval requests have been registered.
+    /// </summary>
+    public bool HasApprovalRequests => _approvalInterrupts.Count > 0;
 
     /// <summary>
     /// Gets the set of frontend tool call IDs that have been emitted.
@@ -217,6 +223,19 @@ public sealed class AGUIEventEmitter
     };
 
     /// <summary>
+    /// Registers a pending backend tool approval request to be included in the next
+    /// <see cref="EmitRunFinished"/> call as a <c>human_approval</c> interrupt.
+    /// </summary>
+    /// <param name="interruptId">
+    /// The AG-UI interrupt ID (opaque; typically built by <c>AGUIInterruptKind.ForApproval</c>).
+    /// </param>
+    /// <param name="toolCallId">The MEAI tool call ID for correlation with the resume entry.</param>
+    /// <param name="toolName">The name of the tool requesting approval.</param>
+    /// <param name="argsJson">The serialized arguments JSON for display in the approval UI.</param>
+    public void RegisterApprovalRequest(string interruptId, string toolCallId, string toolName, string argsJson)
+        => _approvalInterrupts.Add((interruptId, toolCallId, toolName, argsJson));
+
+    /// <summary>
     /// Emits a <see cref="RunFinishedEvent"/> with the appropriate outcome.
     /// </summary>
     /// <returns>The run finished event.</returns>
@@ -237,19 +256,33 @@ public sealed class AGUIEventEmitter
     /// </remarks>
     public RunFinishedEvent EmitRunFinished()
     {
-        AGUIRunOutcome outcome = HasFrontendToolCalls
-            ? new AGUIRunOutcomeInterrupt(
-                _frontendToolCallIds
-                    .Select(toolCallId => new AGUIInterruptInfo
-                    {
-                        // Use toolCallId as the interrupt id so the server can recover
-                        // the corresponding tool call from a resume entry without
-                        // having to track an interruptId -> toolCallId mapping.
-                        Id = toolCallId,
-                        Reason = "tool_call",
-                        ToolCallId = toolCallId,
-                    })
-                    .ToList())
+        var interrupts = new List<AGUIInterruptInfo>();
+
+        // Frontend tool interrupts — client executes these, so the agent is paused waiting for result.
+        interrupts.AddRange(_frontendToolCallIds.Select(toolCallId => new AGUIInterruptInfo
+        {
+            // Use toolCallId as the interrupt id so the server can recover the
+            // corresponding tool call from a resume entry without server-side state.
+            Id = toolCallId,
+            Reason = "tool_call",
+            ToolCallId = toolCallId,
+        }));
+
+        // Backend tool approval interrupts — user must approve before execution.
+        interrupts.AddRange(_approvalInterrupts.Select(a => new AGUIInterruptInfo
+        {
+            Id = a.InterruptId,
+            Reason = "human_approval",
+            ToolCallId = a.ToolCallId,
+            Metadata = new Dictionary<string, object?>
+            {
+                ["toolName"] = a.ToolName,
+                ["args"] = a.ArgsJson,
+            },
+        }));
+
+        AGUIRunOutcome outcome = interrupts.Count > 0
+            ? new AGUIRunOutcomeInterrupt(interrupts)
             : new AGUIRunOutcomeSuccess();
 
         return new RunFinishedEvent

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/AGUI/AGUIInterruptKind.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/AGUI/AGUIInterruptKind.cs
@@ -1,0 +1,28 @@
+namespace Umbraco.AI.Agent.Core.AGUI;
+
+/// <summary>
+/// Helpers for building and recognising Umbraco-specific AG-UI interrupt IDs.
+/// </summary>
+/// <remarks>
+/// Encodes the interrupt category as a namespaced prefix in the AG-UI interrupt ID so that
+/// the stateless resume path can reconstruct the correct <c>ToolApprovalResponseContent</c>
+/// without needing server-side state.
+/// </remarks>
+internal static class AGUIInterruptKind
+{
+    private const string ApprovalPrefix = "approval:";
+
+    /// <summary>Returns an interrupt ID for a backend tool approval request.</summary>
+    public static string ForApproval(string callId) => $"{ApprovalPrefix}{callId}";
+
+    /// <summary>Returns <c>true</c> when <paramref name="interruptId"/> encodes a tool approval request.</summary>
+    public static bool IsApproval(string interruptId) =>
+        interruptId.StartsWith(ApprovalPrefix, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Extracts the underlying MEAI <c>FunctionCallContent.CallId</c> from an approval interrupt ID,
+    /// or <c>null</c> if the ID is not an approval interrupt.
+    /// </summary>
+    public static string? GetCallId(string interruptId) =>
+        IsApproval(interruptId) ? interruptId[ApprovalPrefix.Length..] : null;
+}

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/AGUI/AGUIStreamingService.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/AGUI/AGUIStreamingService.cs
@@ -159,7 +159,12 @@ internal sealed class AGUIStreamingService : IAGUIStreamingService
         // Per AG-UI spec the resume array contains one entry per open interrupt.
         if (request.Resume is { Count: > 0 })
         {
-            var resumeMessages = ExtractToolResultsFromResume(request.Resume);
+            // Promote FunctionCallContent → ToolApprovalRequestContent in the converted history
+            // for any approval interrupt. FICC needs the original request present in the
+            // replayed history to correlate the ToolApprovalResponseContent (spike Finding B).
+            PromoteApprovalRequestsInHistory(chatMessages, request.Resume);
+
+            var resumeMessages = ExtractToolResultsFromResume(chatMessages, request.Resume);
             chatMessages.AddRange(resumeMessages);
 
             _logger.LogDebug(
@@ -183,6 +188,26 @@ internal sealed class AGUIStreamingService : IAGUIStreamingService
                 {
                     switch (content)
                     {
+                        case ToolApprovalRequestContent approvalRequest:
+                            // MEAI's FunctionInvokingChatClient emits this instead of executing
+                            // a destructive tool wrapped in ApprovalRequiredAIFunction.
+                            // Emit the tool call event so the frontend sees the pending call,
+                            // then register the approval interrupt for EmitRunFinished.
+                            if (approvalRequest.ToolCall is FunctionCallContent pendingCall)
+                            {
+                                var approvalInterruptId = AGUIInterruptKind.ForApproval(pendingCall.CallId);
+                                var argsJson = pendingCall.Arguments is not null
+                                    ? System.Text.Json.JsonSerializer.Serialize(pendingCall.Arguments)
+                                    : "{}";
+                                var pendingEvent = emitter.EmitToolCall(pendingCall.CallId, pendingCall.Name, pendingCall.Arguments, isFrontendTool: false);
+                                if (pendingEvent != null)
+                                {
+                                    yield return pendingEvent;
+                                }
+                                emitter.RegisterApprovalRequest(approvalInterruptId, pendingCall.CallId, pendingCall.Name, argsJson);
+                            }
+                            break;
+
                         case FunctionCallContent functionCall:
                             // Diagnostic: this log line is the smoking gun for "model
                             // generated a tool_use but no TOOL_CALL_CHUNK reached the
@@ -305,21 +330,83 @@ internal sealed class AGUIStreamingService : IAGUIStreamingService
     }
 
     /// <summary>
-    /// Converts AG-UI resume entries into M.E.AI tool-result chat messages.
+    /// Promotes <see cref="FunctionCallContent"/> to <see cref="ToolApprovalRequestContent"/>
+    /// in-place for any assistant message whose tool call is covered by an approval resume entry.
+    /// FICC requires the original approval request to be present in the replayed history so it
+    /// can correlate the matching <see cref="ToolApprovalResponseContent"/> (spike Finding B).
+    /// </summary>
+    private static void PromoteApprovalRequestsInHistory(
+        List<ChatMessage> chatMessages,
+        IReadOnlyList<AGUIResumeEntry> resume)
+    {
+        var approvalCallIds = resume
+            .Where(e => AGUIInterruptKind.IsApproval(e.InterruptId))
+            .Select(e => AGUIInterruptKind.GetCallId(e.InterruptId)!)
+            .Where(id => !string.IsNullOrEmpty(id))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        if (approvalCallIds.Count == 0) return;
+
+        for (var i = 0; i < chatMessages.Count; i++)
+        {
+            var msg = chatMessages[i];
+            if (msg.Role != ChatRole.Assistant || msg.Contents is null) continue;
+
+            var modified = false;
+            var newContents = new List<AIContent>(msg.Contents.Count);
+
+            foreach (var content in msg.Contents)
+            {
+                if (content is FunctionCallContent fc && approvalCallIds.Contains(fc.CallId))
+                {
+                    newContents.Add(new ToolApprovalRequestContent(fc.CallId, fc));
+                    modified = true;
+                }
+                else
+                {
+                    newContents.Add(content);
+                }
+            }
+
+            if (modified)
+            {
+                chatMessages[i] = new ChatMessage(ChatRole.Assistant, newContents)
+                {
+                    MessageId = msg.MessageId
+                };
+            }
+        }
+    }
+
+    /// <summary>
+    /// Converts AG-UI resume entries into M.E.AI chat messages.
     /// </summary>
     /// <remarks>
     /// <para>
     /// Per AG-UI spec each resume entry maps 1:1 with an open interrupt the previous
-    /// run emitted. For frontend tool-call interrupts we set <c>InterruptInfo.Id</c>
-    /// equal to the <c>toolCallId</c> when emitting (see <c>AGUIEventEmitter</c>),
-    /// so the resume entry's <c>InterruptId</c> recovers the original tool call id.
+    /// run emitted. Two interrupt kinds are handled:
     /// </para>
+    /// <list type="bullet">
+    ///   <item>
+    ///     <b>Approval interrupts</b> (<c>"approval:callId"</c> prefix): the payload carries
+    ///     <c>{ "approved": bool }</c>. Produces a <see cref="ToolApprovalResponseContent"/>
+    ///     on <see cref="ChatRole.User"/> so FICC executes (approved) or skips (denied)
+    ///     the wrapped <see cref="ApprovalRequiredAIFunction"/> on the next invocation.
+    ///   </item>
+    ///   <item>
+    ///     <b>Tool-call interrupts</b> (no prefix): the interrupt id equals the tool call id.
+    ///     Produces a <see cref="FunctionResultContent"/> on <see cref="ChatRole.Tool"/>
+    ///     (unchanged from the original frontend-tool resume path).
+    ///   </item>
+    /// </list>
     /// <para>
-    /// Cancelled entries are skipped — we don't synthesise a tool result when the user
+    /// Cancelled entries are skipped — we don't synthesise a result when the user
     /// abandoned the interrupt without input.
     /// </para>
     /// </remarks>
-    private List<ChatMessage> ExtractToolResultsFromResume(IReadOnlyList<AGUIResumeEntry> resume)
+    private List<ChatMessage> ExtractToolResultsFromResume(
+        IReadOnlyList<ChatMessage> chatMessages,
+        IReadOnlyList<AGUIResumeEntry> resume)
     {
         var results = new List<ChatMessage>();
 
@@ -338,7 +425,30 @@ internal sealed class AGUIStreamingService : IAGUIStreamingService
                 continue;
             }
 
-            // InterruptId is the toolCallId for tool_call interrupts (see AGUIEventEmitter).
+            if (AGUIInterruptKind.IsApproval(entry.InterruptId))
+            {
+                // Backend tool approval interrupt: payload is { "approved": bool }.
+                // Build a ToolApprovalResponseContent so FICC executes (approved) or
+                // skips (denied) the wrapped ApprovalRequiredAIFunction.
+                var callId = AGUIInterruptKind.GetCallId(entry.InterruptId)!;
+                var approved = entry.Payload.Value.TryGetProperty("approved", out var ap)
+                    && ap.ValueKind == System.Text.Json.JsonValueKind.True;
+
+                // Recover the ToolCallContent from the (already-promoted) history so FICC
+                // can resolve the function name and arguments for execution.
+                var requestedToolCall = chatMessages
+                    .SelectMany(m => m.Contents ?? [])
+                    .OfType<ToolApprovalRequestContent>()
+                    .FirstOrDefault(c => c.ToolCall.CallId == callId)
+                    ?.ToolCall
+                    ?? new FunctionCallContent(callId, string.Empty, null);
+
+                results.Add(new ChatMessage(ChatRole.User,
+                    [new ToolApprovalResponseContent(callId, approved, requestedToolCall)]));
+                continue;
+            }
+
+            // Frontend tool_call interrupt (unchanged): InterruptId == toolCallId.
             var resultContent = new FunctionResultContent(entry.InterruptId, entry.Payload.Value);
             results.Add(new ChatMessage(ChatRole.Tool, [resultContent]));
         }

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Agents/AIAgentExecutionOptions.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Agents/AIAgentExecutionOptions.cs
@@ -39,6 +39,15 @@ public class AIAgentExecutionOptions
     public IEnumerable<Guid>? UserGroupIds { get; init; }
 
     /// <summary>
+    /// Controls how destructive backend tools are gated for human approval during this execution.
+    /// Defaults to <see cref="AIApprovalPolicy.DenyAll"/> — the safe choice for non-interactive
+    /// callers (programmatic execution, Automate), which have no way to resolve a
+    /// <c>human_approval</c> interrupt. The AG-UI streaming path overrides this to
+    /// <see cref="AIApprovalPolicy.Interactive"/> because it can pause and resume.
+    /// </summary>
+    public AIApprovalPolicy ApprovalPolicy { get; init; } = AIApprovalPolicy.DenyAll;
+
+    /// <summary>
     /// Optional output schema to override the agent's configured <see cref="AIStandardAgentConfig.OutputSchema"/>.
     /// When set, the agent's response will be constrained to this schema.
     /// </summary>

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Agents/AIAgentService.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Agents/AIAgentService.cs
@@ -455,7 +455,9 @@ internal sealed class AIAgentService : IAIAgentService
         // Convert AG-UI messages to M.E.AI before publishing notification
         var chatMessages = _messageConverter.ConvertToChatMessages(request.Messages);
 
-        // Prepare agent execution (profile override, notification, permissions, MAF agent creation)
+        // Prepare agent execution (profile override, notification, permissions, MAF agent creation).
+        // AG-UI is the interactive surface — it can emit a human_approval interrupt and resume,
+        // so destructive tools are gated for real approval regardless of the options default.
         var context = await PrepareAgentExecutionAsync(
             agent, chatMessages, options, frontendTools,
             contextItems: _contextConverter.ConvertToRequestContextItems(request.Context),
@@ -465,6 +467,7 @@ internal sealed class AIAgentService : IAIAgentService
                 { Constants.ContextKeys.ThreadId, request.ThreadId },
                 { CoreConstants.ContextKeys.LogKeys, new[] { Constants.ContextKeys.RunId, Constants.ContextKeys.ThreadId } }
             },
+            approvalPolicy: AIApprovalPolicy.Interactive,
             cancellationToken);
 
         if (context is null)
@@ -505,11 +508,14 @@ internal sealed class AIAgentService : IAIAgentService
 
         var additionalProperties = BuildAgentProperties(builder);
 
+        // Inline agents are created for programmatic callers with no interactive surface to
+        // resolve a human_approval interrupt — deny destructive tools so runs don't stall.
         return await _agentFactory.CreateAgentAsync(
             agent,
             builder.ContextItems,
             additionalTools: null,
             additionalProperties,
+            approvalPolicy: AIApprovalPolicy.DenyAll,
             cancellationToken);
     }
 
@@ -544,11 +550,13 @@ internal sealed class AIAgentService : IAIAgentService
         try
         {
             var additionalProperties = BuildAgentProperties(builder);
+            // Non-interactive programmatic execution — deny destructive tools (no resume surface).
             var mafAgent = await _agentFactory.CreateAgentAsync(
                 agent,
                 builder.ContextItems,
                 additionalTools: null,
                 additionalProperties,
+                approvalPolicy: AIApprovalPolicy.DenyAll,
                 cancellationToken);
 
             var response = await mafAgent.RunAsync(chatMessages, session: null, options: null, cancellationToken);
@@ -608,11 +616,13 @@ internal sealed class AIAgentService : IAIAgentService
         try
         {
             var additionalProperties = BuildAgentProperties(builder);
+            // Programmatic streaming (not AG-UI) has no resume surface — deny destructive tools.
             var mafAgent = await _agentFactory.CreateAgentAsync(
                 agent,
                 builder.ContextItems,
                 additionalTools: null,
                 additionalProperties,
+                approvalPolicy: AIApprovalPolicy.DenyAll,
                 cancellationToken);
 
             await foreach (var update in mafAgent.RunStreamingAsync(chatMessages, session: null, options: null, cancellationToken))
@@ -786,6 +796,7 @@ internal sealed class AIAgentService : IAIAgentService
             agent, chatMessages, options, frontendTools: null,
             contextItems: options.ContextItems,
             additionalProperties: BuildAdditionalPropertiesFromOptions(options),
+            approvalPolicy: options.ApprovalPolicy,
             cancellationToken);
 
         if (context is null)
@@ -830,6 +841,7 @@ internal sealed class AIAgentService : IAIAgentService
             agent, chatMessages, options, frontendTools: null,
             contextItems: options.ContextItems,
             additionalProperties: BuildAdditionalPropertiesFromOptions(options),
+            approvalPolicy: options.ApprovalPolicy,
             cancellationToken);
 
         if (context is null)
@@ -881,6 +893,7 @@ internal sealed class AIAgentService : IAIAgentService
         IEnumerable<AIFrontendTool>? frontendTools,
         IEnumerable<AIRequestContextItem>? contextItems,
         Dictionary<string, object?>? additionalProperties,
+        AIApprovalPolicy approvalPolicy,
         CancellationToken cancellationToken)
     {
         // Apply profile override if specified
@@ -946,12 +959,15 @@ internal sealed class AIAgentService : IAIAgentService
             additionalProperties[AI.Core.Constants.ContextKeys.GuardrailIdsOverride] = options.GuardrailIdsOverride;
         }
 
-        // Create MAF agent
+        // Create MAF agent. The AG-UI streaming caller passes Interactive (it can resume), while
+        // headless callers pass options.ApprovalPolicy (default DenyAll) so destructive tools
+        // never stall a run that has no way to approve them.
         var mafAgent = await _agentFactory.CreateAgentAsync(
             agent,
             contextItems,
             convertedFrontendTools,
             additionalProperties,
+            approvalPolicy,
             cancellationToken);
 
         return new AgentExecutionContext(

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Agents/AIApprovalPolicy.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Agents/AIApprovalPolicy.cs
@@ -1,0 +1,33 @@
+namespace Umbraco.AI.Agent.Core.Agents;
+
+/// <summary>
+/// Controls how destructive backend tools are gated for human-in-the-loop (HITL) approval
+/// during an agent run. Backend approval relies on the AG-UI interrupt/resume mechanism, which
+/// only exists on the interactive streaming path; non-interactive callers must choose a policy
+/// that resolves deterministically without a human, so a destructive tool can never leave a run
+/// stalled waiting for an approval that will never arrive.
+/// </summary>
+public enum AIApprovalPolicy
+{
+    /// <summary>
+    /// Pause the run and emit a <c>human_approval</c> interrupt for each destructive tool call,
+    /// resuming (executing or skipping) once the user responds. Requires an interactive surface
+    /// that can resume — i.e. the AG-UI streaming path. This is the only policy that actually
+    /// asks a human.
+    /// </summary>
+    Interactive,
+
+    /// <summary>
+    /// Skip destructive tools without executing them and tell the model the action was denied,
+    /// allowing the run to complete. Safe default for non-interactive callers (programmatic
+    /// <c>RunAgentAsync</c>/<c>StreamAgentAsync</c>, Automate) where no human is present to approve.
+    /// </summary>
+    DenyAll,
+
+    /// <summary>
+    /// Execute destructive tools without prompting for approval. The action is still captured by
+    /// the existing audit-log middleware. Use only behind an explicit per-agent/per-automation
+    /// opt-in: it bypasses the approval gate entirely.
+    /// </summary>
+    AllowAll,
+}

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Chat/AIAgentFactory.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Chat/AIAgentFactory.cs
@@ -61,13 +61,14 @@ internal sealed class AIAgentFactory : IAIAgentFactory
         IEnumerable<AIRequestContextItem>? contextItems = null,
         IEnumerable<AITool>? additionalTools = null,
         IReadOnlyDictionary<string, object?>? additionalProperties = null,
+        AIApprovalPolicy approvalPolicy = AIApprovalPolicy.Interactive,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(agent);
 
         MsAIAgent innerAgent = agent.AgentType switch
         {
-            AIAgentType.Standard => await CreateStandardAgentAsync(agent, contextItems, additionalTools, cancellationToken),
+            AIAgentType.Standard => await CreateStandardAgentAsync(agent, contextItems, additionalTools, approvalPolicy, cancellationToken),
             AIAgentType.Orchestrated => await CreateOrchestratedAgentAsync(
                 agent,
                 agent.GetOrchestratedConfig()
@@ -93,6 +94,7 @@ internal sealed class AIAgentFactory : IAIAgentFactory
         UmbracoAIAgent agent,
         IEnumerable<AIRequestContextItem>? contextItems,
         IEnumerable<AITool>? additionalTools,
+        AIApprovalPolicy approvalPolicy,
         CancellationToken cancellationToken)
     {
         // STEP 1: Get allowed tool IDs (permission check - existing logic)
@@ -117,8 +119,37 @@ internal sealed class AIAgentFactory : IAIAgentFactory
         //         - Tool metadata (ForEntityTypes) from enriched descriptions
         //         - User's question
         //         to make informed decisions about which tools to use
+        //
+        //         Destructive non-system tools are gated for approval per the resolved
+        //         AIApprovalPolicy:
+        //           - Interactive → wrap in ApprovalRequiredAIFunction (MEAI emits
+        //                           ToolApprovalRequestContent instead of executing inline)
+        //           - DenyAll     → wrap in ApprovalDeniedAIFunction (skip + tell the model),
+        //                           so non-interactive runs complete without stalling
+        //           - AllowAll    → leave unwrapped (executes; captured by audit middleware)
+        var destructiveToolIds = allowedToolIds
+            .Select(id => _toolCollection.GetById(id))
+            .Where(t => t is not null && t.IsDestructive && t is not IAISystemTool)
+            .Select(t => t!.Id)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
         var tools = new List<AITool>();
-        tools.AddRange(_toolCollection.ToAIFunctions(allowedToolIds, _functionFactory));
+        foreach (var fn in _toolCollection.ToAIFunctions(allowedToolIds, _functionFactory))
+        {
+            if (!destructiveToolIds.Contains(fn.Name))
+            {
+                tools.Add(fn);
+                continue;
+            }
+
+            tools.Add(approvalPolicy switch
+            {
+                AIApprovalPolicy.Interactive => new ApprovalRequiredAIFunction(fn),
+                AIApprovalPolicy.DenyAll => new ApprovalDeniedAIFunction(fn),
+                AIApprovalPolicy.AllowAll => fn,
+                _ => new ApprovalDeniedAIFunction(fn),
+            });
+        }
 
         // STEP 4: Filter frontend tools by runtime context
         //         Frontend tools ARE context-bound (operate on currently open entity)
@@ -137,12 +168,20 @@ internal sealed class AIAgentFactory : IAIAgentFactory
 
         var config = agent.GetStandardConfig();
 
+        // Only the Interactive policy produces ToolApprovalRequestContent; the multi-call
+        // disable (which scopes approval to exactly the destructive tool the model chose) is
+        // therefore only meaningful when destructive tools are actually wrapped for approval.
+        var requiresApproval = destructiveToolIds.Count > 0 && approvalPolicy == AIApprovalPolicy.Interactive;
+
         // Build ChatOptions — always needed for instructions and tools,
-        // plus output schema response format if configured
+        // plus output schema response format if configured.
+        // When approval is required, disable multi-call turns so each destructive
+        // tool call is presented individually for approval (MEAI limitation).
         var chatOptions = new ChatOptions
         {
             Instructions = config?.Instructions,
             Tools = tools,
+            AllowMultipleToolCalls = requiresApproval ? false : null,
         };
 
         if (config?.OutputSchema is JsonElement schema)

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Chat/ApprovalDeniedAIFunction.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Chat/ApprovalDeniedAIFunction.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.AI;
+
+namespace Umbraco.AI.Agent.Core.Chat;
+
+/// <summary>
+/// Wraps a destructive backend tool so that, under <see cref="Agents.AIApprovalPolicy.DenyAll"/>,
+/// it is never executed. When the model calls it, the inner function is bypassed and a denial
+/// result is returned instead, telling the model the action required approval that was not granted.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This keeps non-interactive runs flowing: the model receives a tool result (the denial) and can
+/// complete its turn, rather than the run stalling on an unresolved
+/// <see cref="ApprovalRequiredAIFunction"/> with no interactive surface to approve it.
+/// </para>
+/// <para>
+/// <see cref="DelegatingAIFunction"/> passes <see cref="AIFunction.Name"/>,
+/// <see cref="AIFunction.Description"/> and the JSON schema through to the inner function, so the
+/// model still sees the tool exactly as declared — only invocation is short-circuited.
+/// </para>
+/// </remarks>
+internal sealed class ApprovalDeniedAIFunction : DelegatingAIFunction
+{
+    public ApprovalDeniedAIFunction(AIFunction innerFunction)
+        : base(innerFunction)
+    {
+    }
+
+    protected override ValueTask<object?> InvokeCoreAsync(
+        AIFunctionArguments arguments,
+        CancellationToken cancellationToken)
+        => ValueTask.FromResult<object?>(
+            $"This action requires human approval, which is not available in the current " +
+            $"execution context. The '{Name}' tool was not executed.");
+}

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Chat/IAIAgentFactory.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Chat/IAIAgentFactory.cs
@@ -42,6 +42,11 @@ public interface IAIAgentFactory
     /// <param name="additionalTools">Optional additional tools to include in the agent (e.g., frontend tools).</param>
     /// <param name="additionalProperties">Optional additional properties to set in the runtime context
     ///  (e.g., RunId, ThreadId for telemetry/logging).</param>
+    /// <param name="approvalPolicy">How destructive backend tools are gated for human approval.
+    ///  Defaults to <see cref="AIApprovalPolicy.Interactive"/> (wrap in
+    ///  <see cref="ApprovalRequiredAIFunction"/>). Non-interactive callers must pass
+    ///  <see cref="AIApprovalPolicy.DenyAll"/> (or <see cref="AIApprovalPolicy.AllowAll"/>)
+    ///  since they cannot resolve a <c>human_approval</c> interrupt.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>An <see cref="MsAIAgent"/> ready for use with MAF's RunAsync/RunStreamingAsync methods.</returns>
     /// <remarks>
@@ -79,5 +84,6 @@ public interface IAIAgentFactory
         IEnumerable<AIRequestContextItem>? contextItems = null,
         IEnumerable<AITool>? additionalTools = null,
         IReadOnlyDictionary<string, object?>? additionalProperties = null,
+        AIApprovalPolicy approvalPolicy = AIApprovalPolicy.Interactive,
         CancellationToken cancellationToken = default);
 }

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Client/src/transport/uai-agent-client.ts
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Client/src/transport/uai-agent-client.ts
@@ -121,11 +121,13 @@ export class UaiAgentClient {
      * @param messages The messages to send
      * @param tools Optional frontend tools to include (with metadata)
      * @param context Optional context items to include for LLM awareness
+     * @param resume Optional resume entries for human_approval or tool_call interrupts
      */
     sendMessage(
         messages: UaiChatMessage[],
         tools?: UaiFrontendTool[],
         context?: Array<{ description: string; value: string }>,
+        resume?: Array<{ interruptId: string; status: "resolved" | "cancelled"; payload?: unknown }>,
     ): void {
         const runId = crypto.randomUUID();
 
@@ -150,6 +152,9 @@ export class UaiAgentClient {
                 messages: convertedMessages,
                 tools: aguiTools,
                 context: context ?? [],
+                // Thread resume entries through forwardedProps so UaiHttpAgent can lift
+                // them into the typed body.resume field on the server request.
+                forwardedProps: resume?.length ? { resume } : undefined,
             })
             .pipe(transformChunks(false))
             .subscribe({

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Client/src/transport/uai-http-agent.ts
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Client/src/transport/uai-http-agent.ts
@@ -8,6 +8,7 @@ import {
     type AGUIToolCallModel,
     type AGUIMessageRoleModel,
     type AGUIContextItemModel,
+    type AGUIResumeEntryModel,
 } from "../api/index.js";
 import type { AgentTransport } from "./types.js";
 
@@ -66,6 +67,18 @@ export class UaiHttpAgent extends AbstractAgent implements AgentTransport {
         },
         signal: AbortSignal,
     ): Promise<void> {
+        // Lift resume entries out of forwardedProps (where UaiAgentClient stashes them) into
+        // the typed body.resume field the server actually reads. `resume` IS a first-class
+        // RunAgentInput field in the AG-UI draft interrupt spec
+        // (https://docs.ag-ui.com/concepts/interrupts), but the installed @ag-ui/client SDK
+        // predates that draft and its RunAgentInput type has no resume slot — so UaiAgentClient
+        // ferries the entries across that boundary via forwardedProps as a temporary shim. Once
+        // the SDK adds resume to RunAgentInput (umbraco/Umbraco.AI#210), set it directly and drop
+        // this lift. The server ignores forwardedProps.resume, so we strip it from the forwarded
+        // props here rather than sending it redundantly alongside body.resume.
+        const { resume, ...otherForwardedProps } =
+            (input.forwardedProps as { resume?: AGUIResumeEntryModel[] } | undefined) ?? {};
+
         // Convert AG-UI RunAgentInput to hey-api AGUIRunRequestModel
         const body: AGUIRunRequestModel = {
             threadId: input.threadId,
@@ -74,7 +87,9 @@ export class UaiHttpAgent extends AbstractAgent implements AgentTransport {
             tools: input.tools?.map((tool) => this.#toAGUITool(tool)),
             state: input.state,
             context: input.context?.map((ctx) => this.#toAGUIContext(ctx)),
-            forwardedProps: input.forwardedProps,
+            resume: resume?.length ? resume : undefined,
+            // Forward only genuine props — not the resume we just lifted out.
+            forwardedProps: Object.keys(otherForwardedProps).length > 0 ? otherForwardedProps : undefined,
         };
 
         const result = await AgentsService.streamAgentAGUI({

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Integration/Agents/BackendToolApprovalFlowTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Integration/Agents/BackendToolApprovalFlowTests.cs
@@ -1,0 +1,236 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Shouldly;
+using Umbraco.AI.Agent.Core.AGUI;
+using Umbraco.AI.Agent.Core.Agents;
+using Umbraco.AI.Agent.Core.Chat;
+using Umbraco.AI.AGUI.Events;
+using Umbraco.AI.AGUI.Events.Lifecycle;
+using Umbraco.AI.AGUI.Models;
+using Xunit;
+using MsAIAgent = Microsoft.Agents.AI.AIAgent;
+
+namespace Umbraco.AI.Agent.Tests.Integration.Agents;
+
+/// <summary>
+/// End-to-end composition test for the backend tool HITL approval flow. Unlike the unit
+/// tests — which mock each seam in isolation — this drives a REAL MAF
+/// <see cref="ChatClientAgent"/> (with its built-in function-invocation middleware) over a
+/// scripted <see cref="IChatClient"/> through the real <see cref="AGUIStreamingService"/>,
+/// proving Tasks 1–4 actually compose: a destructive tool wrapped in
+/// <see cref="ApprovalRequiredAIFunction"/> pauses with a <c>human_approval</c> interrupt and,
+/// on resume, executes exactly once when approved and never when denied.
+/// </summary>
+public class BackendToolApprovalFlowTests
+{
+    private const string ToolName = "delete_content";
+    private const string CallId = "call-1";
+    private const string ApprovalInterruptId = "approval:call-1";
+
+    private readonly Mock<IAGUIMessageConverter> _converter = new();
+    private readonly Mock<IAGUIFileProcessor> _fileProcessor = new();
+    private readonly AGUIStreamingService _service;
+
+    public BackendToolApprovalFlowTests()
+    {
+        _fileProcessor
+            .Setup(x => x.ProcessInboundAsync(It.IsAny<IEnumerable<AGUIMessage>?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<AGUIMessage>? msgs, string _, CancellationToken _) =>
+                new AGUIFileProcessorResult { RewrittenMessages = msgs ?? [], ResolvedMessages = msgs ?? [] });
+
+        _service = new AGUIStreamingService(_converter.Object, _fileProcessor.Object, NullLogger<AGUIStreamingService>.Instance);
+    }
+
+    [Fact]
+    public async Task DestructiveBackendTool_PausesForApproval_ThenExecutesOnApprove()
+    {
+        var executions = 0;
+        var agent = CreateApprovalAgent(() => executions++);
+
+        // --- Run 1: initial call. The model requests the destructive tool. ---
+        // Converter yields just the user turn; FICC turns the tool call into an approval request.
+        SetConverterHistory(new ChatMessage(ChatRole.User, "delete content 42"));
+
+        var firstRun = await CollectEvents(agent, CreateRequest());
+
+        var interrupt = firstRun.OfType<RunFinishedEvent>().Single()
+            .Outcome.ShouldBeOfType<AGUIRunOutcomeInterrupt>()
+            .Interrupts.Single(i => i.Reason == "human_approval");
+        interrupt.Id.ShouldBe(ApprovalInterruptId);
+        interrupt.ToolCallId.ShouldBe(CallId);
+        executions.ShouldBe(0); // tool has NOT run while awaiting approval
+
+        // --- Run 2: resume, approved. Replay the history (incl. the pending tool call) + resume entry. ---
+        SetConverterHistory(
+            new ChatMessage(ChatRole.User, "delete content 42"),
+            new ChatMessage(ChatRole.Assistant, [PendingToolCall()]));
+
+        var secondRun = await CollectEvents(agent, CreateResumeRequest(approved: true));
+
+        // The wrapped function executed exactly once and the run completed without re-prompting.
+        executions.ShouldBe(1);
+        secondRun.OfType<RunFinishedEvent>().Single()
+            .Outcome.ShouldBeOfType<AGUIRunOutcomeSuccess>();
+    }
+
+    [Fact]
+    public async Task DestructiveBackendTool_Denied_DoesNotExecute()
+    {
+        var executions = 0;
+        var agent = CreateApprovalAgent(() => executions++);
+
+        // Resume directly with a denial over the replayed pending tool call.
+        SetConverterHistory(
+            new ChatMessage(ChatRole.User, "delete content 42"),
+            new ChatMessage(ChatRole.Assistant, [PendingToolCall()]));
+
+        var run = await CollectEvents(agent, CreateResumeRequest(approved: false));
+
+        // The wrapped function never ran; the run still completes (model is told it was denied).
+        executions.ShouldBe(0);
+        run.OfType<RunFinishedEvent>().Single()
+            .Outcome.ShouldBeOfType<AGUIRunOutcomeSuccess>();
+    }
+
+    [Fact]
+    public async Task DestructiveBackendTool_DenyAllPolicy_CompletesWithoutExecuting()
+    {
+        // Non-interactive callers (DenyAll) wrap destructive tools in ApprovalDeniedAIFunction:
+        // the model's call is answered with a denial result so the run completes, but the
+        // underlying function never runs — no human_approval interrupt is emitted.
+        var executions = 0;
+        var agent = CreateDenyAllAgent(() => executions++);
+
+        SetConverterHistory(new ChatMessage(ChatRole.User, "delete content 42"));
+
+        var run = await CollectEvents(agent, CreateRequest());
+
+        executions.ShouldBe(0);
+        run.OfType<RunFinishedEvent>().Single()
+            .Outcome.ShouldBeOfType<AGUIRunOutcomeSuccess>();
+    }
+
+    // ---- Helpers ----
+
+    /// <summary>
+    /// Builds a <see cref="ChatClientAgent"/> exactly as <c>AIAgentFactory</c> does for a
+    /// destructive backend tool: the inner function (a spy counting executions) wrapped in
+    /// <see cref="ApprovalRequiredAIFunction"/>, with <c>AllowMultipleToolCalls = false</c>.
+    /// </summary>
+    private static ChatClientAgent CreateApprovalAgent(Action onExecute)
+    {
+        var inner = AIFunctionFactory.Create(
+            (string id) => { onExecute(); return $"deleted {id}"; },
+            name: ToolName);
+        var approvalFn = new ApprovalRequiredAIFunction(inner);
+
+        var chatOptions = new ChatOptions
+        {
+            Tools = [approvalFn],
+            AllowMultipleToolCalls = false,
+        };
+
+        return new ChatClientAgent(new ScriptedApprovalChatClient(), new ChatClientAgentOptions
+        {
+            ChatOptions = chatOptions,
+        });
+    }
+
+    /// <summary>
+    /// Builds an agent for the non-interactive <see cref="AIApprovalPolicy.DenyAll"/> path: the
+    /// destructive function is wrapped in <see cref="ApprovalDeniedAIFunction"/> so it is never
+    /// executed, exactly as <c>AIAgentFactory</c> produces it under that policy.
+    /// </summary>
+    private static ChatClientAgent CreateDenyAllAgent(Action onExecute)
+    {
+        var inner = AIFunctionFactory.Create(
+            (string id) => { onExecute(); return $"deleted {id}"; },
+            name: ToolName);
+        var deniedFn = new ApprovalDeniedAIFunction(inner);
+
+        return new ChatClientAgent(new ScriptedApprovalChatClient(), new ChatClientAgentOptions
+        {
+            ChatOptions = new ChatOptions { Tools = [deniedFn] },
+        });
+    }
+
+    private static FunctionCallContent PendingToolCall() =>
+        new(CallId, ToolName, new Dictionary<string, object?> { ["id"] = "42" });
+
+    private void SetConverterHistory(params ChatMessage[] messages) =>
+        _converter
+            .Setup(x => x.ConvertToChatMessages(It.IsAny<IEnumerable<AGUIMessage>?>()))
+            .Returns(messages.ToList());
+
+    private static AGUIRunRequest CreateRequest() => new()
+    {
+        ThreadId = "thread-approval",
+        RunId = "run-approval",
+        Messages = [new() { Id = Guid.NewGuid().ToString(), Role = AGUIMessageRole.User, Content = "delete content 42" }],
+    };
+
+    private static AGUIRunRequest CreateResumeRequest(bool approved)
+    {
+        var request = CreateRequest();
+        request.Resume =
+        [
+            new AGUIResumeEntry
+            {
+                InterruptId = ApprovalInterruptId,
+                Status = AGUIResumeStatus.Resolved,
+                Payload = JsonSerializer.SerializeToElement(new { approved }),
+            },
+        ];
+        return request;
+    }
+
+    private async Task<List<IAGUIEvent>> CollectEvents(MsAIAgent agent, AGUIRunRequest request)
+    {
+        var events = new List<IAGUIEvent>();
+        await foreach (var evt in _service.StreamAgentAsync(agent, request, frontendTools: null, CancellationToken.None))
+        {
+            events.Add(evt);
+        }
+        return events;
+    }
+
+    /// <summary>
+    /// Stateless scripted chat client: requests the destructive tool until the conversation
+    /// already carries an approval response or a function result (i.e. the tool turn has been
+    /// resolved by FICC), after which it returns a closing text completion.
+    /// </summary>
+    private sealed class ScriptedApprovalChatClient : IChatClient
+    {
+        public ChatClientMetadata Metadata { get; } = new("scripted-approval");
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken ct = default)
+            => throw new NotSupportedException("Agent uses the streaming path.");
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            await Task.Yield();
+
+            var resolved = messages.Any(m => m.Contents.Any(c =>
+                c is ToolApprovalResponseContent or FunctionResultContent));
+
+            if (resolved)
+            {
+                yield return new ChatResponseUpdate(ChatRole.Assistant, "done");
+                yield break;
+            }
+
+            yield return new ChatResponseUpdate(ChatRole.Assistant, new List<AIContent> { PendingToolCall() });
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose() { }
+    }
+}

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Integration/Umbraco.AI.Agent.Tests.Integration.csproj
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Integration/Umbraco.AI.Agent.Tests.Integration.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <UseProjectReferences Condition="'$(UseProjectReferences)' == ''">true</UseProjectReferences>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Moq" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(UseProjectReferences)' == 'true'">
+        <ProjectReference Include="..\..\..\Umbraco.AI\src\Umbraco.AI.Core\Umbraco.AI.Core.csproj" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(UseProjectReferences)' != 'true'">
+        <PackageReference Include="Umbraco.AI.Core" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Umbraco.AI.Agent.Core\Umbraco.AI.Agent.Core.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/AGUI/AGUIEventEmitterTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/AGUI/AGUIEventEmitterTests.cs
@@ -353,6 +353,56 @@ public class AGUIEventEmitterTests
         interrupt.Id.ShouldNotBeNullOrEmpty();
     }
 
+    [Fact]
+    public void EmitRunFinished_WithApprovalRequest_ReturnsHumanApprovalInterrupt()
+    {
+        // Arrange
+        var emitter = new AGUIEventEmitter(TestThreadId, TestRunId);
+        emitter.RegisterApprovalRequest("approval:call-del", "call-del", "delete_thing", "{\"id\":\"42\"}");
+
+        // Act
+        var evt = emitter.EmitRunFinished();
+
+        // Assert
+        var interruptOutcome = evt.Outcome.ShouldBeOfType<AGUIRunOutcomeInterrupt>();
+        interruptOutcome.Interrupts.Count.ShouldBe(1);
+        var interrupt = interruptOutcome.Interrupts[0];
+        interrupt.Id.ShouldBe("approval:call-del");
+        interrupt.Reason.ShouldBe("human_approval");
+        interrupt.ToolCallId.ShouldBe("call-del");
+    }
+
+    [Fact]
+    public void EmitRunFinished_WithFrontendAndApprovalRequests_IncludesBothInterrupts()
+    {
+        // Arrange
+        var emitter = new AGUIEventEmitter(TestThreadId, TestRunId);
+        emitter.EmitToolCall("call-frontend", "confirm", null, isFrontendTool: true);
+        emitter.RegisterApprovalRequest("approval:call-del", "call-del", "delete_thing", "{}");
+
+        // Act
+        var interruptOutcome = emitter.EmitRunFinished().Outcome.ShouldBeOfType<AGUIRunOutcomeInterrupt>();
+
+        // Assert
+        interruptOutcome.Interrupts.Count.ShouldBe(2);
+        interruptOutcome.Interrupts.ShouldContain(i => i.Reason == "tool_call");
+        interruptOutcome.Interrupts.ShouldContain(i => i.Reason == "human_approval");
+    }
+
+    [Fact]
+    public void EmitRunFinished_WithOnlyApprovalRequest_DoesNotReturnSuccess()
+    {
+        // Arrange
+        var emitter = new AGUIEventEmitter(TestThreadId, TestRunId);
+        emitter.RegisterApprovalRequest("approval:call-x", "call-x", "do_thing", "{}");
+
+        // Act
+        var outcome = emitter.EmitRunFinished().Outcome;
+
+        // Assert — should be interrupt, not success
+        outcome.ShouldBeOfType<AGUIRunOutcomeInterrupt>();
+    }
+
     #endregion
 
     #region Helper Methods Tests

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/AGUI/AGUIInterruptKindTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/AGUI/AGUIInterruptKindTests.cs
@@ -1,0 +1,50 @@
+using Shouldly;
+using Umbraco.AI.Agent.Core.AGUI;
+using Xunit;
+
+namespace Umbraco.AI.Agent.Tests.Unit.AGUI;
+
+public class AGUIInterruptKindTests
+{
+    [Fact]
+    public void ForApproval_ReturnsApprovalPrefixedId()
+    {
+        AGUIInterruptKind.ForApproval("call-123").ShouldBe("approval:call-123");
+    }
+
+    [Fact]
+    public void IsApproval_WithApprovalPrefixedId_ReturnsTrue()
+    {
+        AGUIInterruptKind.IsApproval("approval:call-123").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsApproval_WithNonApprovalId_ReturnsFalse()
+    {
+        AGUIInterruptKind.IsApproval("call-123").ShouldBeFalse();
+        AGUIInterruptKind.IsApproval("tool_call:call-123").ShouldBeFalse();
+        AGUIInterruptKind.IsApproval(string.Empty).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetCallId_WithApprovalId_ReturnsCallId()
+    {
+        AGUIInterruptKind.GetCallId("approval:call-123").ShouldBe("call-123");
+    }
+
+    [Fact]
+    public void GetCallId_WithNonApprovalId_ReturnsNull()
+    {
+        AGUIInterruptKind.GetCallId("call-123").ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("approval:")]
+    [InlineData("approval:call-abc-xyz")]
+    public void ForApproval_RoundTrips_Correctly(string interruptId)
+    {
+        var callId = AGUIInterruptKind.GetCallId(interruptId)!;
+        AGUIInterruptKind.ForApproval(callId).ShouldBe(interruptId);
+        AGUIInterruptKind.IsApproval(interruptId).ShouldBeTrue();
+    }
+}

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/AGUI/AGUIStreamingServiceTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/AGUI/AGUIStreamingServiceTests.cs
@@ -263,6 +263,36 @@ public class AGUIStreamingServiceTests
         events.OfType<ToolCallResultEvent>().ShouldBeEmpty();
     }
 
+    [Fact]
+    public async Task StreamAgentAsync_WithToolApprovalRequest_EmitsToolCallAndRegistersApprovalInterrupt()
+    {
+        // Arrange — stream a ToolApprovalRequestContent (what FICC emits for ApprovalRequiredAIFunction)
+        var functionCall = new FunctionCallContent("call-del", "delete_thing",
+            new Dictionary<string, object?> { ["id"] = "42" });
+        var approvalRequest = new ToolApprovalRequestContent("call-del", functionCall);
+        var update = new ChatResponseUpdate(ChatRole.Assistant, new List<AIContent> { approvalRequest });
+        var agent = CreateMockAgent(new[] { update }.ToAsyncEnumerable());
+        var request = CreateRequest();
+
+        // Act
+        var events = await CollectEvents(agent, request);
+
+        // Assert — tool call event emitted so the frontend shows the pending call
+        var toolCallEvent = events.OfType<ToolCallChunkEvent>().FirstOrDefault();
+        toolCallEvent.ShouldNotBeNull();
+        toolCallEvent!.ToolCallId.ShouldBe("call-del");
+        toolCallEvent.ToolCallName.ShouldBe("delete_thing");
+
+        // Assert — RunFinished carries a human_approval interrupt
+        var finishedEvent = events.OfType<RunFinishedEvent>().First();
+        var interruptOutcome = finishedEvent.Outcome.ShouldBeOfType<AGUIRunOutcomeInterrupt>();
+        interruptOutcome.Interrupts.Count.ShouldBe(1);
+        var interrupt = interruptOutcome.Interrupts[0];
+        interrupt.Id.ShouldBe("approval:call-del");
+        interrupt.Reason.ShouldBe("human_approval");
+        interrupt.ToolCallId.ShouldBe("call-del");
+    }
+
     #endregion
 
     #region Outcome Tests
@@ -407,6 +437,130 @@ public class AGUIStreamingServiceTests
         _mockConverter.Verify(
             x => x.ConvertToChatMessages(It.IsAny<IEnumerable<AGUIMessage>>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task StreamAgentAsync_WithApprovalResume_Approved_PromotesHistoryAndAddsApprovalResponse()
+    {
+        // Arrange: converter returns an assistant message with a FunctionCallContent (approval-pending)
+        var pendingToolCall = new FunctionCallContent("call-del", "delete_thing",
+            new Dictionary<string, object?> { ["id"] = "42" });
+        var assistantHistory = new ChatMessage(ChatRole.Assistant, new List<AIContent> { pendingToolCall });
+        // Hold reference to the list so we can inspect it after the service runs
+        var converterReturnList = new List<ChatMessage> { new(ChatRole.User, "delete content 42"), assistantHistory };
+        _mockConverter
+            .Setup(x => x.ConvertToChatMessages(It.IsAny<IEnumerable<AGUIMessage>?>()))
+            .Returns(converterReturnList);
+        var agent = CreateMockAgent(AsyncEnumerable.Empty<ChatResponseUpdate>());
+
+        var request = new AGUIRunRequest
+        {
+            ThreadId = "thread-1", RunId = "run-1",
+            Messages = [new() { Id = Guid.NewGuid().ToString(), Role = AGUIMessageRole.User, Content = "Delete content 42" }],
+            Resume = [new()
+            {
+                InterruptId = "approval:call-del",
+                Status = AGUIResumeStatus.Resolved,
+                Payload = JsonSerializer.SerializeToElement(new { approved = true })
+            }]
+        };
+
+        // Act
+        await CollectEvents(agent, request);
+
+        // Assert: list passed to RunStreamingAsync has 3 entries:
+        // [0] original user message, [1] promoted assistant, [2] ToolApprovalResponseContent
+        // (MAF normalises ToolApprovalRequestContent → FunctionCallContent when forwarding to the
+        // model client, so we verify against the list WE built, not what the model client sees.)
+        converterReturnList.Count.ShouldBe(3);
+
+        // [1] FunctionCallContent → ToolApprovalRequestContent (spike Finding B: FICC needs it)
+        var promotedContent = converterReturnList[1].Contents!
+            .OfType<ToolApprovalRequestContent>()
+            .FirstOrDefault();
+        promotedContent.ShouldNotBeNull("assistant FunctionCallContent should be promoted to ToolApprovalRequestContent");
+        promotedContent!.ToolCall.CallId.ShouldBe("call-del");
+
+        // [2] ToolApprovalResponseContent on ChatRole.User (approved)
+        converterReturnList[2].Role.ShouldBe(ChatRole.User);
+        var approvalResponse = converterReturnList[2].Contents!
+            .OfType<ToolApprovalResponseContent>()
+            .FirstOrDefault();
+        approvalResponse.ShouldNotBeNull("resume should produce a ToolApprovalResponseContent");
+        approvalResponse!.Approved.ShouldBeTrue();
+        approvalResponse.ToolCall.CallId.ShouldBe("call-del");
+    }
+
+    [Fact]
+    public async Task StreamAgentAsync_WithApprovalResume_Denied_AddesDeniedApprovalResponse()
+    {
+        var pendingToolCall = new FunctionCallContent("call-x", "delete_thing", null);
+        var assistantHistory = new ChatMessage(ChatRole.Assistant, new List<AIContent> { pendingToolCall });
+        var converterReturnList = new List<ChatMessage> { assistantHistory };
+        _mockConverter
+            .Setup(x => x.ConvertToChatMessages(It.IsAny<IEnumerable<AGUIMessage>?>()))
+            .Returns(converterReturnList);
+        var agent = CreateMockAgent(AsyncEnumerable.Empty<ChatResponseUpdate>());
+
+        var request = new AGUIRunRequest
+        {
+            ThreadId = "t1", RunId = "r1",
+            Messages = [new() { Id = Guid.NewGuid().ToString(), Role = AGUIMessageRole.User, Content = "deny" }],
+            Resume = [new()
+            {
+                InterruptId = "approval:call-x",
+                Status = AGUIResumeStatus.Resolved,
+                Payload = JsonSerializer.SerializeToElement(new { approved = false })
+            }]
+        };
+
+        await CollectEvents(agent, request);
+
+        // [0] original assistant message, [1] ToolApprovalResponseContent (denied)
+        converterReturnList.Count.ShouldBe(2);
+        converterReturnList[1].Role.ShouldBe(ChatRole.User);
+        var approvalResponse = converterReturnList[1].Contents!
+            .OfType<ToolApprovalResponseContent>()
+            .FirstOrDefault();
+        approvalResponse.ShouldNotBeNull();
+        approvalResponse!.Approved.ShouldBeFalse();
+        approvalResponse.ToolCall.CallId.ShouldBe("call-x");
+    }
+
+    [Fact]
+    public async Task StreamAgentAsync_WithToolCallResume_StillProducesFunctionResultContent()
+    {
+        // Regular frontend tool_call resume (unchanged behavior)
+        var converterReturnList = new List<ChatMessage>();
+        _mockConverter
+            .Setup(x => x.ConvertToChatMessages(It.IsAny<IEnumerable<AGUIMessage>?>()))
+            .Returns(converterReturnList);
+        var agent = CreateMockAgent(AsyncEnumerable.Empty<ChatResponseUpdate>());
+
+        var request = new AGUIRunRequest
+        {
+            ThreadId = "t1", RunId = "r1",
+            Messages = [new() { Id = Guid.NewGuid().ToString(), Role = AGUIMessageRole.User, Content = "hi" }],
+            Resume = [new()
+            {
+                InterruptId = "call-fe-1",  // no "approval:" prefix
+                Status = AGUIResumeStatus.Resolved,
+                Payload = JsonSerializer.SerializeToElement(new { ok = true })
+            }]
+        };
+
+        await CollectEvents(agent, request);
+
+        // Should produce a Tool-role message with FunctionResultContent (not ToolApprovalResponseContent)
+        converterReturnList.Count.ShouldBe(1);
+        converterReturnList[0].Role.ShouldBe(ChatRole.Tool);
+        var resultContent = converterReturnList[0].Contents!
+            .OfType<FunctionResultContent>()
+            .FirstOrDefault();
+        resultContent.ShouldNotBeNull();
+        resultContent!.CallId.ShouldBe("call-fe-1");
+        // No ToolApprovalResponseContent for a plain tool_call interrupt
+        converterReturnList[0].Contents!.OfType<ToolApprovalResponseContent>().ShouldBeEmpty();
     }
 
     #endregion

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/Agents/AIAgentServiceExecutionTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/Agents/AIAgentServiceExecutionTests.cs
@@ -35,9 +35,10 @@ public class AIAgentServiceExecutionTests
                 It.IsAny<IEnumerable<AIRequestContextItem>?>(),
                 It.IsAny<IEnumerable<AITool>?>(),
                 It.IsAny<IReadOnlyDictionary<string, object?>?>(),
+                It.IsAny<AIApprovalPolicy>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<AIAgent, IEnumerable<AIRequestContextItem>?, IEnumerable<AITool>?, IReadOnlyDictionary<string, object?>?, CancellationToken>(
-                (_, _, _, properties, _) => capturedAdditionalProperties = properties)
+            .Callback<AIAgent, IEnumerable<AIRequestContextItem>?, IEnumerable<AITool>?, IReadOnlyDictionary<string, object?>?, AIApprovalPolicy, CancellationToken>(
+                (_, _, _, properties, _, _) => capturedAdditionalProperties = properties)
             .ReturnsAsync(CreateRespondingAgent());
 
         var eventAggregatorMock = new Mock<IEventAggregator>();

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/Chat/AIAgentFactoryApprovalTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/Chat/AIAgentFactoryApprovalTests.cs
@@ -1,0 +1,229 @@
+using System.Reflection;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Moq;
+using Shouldly;
+using Umbraco.AI.Agent.Core.Agents;
+using Umbraco.AI.Agent.Core.Chat;
+using Umbraco.AI.Agent.Core.Workflows;
+using Umbraco.AI.Core.Chat;
+using Umbraco.AI.Core.Profiles;
+using Umbraco.AI.Core.RuntimeContext;
+using Umbraco.AI.Core.Tools;
+using Umbraco.AI.Core.Tools.Scopes;
+using Xunit;
+using MsAIAgent = Microsoft.Agents.AI.AIAgent;
+using UmbracoAIAgent = Umbraco.AI.Agent.Core.Agents.AIAgent;
+
+namespace Umbraco.AI.Agent.Tests.Unit.Chat;
+
+public class AIAgentFactoryApprovalTests
+{
+    private static readonly Guid TestProfileId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private sealed class TestTool : IAITool
+    {
+        public required string Id { get; init; }
+        public required string Name { get; init; }
+        public string Description => string.Empty;
+        public string ScopeId => "test-scope";
+        public bool IsDestructive { get; init; }
+        public IReadOnlyList<string> Tags => [];
+        public Type? ArgsType => null;
+        public Task<object> ExecuteAsync(object? args, CancellationToken cancellationToken = default)
+            => Task.FromResult<object>("result");
+    }
+
+    private sealed class TestSystemTool : IAITool, IAISystemTool
+    {
+        public required string Id { get; init; }
+        public required string Name { get; init; }
+        public string Description => string.Empty;
+        public string ScopeId => "test-scope";
+        public bool IsDestructive { get; init; }
+        public IReadOnlyList<string> Tags => [];
+        public Type? ArgsType => null;
+        public Task<object> ExecuteAsync(object? args, CancellationToken cancellationToken = default)
+            => Task.FromResult<object>("result");
+    }
+
+    [Fact]
+    public async Task CreateAgentAsync_DestructiveNonSystemTool_IsWrappedInApprovalRequired()
+    {
+        IAITool[] tools =
+        [
+            new TestTool { Id = "delete-thing", Name = "delete-thing", IsDestructive = true },
+            new TestTool { Id = "get-thing",    Name = "get-thing",    IsDestructive = false },
+        ];
+
+        var factory = CreateFactory(tools);
+        var agent = CreateAgent(["delete-thing", "get-thing"]);
+
+        var result = await factory.CreateAgentAsync(agent);
+
+        var chatOptions = ExtractChatOptions(result);
+        chatOptions.ShouldNotBeNull();
+        chatOptions!.Tools.ShouldNotBeNull();
+        chatOptions.Tools!.Single(t => t.Name == "delete-thing").ShouldBeOfType<ApprovalRequiredAIFunction>();
+        chatOptions.Tools!.Single(t => t.Name == "get-thing").ShouldNotBeOfType<ApprovalRequiredAIFunction>();
+    }
+
+    [Fact]
+    public async Task CreateAgentAsync_WithDestructiveTool_SetsAllowMultipleToolCallsFalse()
+    {
+        IAITool[] tools = [new TestTool { Id = "delete-thing", Name = "delete-thing", IsDestructive = true }];
+
+        var factory = CreateFactory(tools);
+        var agent = CreateAgent(["delete-thing"]);
+
+        var result = await factory.CreateAgentAsync(agent);
+
+        ExtractChatOptions(result)!.AllowMultipleToolCalls.ShouldBe(false);
+    }
+
+    [Fact]
+    public async Task CreateAgentAsync_WithNoDestructiveTool_LeavesAllowMultipleToolCallsNull()
+    {
+        IAITool[] tools = [new TestTool { Id = "get-thing", Name = "get-thing", IsDestructive = false }];
+
+        var factory = CreateFactory(tools);
+        var agent = CreateAgent(["get-thing"]);
+
+        var result = await factory.CreateAgentAsync(agent);
+
+        ExtractChatOptions(result)!.AllowMultipleToolCalls.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task CreateAgentAsync_DenyAllPolicy_WrapsDestructiveToolInApprovalDenied()
+    {
+        IAITool[] tools =
+        [
+            new TestTool { Id = "delete-thing", Name = "delete-thing", IsDestructive = true },
+            new TestTool { Id = "get-thing",    Name = "get-thing",    IsDestructive = false },
+        ];
+
+        var factory = CreateFactory(tools);
+        var agent = CreateAgent(["delete-thing", "get-thing"]);
+
+        var result = await factory.CreateAgentAsync(agent, approvalPolicy: AIApprovalPolicy.DenyAll);
+
+        var chatOptions = ExtractChatOptions(result);
+        chatOptions!.Tools!.Single(t => t.Name == "delete-thing").ShouldBeOfType<ApprovalDeniedAIFunction>();
+        chatOptions.Tools!.Single(t => t.Name == "get-thing").ShouldNotBeOfType<ApprovalDeniedAIFunction>();
+        // No ApprovalRequiredAIFunction is produced under DenyAll, so multi-call stays at the default.
+        chatOptions.AllowMultipleToolCalls.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task CreateAgentAsync_AllowAllPolicy_LeavesDestructiveToolUnwrapped()
+    {
+        IAITool[] tools = [new TestTool { Id = "delete-thing", Name = "delete-thing", IsDestructive = true }];
+
+        var factory = CreateFactory(tools);
+        var agent = CreateAgent(["delete-thing"]);
+
+        var result = await factory.CreateAgentAsync(agent, approvalPolicy: AIApprovalPolicy.AllowAll);
+
+        var tool = ExtractChatOptions(result)!.Tools!.Single(t => t.Name == "delete-thing");
+        tool.ShouldNotBeOfType<ApprovalRequiredAIFunction>();
+        tool.ShouldNotBeOfType<ApprovalDeniedAIFunction>();
+        ExtractChatOptions(result)!.AllowMultipleToolCalls.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task CreateAgentAsync_DestructiveSystemTool_IsNotWrappedAndDoesNotSetMultipleToolCallsFalse()
+    {
+        // System tools are always included even without explicit AllowedToolIds;
+        // they must not be wrapped in ApprovalRequiredAIFunction.
+        IAITool[] tools = [new TestSystemTool { Id = "sys-delete", Name = "sys-delete", IsDestructive = true }];
+
+        var factory = CreateFactory(tools);
+        var agent = CreateAgent([]); // no explicit tool IDs; system tool is auto-included
+
+        var result = await factory.CreateAgentAsync(agent);
+
+        var chatOptions = ExtractChatOptions(result);
+        chatOptions!.Tools!.Single(t => t.Name == "sys-delete").ShouldNotBeOfType<ApprovalRequiredAIFunction>();
+        chatOptions.AllowMultipleToolCalls.ShouldBeNull();
+    }
+
+    private static AIAgentFactory CreateFactory(IEnumerable<IAITool> tools)
+    {
+        var toolCollection = new AIToolCollection(() => tools);
+        var scopeCollection = new AIToolScopeCollection(() => []);
+        var workflowCollection = new AIAgentWorkflowCollection(() => []);
+        var contributorCollection = new AIRuntimeContextContributorCollection(() => []);
+
+        var functionFactoryMock = new Mock<IAIFunctionFactory>();
+        functionFactoryMock
+            .Setup(f => f.Create(It.IsAny<IEnumerable<IAITool>>()))
+            .Returns<IEnumerable<IAITool>>(ts =>
+                ts.Select(t => Microsoft.Extensions.AI.AIFunctionFactory.Create(() => "ok", name: t.Id)).ToList());
+
+        var chatClientMock = new Mock<IChatClient>();
+        chatClientMock
+            .Setup(x => x.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, "ok")));
+
+        var dummyProfile = new AIProfile
+        {
+            Id = TestProfileId,
+            Alias = "test",
+            Name = "Test",
+            ConnectionId = Guid.Empty,
+        };
+
+        var profileServiceMock = new Mock<IAIProfileService>();
+        profileServiceMock
+            .Setup(x => x.GetProfileAsync(TestProfileId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(dummyProfile);
+
+        var chatClientFactoryMock = new Mock<IAIChatClientFactory>();
+        chatClientFactoryMock
+            .Setup(x => x.CreateClientAsync(dummyProfile, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chatClientMock.Object);
+
+        return new AIAgentFactory(
+            new Mock<IAIRuntimeContextScopeProvider>().Object,
+            contributorCollection,
+            profileServiceMock.Object,
+            chatClientFactoryMock.Object,
+            toolCollection,
+            scopeCollection,
+            functionFactoryMock.Object,
+            workflowCollection);
+    }
+
+    private static UmbracoAIAgent CreateAgent(IReadOnlyList<string> allowedToolIds)
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            Alias = "test-agent",
+            Name = "Test Agent",
+            ProfileId = TestProfileId,
+            AgentType = AIAgentType.Standard,
+            Config = new AIStandardAgentConfig
+            {
+                AllowedToolIds = allowedToolIds,
+                AllowedToolScopeIds = [],
+            },
+            IsActive = true,
+        };
+
+    private static ChatOptions? ExtractChatOptions(MsAIAgent agent)
+    {
+        // agent is ScopedAIAgent : DelegatingAIAgent; InnerAgent is the ChatClientAgent
+        const BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
+        var innerAgent = agent.GetType().BaseType?
+            .GetProperty("InnerAgent", flags)?
+            .GetValue(agent) as MsAIAgent;
+        if (innerAgent == null) return null;
+        return (ChatOptions?)innerAgent.GetType()
+            .GetProperty("ChatOptions", flags)?
+            .GetValue(innerAgent);
+    }
+}

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/Chat/MeaiApprovalRoundTripSpikeTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/Chat/MeaiApprovalRoundTripSpikeTests.cs
@@ -1,0 +1,161 @@
+using Microsoft.Extensions.AI;
+using Shouldly;
+using Xunit;
+
+namespace Umbraco.AI.Agent.Tests.Unit.Chat;
+
+public class MeaiApprovalRoundTripSpikeTests
+{
+    // A fake IChatClient that, on the FIRST call, returns one tool call to "delete_thing",
+    // and on the SECOND call (after the approval response is in history) returns a plain
+    // text completion. This lets us observe exactly what FICC produces/consumes.
+    private sealed class ScriptedChatClient : IChatClient
+    {
+        private int _calls;
+        public ChatClientMetadata Metadata { get; } = new("scripted");
+        public bool ToolWasInvoked { get; private set; }
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken ct = default)
+        {
+            _calls++;
+            if (_calls == 1)
+            {
+                var call = new FunctionCallContent("call-1", "delete_thing",
+                    new Dictionary<string, object?> { ["id"] = "42" });
+                return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, [call])));
+            }
+
+            // Record whether, by the second model turn, a FunctionResultContent for call-1
+            // appeared in history (i.e. FICC executed the tool after approval).
+            ToolWasInvoked = messages.Any(m => m.Contents.OfType<FunctionResultContent>()
+                .Any(r => r.CallId == "call-1"));
+            return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "done")));
+        }
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
+    }
+
+    [Fact]
+    public async Task ApprovalRequiredFunction_FirstTurn_ProducesApprovalRequest_AndDoesNotInvoke()
+    {
+        var invoked = false;
+        var inner = AIFunctionFactory.Create(
+            (string id) => { invoked = true; return $"deleted {id}"; },
+            name: "delete_thing");
+        var approvalFn = new ApprovalRequiredAIFunction(inner);
+
+        var scripted = new ScriptedChatClient();
+        var client = scripted.AsBuilder().UseFunctionInvocation().Build();
+
+        var options = new ChatOptions { Tools = [approvalFn] };
+        var response = await client.GetResponseAsync(
+            [new ChatMessage(ChatRole.User, "delete thing 42")], options);
+
+        var approvalRequest = response.Messages
+            .SelectMany(m => m.Contents)
+            .OfType<ToolApprovalRequestContent>()
+            .FirstOrDefault();
+
+        approvalRequest.ShouldNotBeNull();
+        approvalRequest!.ToolCall.CallId.ShouldBe("call-1");
+        invoked.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ApprovalResponse_Approved_CausesToolInvocation()
+    {
+        var invoked = false;
+        var inner = AIFunctionFactory.Create(
+            (string id) => { invoked = true; return $"deleted {id}"; },
+            name: "delete_thing");
+        var approvalFn = new ApprovalRequiredAIFunction(inner);
+
+        var scripted = new ScriptedChatClient();
+        var client = scripted.AsBuilder().UseFunctionInvocation().Build();
+        var options = new ChatOptions { Tools = [approvalFn] };
+
+        // First turn: get the approval request.
+        var first = await client.GetResponseAsync(
+            [new ChatMessage(ChatRole.User, "delete thing 42")], options);
+        var request = first.Messages.SelectMany(m => m.Contents)
+            .OfType<ToolApprovalRequestContent>().Single();
+
+        var approvalResponse = request.CreateResponse(approved: true, reason: null);
+
+        var history = new List<ChatMessage> { new(ChatRole.User, "delete thing 42") };
+        history.AddRange(first.Messages);
+        history.Add(new ChatMessage(ChatRole.User, [approvalResponse]));
+
+        var second = await client.GetResponseAsync(history, options);
+
+        invoked.ShouldBeTrue();
+        scripted.ToolWasInvoked.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ApprovalResponse_Denied_DoesNotInvoke()
+    {
+        var invoked = false;
+        var inner = AIFunctionFactory.Create(
+            (string id) => { invoked = true; return $"deleted {id}"; },
+            name: "delete_thing");
+        var approvalFn = new ApprovalRequiredAIFunction(inner);
+
+        var client = new ScriptedChatClient().AsBuilder().UseFunctionInvocation().Build();
+        var options = new ChatOptions { Tools = [approvalFn] };
+
+        var first = await client.GetResponseAsync(
+            [new ChatMessage(ChatRole.User, "delete thing 42")], options);
+        var request = first.Messages.SelectMany(m => m.Contents)
+            .OfType<ToolApprovalRequestContent>().Single();
+
+        var denial = request.CreateResponse(approved: false, reason: "user denied");
+        var history = new List<ChatMessage> { new(ChatRole.User, "delete thing 42") };
+        history.AddRange(first.Messages);
+        history.Add(new ChatMessage(ChatRole.User, [denial]));
+
+        await client.GetResponseAsync(history, options);
+        invoked.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ApprovalResponse_StatelessConstruction_Approved_CausesToolInvocation()
+    {
+        // Tests finding C: whether a freshly built ToolApprovalResponseContent (without
+        // using CreateResponse) also works — this is what the stateless resume path does.
+        var invoked = false;
+        var inner = AIFunctionFactory.Create(
+            (string id) => { invoked = true; return $"deleted {id}"; },
+            name: "delete_thing");
+        var approvalFn = new ApprovalRequiredAIFunction(inner);
+
+        var scripted = new ScriptedChatClient();
+        var client = scripted.AsBuilder().UseFunctionInvocation().Build();
+        var options = new ChatOptions { Tools = [approvalFn] };
+
+        var first = await client.GetResponseAsync(
+            [new ChatMessage(ChatRole.User, "delete thing 42")], options);
+        var request = first.Messages.SelectMany(m => m.Contents)
+            .OfType<ToolApprovalRequestContent>().Single();
+
+        // Stateless construction — what the resume path will do without the original request object.
+        var statelessResponse = new ToolApprovalResponseContent(
+            request.ToolCall.CallId,
+            approved: true,
+            request.ToolCall);
+
+        var history = new List<ChatMessage> { new(ChatRole.User, "delete thing 42") };
+        history.AddRange(first.Messages);
+        history.Add(new ChatMessage(ChatRole.User, [statelessResponse]));
+
+        await client.GetResponseAsync(history, options);
+        invoked.ShouldBeTrue();
+        scripted.ToolWasInvoked.ShouldBeTrue();
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Umbraco.AI.Core.csproj
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Umbraco.AI.Core.csproj
@@ -48,6 +48,9 @@
             <_Parameter1>Umbraco.AI.Tests.Integration</_Parameter1>
         </AssemblyAttribute>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Umbraco.AI.Agent.Tests.Unit</_Parameter1>
+        </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
             <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
         </AssemblyAttribute>
     </ItemGroup>

--- a/docs/internal/plans/2026-06-16-backend-tool-hitl-approval.md
+++ b/docs/internal/plans/2026-06-16-backend-tool-hitl-approval.md
@@ -218,9 +218,9 @@ git commit -m "test(agent): characterize MEAI ApprovalRequiredAIFunction round-t
 ```
 
 > **Task 3/4 assumptions (filled in by Task 0):**
-> - A. Response role: `__________`
-> - B. Request must be in replayed history: `__________`
-> - C. Stateless construction `new ToolApprovalResponseContent(callId, approved, toolCall)` works: `__________`
+> - A. Response role: `ChatRole.User`
+> - B. Request must be in replayed history: `yes` — `history.AddRange(first.Messages)` required
+> - C. Stateless construction `new ToolApprovalResponseContent(callId, approved, toolCall)` works: `yes`
 
 ---
 
@@ -789,37 +789,36 @@ If FICC requires the original `ToolApprovalRequestContent` to be present in the 
 
 The client already has `UaiHitlInterruptHandler` keyed to `reason = "human_approval"` and an approval UI. This task confirms the server's new interrupt shape matches what the client expects and that resume sends `{ approved: bool }`.
 
-- [ ] **Step 1: Trace the client interrupt→resume path**
+- [x] **Step 1: Trace the client interrupt→resume path**
 
-Read the four files above and confirm:
-- The handler receives an interrupt whose `reason === "human_approval"` and renders the approval element.
-- The approval element's approve/deny resolves to a resume payload of `{ approved: true }` / `{ approved: false }`, with the resume entry's `interruptId` set to the server's interrupt `Id` (i.e. `"approval:call-9"`), `status: "Resolved"`.
-- The `message`, `toolName`, and `arguments` (from interrupt `Metadata`) are surfaced to the user.
+**Finding:** the interrupt→render path was already correct (`UaiHitlInterruptHandler` → `UaiHitlContext.setInterrupt` → `uai-hitl-approval` → default approval element resolving `{ approved: bool }`). **But the resume path was NOT wired for approval.** `run.controller.#resumeRun` injected the approve/deny decision as a *user chat message* and re-sent the conversation with no `resume` array — so the server's `ExtractToolResultsFromResume` (Task 4) never ran. The frontend never populated `AGUIRunRequestModel.resume` at all (the field existed in the generated client but was unused).
 
-- [ ] **Step 2: Align any mismatch (edit only if needed)**
+- [x] **Step 2: Align the mismatch (real edits required)**
 
-If the client currently builds a different payload shape (e.g. `{ approve: ... }` or echoes the option `value` string), adjust the approval element / resume assembly so the resolved payload is exactly `{ approved: boolean }` to match `ApprovalResponseSchema` from Task 2. Keep changes minimal and within the existing approval components.
+Wired a true resume path (commit `fix(agent,agent-ui): Wire human_approval resume entries to backend`):
+- `transport/uai-agent-client.ts`: `sendMessage` gained an optional `resume` param, threaded through `forwardedProps` (the AG-UI `RunAgentInput` schema has no first-class resume slot).
+- `transport/uai-http-agent.ts`: lifts `resume` out of `forwardedProps` into the typed `body.resume` field the server reads.
+- `chat/services/run.controller.ts`: `#resumeRun` detects `interrupt.reason === "human_approval"` and sends a single resume entry `{ interruptId: interrupt.id /* "approval:<callId>" */, status: "Resolved", payload: { approved } }` instead of a polluting user turn. The pending tool call is already replayed in the assistant message history (captured by `onToolCallStart`/`onToolCallArgsEnd`), so `PromoteApprovalRequestsInHistory` can correlate it server-side. Frontend `tool_call` resume is unchanged (its result is already appended as a tool-role message).
 
-- [ ] **Step 3: Build the frontend to verify it compiles**
+- [x] **Step 3: Build the frontend to verify it compiles**
 
-Run: `npm run build:agent-ui`
-Expected: build succeeds with no type errors.
+`npm run build:agent-ui` cannot reach a fully-green build in this worktree due to a **pre-existing** duplicate-`@umbraco-cms/backoffice`-copy nominal-identity issue affecting unrelated management UI components (`agent-picker`, `workflow-picker`, `agent-surface-picker`). Verified my three changed files introduce **zero** new type errors: the tsc error set is byte-identical with my changes applied vs. stashed.
 
-- [ ] **Step 4: Commit (only if files changed)**
+- [x] **Step 4: Commit**
 
-```bash
-git add Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/
-git commit -m "fix(agent-ui): align human_approval resume payload with backend schema"
-```
+Committed as `fix(agent,agent-ui): Wire human_approval resume entries to backend`.
 
 ---
 
 ### Task 6: End-to-end integration test (approve + deny)
 
-**Files:**
-- Test: `Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Integration/Agents/BackendToolApprovalFlowTests.cs` (create; confirm the integration test project name/path first via `ls Umbraco.AI.Agent/tests`)
+**Status: DONE.** No integration project existed (only `Tests.Unit`); created `Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Integration` (matching the repo convention, e.g. `Umbraco.AI.Tests.Integration`) and registered it in `Umbraco.AI.Agent.slnx`. The `InternalsVisibleTo("Umbraco.AI.Agent.Tests.Integration")` entry was already present in `Umbraco.AI.Agent.Core.csproj`. Both tests pass: a real `ChatClientAgent` (built like `AIAgentFactory`, with `AllowMultipleToolCalls = false`) over a stateless scripted `IChatClient`, driven through the real `AGUIStreamingService` — pause→approve executes the spy once, deny never executes it.
 
-- [ ] **Step 1: Write the failing integration test**
+**Files:**
+- Created: `Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Integration/Agents/BackendToolApprovalFlowTests.cs`
+- Created: `Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Integration/Umbraco.AI.Agent.Tests.Integration.csproj`
+
+- [x] **Step 1: Write the failing integration test**
 
 ```csharp
 // Scenario, against a scripted IChatClient registered for a real DI-built agent with one
@@ -862,49 +861,44 @@ git commit -m "test(agent): end-to-end backend tool approval/deny flow"
 
 **Context:** 10.7.0 removed the back-compat path that auto-marked `ToolApprovalResponseContent` as `InformationalOnly`. With approval now in use, verify our resume responses still resume correctly under 10.7.
 
-- [ ] **Step 1: Bump the floors**
+**Status: DONE (no new commit needed).** `Directory.Packages.props` already pins both `Microsoft.Extensions.AI` and `Microsoft.Extensions.AI.OpenAI` at `[10.7.0, 10.999.999)`; no product-level override pins a lower floor.
 
-In `Directory.Packages.props`, change:
-```xml
-<PackageVersion Include="Microsoft.Extensions.AI" Version="[10.7.0, 10.999.999)" />
-<PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="[10.7.0, 10.999.999)" />
-```
-Then check for product-level overrides: `grep -rl "Microsoft.Extensions.AI" --include=Directory.Packages.props .` and update any that pin a lower floor.
+- [x] **Step 1: Bump the floors** — already at 10.7.0.
 
-- [ ] **Step 2: Restore + build**
+- [x] **Step 2: Restore + build** — solution builds on 10.7.0.
 
-Run: `dotnet build Umbraco.AI.Agent/Umbraco.AI.Agent.slnx`
-Expected: succeeds.
+- [x] **Step 3: Re-run the full approval suite**
 
-- [ ] **Step 3: Re-run the full approval suite**
+`dotnet test Umbraco.AI.Agent/Umbraco.AI.Agent.slnx --filter "FullyQualifiedName~Approval|FullyQualifiedName~MeaiApprovalRoundTrip"` → **23 passed** (21 unit incl. the Task 0 spike + 2 integration). The approved-resume path invokes the tool under 10.7 without needing an explicit `InformationalOnly = false`, confirmed by the Task 6 integration test. Full agent unit suite: **163 passed**.
 
-Run: `dotnet test Umbraco.AI.Agent/Umbraco.AI.Agent.slnx --filter "FullyQualifiedName~Approval"`
-Expected: PASS. If the approved-resume path now fails to invoke the tool, the response content needs `InformationalOnly = false` set explicitly — add that in `ExtractToolResultsFromResume` (Task 4) where the `ToolApprovalResponseContent` is built, and re-run. Re-run the Task 0 spike too; update its assumptions if behavior shifted.
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add Directory.Packages.props
-git commit -m "chore(deps): Bump Microsoft.Extensions.AI to 10.7.0 for tool approval"
-```
+- [x] **Step 4: Commit** — the 10.7.0 floor was already committed; nothing new to commit for this task.
 
 ---
 
 ## Scope boundary & open questions: headless / non-interactive approval
 
-This plan implements approval over the **AG-UI streaming** path (interrupt → client approves → resume). It does **not** cover non-interactive callers — a real gap that must be resolved before approval can ever be **default-on** (see `project_v17_alignment_breaking_changes`).
+**RESOLVED (Task 8 — implemented).** Shipped option 1 + 2: `AIApprovalPolicy { Interactive, DenyAll, AllowAll }` on `AIAgentExecutionOptions` (default **`DenyAll`**). The factory (`AIAgentFactory.CreateStandardAgentAsync`) gates destructive non-system tools per policy:
+- `Interactive` → `ApprovalRequiredAIFunction` (AG-UI streaming path forces this).
+- `DenyAll` → `ApprovalDeniedAIFunction` (new `DelegatingAIFunction` that skips execution and returns a denial result, so the run completes instead of stalling).
+- `AllowAll` → unwrapped (executes; captured by the existing audit-log middleware).
+
+`AGUIStreamingService` callers go through `IAIAgentService.StreamAgentAGUIAsync`, which passes `Interactive`. All headless service paths (`RunAgentAsync`/`StreamAgentAsync` persisted + inline, `CreateInlineAgentAsync`) pass `DenyAll`. `Umbraco.AI.Automate.RunAgentAction` builds `AIAgentExecutionOptions` without setting the policy, so it inherits the safe `DenyAll` default — destructive tools are denied (not stalled) under automation. Tests: factory unit tests for `DenyAll`/`AllowAll` wrapping; integration test `DestructiveBackendTool_DenyAllPolicy_CompletesWithoutExecuting`. The Automate-orchestrated human-task flow (option 4) remains a separate future cross-product effort.
+
+---
+
+This plan implements approval over the **AG-UI streaming** path (interrupt → client approves → resume). The non-interactive gap below is now closed by the `DenyAll` default (see `project_v17_alignment_breaking_changes`).
 
 Verified constraints:
 - **The non-streaming path has no resume.** `RunAgentAction` (`Umbraco.AI.Automate/Actions/RunAgentAction.cs`) and any non-AG-UI caller invoke `IAIAgentService.RunAgentAsync(...)` — a single, non-streaming call. There is no interrupt/resume there, so a `ToolApprovalRequestContent` produced mid-run has nothing to resolve it: under default-on approval a destructive tool would leave the run incomplete (tool unexecuted) or stalled. **Behavior must be defined explicitly**, not inherited from whatever FICC does by default.
 - **No human is present.** `RunAgentAction` runs as the workspace service account; there is no backoffice user or chat surface to approve, and our `Umbraco.AI.Automate` package currently has **no pause/human-task/approval primitive** (grep-confirmed).
 
-Options (decide before default-on; record the outcome here):
-1. **Per-execution approval policy** on `AIAgentExecutionOptions` (it already carries `UserGroupIds`/`AdditionalProperties` for headless) — e.g. `ApprovalPolicy { Interactive, AutoDeny, AutoAllowWithAudit }`. AG-UI streaming ⇒ `Interactive`; Automate ⇒ configurable.
-2. **Auto-deny (safe default):** the tool is skipped, the model is told approval was denied, the run completes. Preserves automation flow; destructive tools simply don't run headlessly without explicit opt-in.
-3. **Auto-allow-with-audit:** approval bypassed but audit-logged. Keeps automation working but defeats the gate — acceptable only behind an explicit per-agent/per-automation opt-in.
+Options (decided — see RESOLVED note above):
+1. **Per-execution approval policy** on `AIAgentExecutionOptions` — shipped as `ApprovalPolicy { Interactive, DenyAll, AllowAll }`. AG-UI streaming ⇒ `Interactive`; Automate ⇒ inherits the `DenyAll` default, configurable.
+2. **DenyAll (safe default):** the tool is skipped, the model is told approval was denied, the run completes. Preserves automation flow; destructive tools simply don't run headlessly without explicit opt-in. **← shipped as the default.**
+3. **AllowAll:** approval bypassed but audit-logged via existing middleware. Keeps automation working but defeats the gate — acceptable only behind an explicit per-agent/per-automation opt-in.
 4. **Orchestrate with Umbraco Automate (richest — user-proposed).** `RunAgentAction` detects a pending approval and surfaces it to the Automate engine: pause the workflow, raise a human-approval task, resume the agent with the decision when actioned. **Depends on Automate capabilities not yet confirmed** — investigate whether `Umbraco.Automate.Core` supports a *suspended/awaiting* `ActionResult`, workflow pause/resume, and a human-task/approval step. Also requires a **non-AG-UI resume mechanism** (re-invoke the agent with a `ToolApprovalResponseContent` injected — the AG-UI `ExtractToolResultsFromResume` logic is AG-UI-specific; Automate needs an analogous path, or the approval is resolved before re-invocation). If Automate supports this, it's the proper headless story; if not, it's a larger cross-product effort and its own plan.
 
-**Recommendation:** ship this plan (AG-UI/interactive) with an `AIAgentExecutionOptions.ApprovalPolicy` defaulting to **`AutoDeny`** for non-interactive callers — that makes a future default-on safe everywhere without deadlock. Treat the Automate-orchestrated human-task flow (option 4) as a **separate cross-product investigation/plan**, gated on confirming Automate's suspend/resume/human-task support.
+**Recommendation (shipped):** this plan (AG-UI/interactive) ships with `AIAgentExecutionOptions.ApprovalPolicy` defaulting to **`DenyAll`** for non-interactive callers — making a future default-on safe everywhere without deadlock. The Automate-orchestrated human-task flow (option 4) remains a **separate cross-product investigation/plan**, gated on confirming Automate's suspend/resume/human-task support.
 
 ## Cross-cutting risks & test obligations
 


### PR DESCRIPTION
Backports **#212** (`feat(agent): Backend tool HITL approval`, merged into `v18/dev`) to the **v17** LTS line, which is under "Features + bug fixes" support policy.

## What this adds
Server-side human-in-the-loop (HITL) approval for **destructive backend agent tools**. Destructive, non-system backend tools are gated per a resolved `AIApprovalPolicy`:

- **Interactive** (AG-UI streaming path): wrapped in MEAI's `ApprovalRequiredAIFunction`, so the call surfaces as a `ToolApprovalRequestContent`, is emitted as an AG-UI `human_approval` interrupt, and executes/skips on resume.
- **DenyAll** (headless/programmatic callers, Automate): wrapped in `ApprovalDeniedAIFunction` so the run completes without stalling on an interrupt that has no interactive surface to resolve it.
- **AllowAll**: left unwrapped (still captured by audit-log middleware).

Frontend tools are unchanged — they keep their client-side approval flow.

Key pieces: `AIApprovalPolicy`, `AIAgentFactory` wrap site, `ApprovalDeniedAIFunction`, `AGUIInterruptKind` (encodes the tool callId into the interrupt ID for stateless resume), stream detection + resume routing in `AGUIStreamingService`/`AGUIEventEmitter`, and `ApprovalPolicy` threading through `AIAgentService`/`AIAgentExecutionOptions`.

## How it was backported
- `git cherry-pick -m 1` of the #212 merge commit — the applied diff is **byte-identical** to the original PR's net diff. All 23 touched files were identical between `v17/dev` and the PR's merge base, so it applied with no conflicts.
- MEAI is already `[10.7.0, 10.999.999)` on v17, so no `Directory.Packages.props` change was needed (the original plan's Task 7 bump is already satisfied on this line).

## Also included
A separate `chore(ci)` commit updates the v17 git hooks (`pre-push`/`pre-merge`/`post-merge`, sh + ps1) for the `vN/` branch naming convention — the v17 line still had the pre-`vN/` validation and rejected valid `vN/feature/*` branch names. The patterns are version-agnostic (`v[0-9]+`), backported verbatim from v18.

## Verification
- ✅ `dotnet build Umbraco.AI.Agent/Umbraco.AI.Agent.slnx` — 0 errors
- ✅ `dotnet test Umbraco.AI.Agent/Umbraco.AI.Agent.slnx` — **165 unit + 3 integration pass** (incl. the new approval/deny flow tests)
- ⚠️ Frontend `build:api` fails on **pre-existing** v17/dev TypeScript errors (11 errors in untouched picker/modal components + `app.ts`), confirmed identical on the clean `v17/dev` baseline. The three TS files this backport touches (`run.controller.ts`, `uai-agent-client.ts`, `uai-http-agent.ts`) compile clean. This pre-existing frontend breakage is being investigated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)