### PR TITLE
chore(ci): Port pipeline branch filters to vN/ naming convention

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,17 +95,17 @@ parameters:
 trigger:
     branches:
         include:
-            - main
-            - dev
-            - release/*
-            - hotfix/*
-            - feature/*
+            - v*/main
+            - v*/dev
+            - v*/release/*
+            - v*/hotfix/*
+            - v*/feature/*
 
 pr:
     branches:
         include:
-            - main
-            - dev
+            - v*/main
+            - v*/dev
 
 variables:
     - group: dependency-track


### PR DESCRIPTION
## Summary

The `azure-pipelines.yml` `trigger` and `pr` branch filters on the v17 line still referenced the **pre-restructure** branch names (`main`, `dev`, `release/*`, `hotfix/*`, `feature/*`). After the `vN/` branch-model restructure, none of these match the real branches (`v17/dev`, `v17/feature/*`, …), so **the pipeline silently skipped every `v17/*` push and PR** — reporting a `neutral` / "No pipeline branch filters matched the modified branch" check instead of running Build & Test.

This backports the `v*/` filter patterns **already present on `v18/dev`** (block is now byte-identical to v18), restoring push and PR CI for the v17 line.

## Change

```yaml
trigger:
  branches:
    include: [ v*/main, v*/dev, v*/release/*, v*/hotfix/*, v*/feature/* ]
pr:
  branches:
    include: [ v*/main, v*/dev ]
```

## Impact

- Restores automated Build & Test on `v17/dev` pushes and on PRs targeting `v17/dev` (including #206, which is currently un-validated by CI for this reason).
- v18 already carries this fix — no port needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)