### PR TITLE
chore(ci): Port remaining vN/ CI-infra changes to v17

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,17 +95,17 @@ parameters:
 trigger:
     branches:
         include:
-            - main
-            - dev
-            - release/*
-            - hotfix/*
-            - feature/*
+            - v*/main
+            - v*/dev
+            - v*/release/*
+            - v*/hotfix/*
+            - v*/feature/*
 
 pr:
     branches:
         include:
-            - main
-            - dev
+            - v*/main
+            - v*/dev
 
 variables:
     - group: dependency-track
@@ -187,7 +187,7 @@ stages:
                       publishLocation: pipeline
 
     # ============================================================
-    # Generate & Upload SBOMs - Only runs on push to main/dev/hotfix/release
+    # Generate & Upload SBOMs - Only runs on push to vN/main, vN/dev, vN/hotfix/*, vN/release/*
     # Generates per-product SBOMs and uploads to Dependency-Track
     # ============================================================
     - stage: GenerateSBOM
@@ -387,8 +387,8 @@ stages:
             succeeded(),
             ne(variables['Build.Reason'], 'PullRequest'),
             or(
-              startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'),
-              startsWith(variables['Build.SourceBranch'], 'refs/heads/hotfix/')
+              contains(variables['Build.SourceBranch'], '/release/'),
+              contains(variables['Build.SourceBranch'], '/hotfix/')
             )
           )
       jobs:
@@ -417,7 +417,7 @@ stages:
       dependsOn:
           - Build
           - ValidateChangelogs
-      # Only pack on push (not PR) to main/dev/hotfix/release branches
+      # Only pack on push (not PR) to vN/main, vN/dev, vN/hotfix/*, vN/release/* branches
       # ValidateChangelogs may be skipped (on main/dev branches), which is OK
       condition: |
           and(
@@ -425,10 +425,10 @@ stages:
             in(dependencies.ValidateChangelogs.result, 'Succeeded', 'Skipped'),
             ne(variables['Build.Reason'], 'PullRequest'),
             or(
-              startsWith(variables['Build.SourceBranch'], 'refs/heads/hotfix/'),
-              startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'),
-              eq(variables['Build.SourceBranch'], 'refs/heads/main'),
-              eq(variables['Build.SourceBranch'], 'refs/heads/dev')
+              contains(variables['Build.SourceBranch'], '/hotfix/'),
+              contains(variables['Build.SourceBranch'], '/release/'),
+              endsWith(variables['Build.SourceBranch'], '/main'),
+              endsWith(variables['Build.SourceBranch'], '/dev')
             )
           )
       jobs:
@@ -450,7 +450,7 @@ stages:
                       filePath: .azure-pipelines/scripts/detect-changes.ps1
                       pwsh: true
                   env:
-                      # Required to query previous builds for main/dev comparison base
+                      # Required to query previous builds for vN/dev comparison base
                       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
                 - task: Bash@3
@@ -534,9 +534,9 @@ stages:
                 - template: .azure-pipelines/templates/pack-product.yml
                   parameters:
                       product: Umbraco.AI
-                      # Use project references on dev (preview releases), NuGet packages on release/hotfix/main (validate ranges).
-                      # packWithNuGetRanges (queue-time) forces NuGet ranges on dev too.
-                      useProjectReferences: ${{ and(eq(variables['Build.SourceBranchName'], 'dev'), not(parameters.packWithNuGetRanges)) }}
+                      # Use project references on vN/dev (preview releases), NuGet packages on vN/release, vN/hotfix, vN/main (validate ranges).
+                      # packWithNuGetRanges (queue-time) forces NuGet ranges on vN/dev too.
+                      useProjectReferences: ${{ and(endsWith(variables['Build.SourceBranch'], '/dev'), not(parameters.packWithNuGetRanges)) }}
 
                 - template: .azure-pipelines/templates/upload-packages.yml
                   parameters:
@@ -586,9 +586,9 @@ stages:
                 - template: .azure-pipelines/templates/pack-product.yml
                   parameters:
                       product: $(product)
-                      # Use project references on dev (preview releases), NuGet packages on release/hotfix/main (validate ranges).
-                      # packWithNuGetRanges (queue-time) forces NuGet ranges on dev too.
-                      useProjectReferences: ${{ and(eq(variables['Build.SourceBranchName'], 'dev'), not(parameters.packWithNuGetRanges)) }}
+                      # Use project references on vN/dev (preview releases), NuGet packages on vN/release, vN/hotfix, vN/main (validate ranges).
+                      # packWithNuGetRanges (queue-time) forces NuGet ranges on vN/dev too.
+                      useProjectReferences: ${{ and(endsWith(variables['Build.SourceBranch'], '/dev'), not(parameters.packWithNuGetRanges)) }}
                       condition: eq(variables['check.shouldPack'], 'true')
 
                 - template: .azure-pipelines/templates/upload-packages.yml
@@ -644,9 +644,9 @@ stages:
                 - template: .azure-pipelines/templates/pack-product.yml
                   parameters:
                       product: $(product)
-                      # Use project references on dev (preview releases), NuGet packages on release/hotfix/main (validate ranges).
-                      # packWithNuGetRanges (queue-time) forces NuGet ranges on dev too.
-                      useProjectReferences: ${{ and(eq(variables['Build.SourceBranchName'], 'dev'), not(parameters.packWithNuGetRanges)) }}
+                      # Use project references on vN/dev (preview releases), NuGet packages on vN/release, vN/hotfix, vN/main (validate ranges).
+                      # packWithNuGetRanges (queue-time) forces NuGet ranges on vN/dev too.
+                      useProjectReferences: ${{ and(endsWith(variables['Build.SourceBranch'], '/dev'), not(parameters.packWithNuGetRanges)) }}
                       condition: eq(variables['check.shouldPack'], 'true')
 
                 - template: .azure-pipelines/templates/upload-packages.yml
@@ -707,9 +707,9 @@ stages:
                 - template: .azure-pipelines/templates/pack-product.yml
                   parameters:
                       product: $(product)
-                      # Use project references on dev (preview releases), NuGet packages on release/hotfix/main (validate ranges).
-                      # packWithNuGetRanges (queue-time) forces NuGet ranges on dev too.
-                      useProjectReferences: ${{ and(eq(variables['Build.SourceBranchName'], 'dev'), not(parameters.packWithNuGetRanges)) }}
+                      # Use project references on vN/dev (preview releases), NuGet packages on vN/release, vN/hotfix, vN/main (validate ranges).
+                      # packWithNuGetRanges (queue-time) forces NuGet ranges on vN/dev too.
+                      useProjectReferences: ${{ and(endsWith(variables['Build.SourceBranch'], '/dev'), not(parameters.packWithNuGetRanges)) }}
                       condition: eq(variables['check.shouldPack'], 'true')
 
                 - template: .azure-pipelines/templates/upload-packages.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,17 +95,17 @@ parameters:
 trigger:
     branches:
         include:
-            - main
-            - dev
-            - release/*
-            - hotfix/*
-            - feature/*
+            - v*/main
+            - v*/dev
+            - v*/release/*
+            - v*/hotfix/*
+            - v*/feature/*
 
 pr:
     branches:
         include:
-            - main
-            - dev
+            - v*/main
+            - v*/dev
 
 variables:
     - group: dependency-track

--- a/scripts/install-package-test-site.ps1
+++ b/scripts/install-package-test-site.ps1
@@ -27,14 +27,28 @@ $RepoRoot = (Resolve-Path (Split-Path -Parent $ScriptDir)).Path
 # Change to repository root to ensure consistent behavior
 Push-Location $RepoRoot
 
+# Detect major version from the Umbraco.Cms.Core lower bound in Directory.Packages.props
+$packagesPropsPath = Join-Path $RepoRoot "Directory.Packages.props"
+if (-not (Test-Path $packagesPropsPath)) {
+    Write-Host "ERROR: Could not find $packagesPropsPath" -ForegroundColor Red
+    exit 1
+}
+$packagesContent = Get-Content $packagesPropsPath -Raw
+if (-not ($packagesContent -match 'Include="Umbraco\.Cms\.Core" Version="\[([^,]+),')) {
+    Write-Host "ERROR: Could not find Umbraco.Cms.Core version range in $packagesPropsPath" -ForegroundColor Red
+    exit 1
+}
+$VersionMajor = [int]($matches[1] -split '\.')[0]
+
 Write-Host "=== Umbraco.AI Feed Test Site Setup ===" -ForegroundColor Cyan
 Write-Host "Working directory: $RepoRoot" -ForegroundColor Gray
 Write-Host "Feed: $Feed ($FeedUrl)" -ForegroundColor Gray
 Write-Host "Site name: $SiteName" -ForegroundColor Gray
+Write-Host "Version: v$VersionMajor (from Directory.Packages.props)" -ForegroundColor Gray
 Write-Host ""
 
 # Check if specific site folder already exists
-$sitePath = "demo\$SiteName"
+$sitePath = "demos\v$VersionMajor\$SiteName"
 if ((Test-Path $sitePath) -and -not $Force) {
     Write-Host "Site folder '$sitePath' already exists. Use -Force to recreate." -ForegroundColor Yellow
     exit 0
@@ -55,29 +69,35 @@ if ($Feed -ne "release") {
 
 # Step 1: Install Umbraco templates
 if (-not $SkipTemplateInstall) {
-    Write-Host "Installing Umbraco templates..." -ForegroundColor Green
-    dotnet new install Umbraco.Templates --force
+    $TemplateVersion = $matches[1]  # Umbraco.Cms.Core lower bound already captured above
+    $IsTemplatePrerelease = $TemplateVersion -match '-'
+
+    Write-Host "Installing Umbraco templates ($TemplateVersion)..." -ForegroundColor Green
+    if ($IsTemplatePrerelease) {
+        Write-Host "NOTE: Prerelease template ($TemplateVersion) requires the umbracoprereleases MyGet source." -ForegroundColor Yellow
+    }
+    dotnet new install "Umbraco.Templates::$TemplateVersion" --force
 }
 
 # Step 2: Create demo folder
-Write-Host "Creating demo folder..." -ForegroundColor Green
-New-Item -ItemType Directory -Path "demo" -Force | Out-Null
+Write-Host "Creating demo folder 'demos\v$VersionMajor'..." -ForegroundColor Green
+New-Item -ItemType Directory -Path "demos\v$VersionMajor" -Force | Out-Null
 
 # Step 3: Create the Umbraco site
 Write-Host "Creating Umbraco site '$SiteName'..." -ForegroundColor Green
-Push-Location "demo"
+Push-Location "demos\v$VersionMajor"
 dotnet new umbraco --force -n $SiteName --friendly-name "Administrator" --email "admin@example.com" --password "password1234" --development-database-type SQLite
 Pop-Location
 
 # Step 4: Install Clean starter kit
 Write-Host "Installing Clean starter kit..." -ForegroundColor Green
-Push-Location "demo\$SiteName"
+Push-Location "demos\v$VersionMajor\$SiteName"
 dotnet add package Clean
 Pop-Location
 
 # Step 5: Configure NuGet sources and PackageSourceMapping
 Write-Host "Configuring NuGet sources and package routing..." -ForegroundColor Green
-Push-Location "demo\$SiteName"
+Push-Location "demos\v$VersionMajor\$SiteName"
 
 # Determine feed name
 $feedName = switch ($Feed) {
@@ -137,7 +157,7 @@ Pop-Location
 
 # Step 6: Install Umbraco.AI packages from feed
 Write-Host "Installing Umbraco.AI packages from $Feed feed..." -ForegroundColor Green
-Push-Location "demo\$SiteName"
+Push-Location "demos\v$VersionMajor\$SiteName"
 
 # Build the base command arguments for dotnet add package
 # For nightly/prereleases, append --prerelease flag
@@ -184,14 +204,14 @@ Pop-Location
 Write-Host ""
 Write-Host "=== Setup Complete! ===" -ForegroundColor Green
 Write-Host ""
-Write-Host "Site location: demo\$SiteName" -ForegroundColor Cyan
+Write-Host "Site location: demos\v$VersionMajor\$SiteName" -ForegroundColor Cyan
 Write-Host ""
 Write-Host "Credentials:" -ForegroundColor Yellow
 Write-Host "  Email: admin@example.com"
 Write-Host "  Password: password1234"
 Write-Host ""
 Write-Host "Next steps:" -ForegroundColor Yellow
-Write-Host "  1. cd demo\$SiteName"
+Write-Host "  1. cd demos\v$VersionMajor\$SiteName"
 Write-Host "  2. dotnet run"
 Write-Host "  3. Open https://localhost:44355 in your browser"
 Write-Host ""

--- a/scripts/install-package-test-site.sh
+++ b/scripts/install-package-test-site.sh
@@ -69,16 +69,30 @@ done
 # Set feed URL based on selection
 FEED_URL="${FEED_URLS[$FEED]}"
 
+# Detect major version from the Umbraco.Cms.Core lower bound in Directory.Packages.props
+PACKAGES_PROPS_PATH="$REPO_ROOT/Directory.Packages.props"
+if [ ! -f "$PACKAGES_PROPS_PATH" ]; then
+    echo "ERROR: Could not find $PACKAGES_PROPS_PATH" >&2
+    exit 1
+fi
+TEMPLATE_VERSION=$(grep -oE 'Include="Umbraco\.Cms\.Core" Version="\[[^,]+,' "$PACKAGES_PROPS_PATH" | grep -oE '\[[^,]+,' | tr -d '[,')
+if [ -z "$TEMPLATE_VERSION" ]; then
+    echo "ERROR: Could not find Umbraco.Cms.Core version range in $PACKAGES_PROPS_PATH" >&2
+    exit 1
+fi
+VERSION_MAJOR=$(echo "$TEMPLATE_VERSION" | cut -d. -f1)
+
 echo "========================================="
 echo "Umbraco.AI Feed Test Site Setup"
 echo "========================================="
 echo "Working directory: $REPO_ROOT"
 echo "Feed: $FEED ($FEED_URL)"
 echo "Site name: $SITE_NAME"
+echo "Version: v$VERSION_MAJOR (from Directory.Packages.props)"
 echo ""
 
 # Check if specific site folder already exists
-SITE_PATH="demo/$SITE_NAME"
+SITE_PATH="demos/v${VERSION_MAJOR}/$SITE_NAME"
 if [ -d "$SITE_PATH" ] && [ "$FORCE" = false ]; then
     echo "Site folder '$SITE_PATH' already exists. Use --force to recreate."
     exit 0
@@ -99,29 +113,33 @@ fi
 
 # Step 1: Install Umbraco templates
 if [ "$SKIP_TEMPLATE_INSTALL" = false ]; then
-    echo "Installing Umbraco templates..."
-    dotnet new install Umbraco.Templates --force
+    # TEMPLATE_VERSION already set above from Directory.Packages.props
+    echo "Installing Umbraco templates ($TEMPLATE_VERSION)..."
+    if echo "$TEMPLATE_VERSION" | grep -q '-'; then
+        echo "NOTE: Prerelease template ($TEMPLATE_VERSION) requires the umbracoprereleases MyGet source."
+    fi
+    dotnet new install "Umbraco.Templates::${TEMPLATE_VERSION}" --force
 fi
 
 # Step 2: Create demo folder
-echo "Creating demo folder..."
-mkdir -p "demo"
+echo "Creating demo folder 'demos/v${VERSION_MAJOR}'..."
+mkdir -p "demos/v${VERSION_MAJOR}"
 
 # Step 3: Create the Umbraco site
 echo "Creating Umbraco site '$SITE_NAME'..."
-pushd "demo" > /dev/null
+pushd "demos/v${VERSION_MAJOR}" > /dev/null
 dotnet new umbraco --force -n "$SITE_NAME" --friendly-name "Administrator" --email "admin@example.com" --password "password1234" --development-database-type SQLite
 popd > /dev/null
 
 # Step 4: Install Clean starter kit
 echo "Installing Clean starter kit..."
-pushd "demo/$SITE_NAME" > /dev/null
+pushd "demos/v${VERSION_MAJOR}/$SITE_NAME" > /dev/null
 dotnet add package Clean
 popd > /dev/null
 
 # Step 5: Configure NuGet sources and PackageSourceMapping
 echo "Configuring NuGet sources and package routing..."
-pushd "demo/$SITE_NAME" > /dev/null
+pushd "demos/v${VERSION_MAJOR}/$SITE_NAME" > /dev/null
 
 # Determine feed name
 case "$FEED" in
@@ -181,7 +199,7 @@ popd > /dev/null
 
 # Step 6: Install Umbraco.AI packages from feed
 echo "Installing Umbraco.AI packages from $FEED feed..."
-pushd "demo/$SITE_NAME" > /dev/null
+pushd "demos/v${VERSION_MAJOR}/$SITE_NAME" > /dev/null
 
 # Determine if we need --prerelease flag (only for nightly/prereleases, not for release)
 if [ "$FEED" = "release" ]; then
@@ -251,14 +269,14 @@ echo "========================================="
 echo "Setup Complete!"
 echo "========================================="
 echo ""
-echo "Site location: demo/$SITE_NAME"
+echo "Site location: demos/v${VERSION_MAJOR}/$SITE_NAME"
 echo ""
 echo "Credentials:"
 echo "  Email: admin@example.com"
 echo "  Password: password1234"
 echo ""
 echo "Next steps:"
-echo "  1. cd demo/$SITE_NAME"
+echo "  1. cd demos/v${VERSION_MAJOR}/$SITE_NAME"
 echo "  2. dotnet run"
 echo "  3. Open https://localhost:44355 in your browser"
 echo ""


### PR DESCRIPTION
Backports the `vN/` branch-model support changes from `v18/dev` to the v17 line that were not yet present on `v17/dev`. Consolidates and **supersedes #222** (`v17/feature/fix-ci-branch-filters`) — that branch is merged into this one, so its authored commit is preserved here and only one PR is needed.

## What's included

**`azure-pipelines.yml` — complete the `vN/` port**
- `trigger:` / `pr:` filters → `v*/main`, `v*/dev`, `v*/release/*`, `v*/hotfix/*`, `v*/feature/*` (this is the #222 change, folded in)
- SBOM + Pack stage conditions → `contains('/release/')`, `contains('/hotfix/')`, `endsWith('/main')`, `endsWith('/dev')`
- `useProjectReferences` expressions → `endsWith(Build.SourceBranch, '/dev')` (4 templates)

Without these, no pipeline ran for `v17/*` branches and the pack/SBOM gating never matched the new branch names.

**`scripts/install-package-test-site.{sh,ps1}` — `demos/vN/` layout**
- Detect the CMS major from the `Umbraco.Cms.Core` lower bound in `Directory.Packages.props`
- Create test sites under `demos/vN/` instead of the flat `demo/` folder, and pin the template to that same range
- Version-agnostic: resolves to `demos/v17/` on this line

## Deliberately NOT ported (v18-specific)
- `NODE_VERSION` `22.x → 24.x` — v17 stays on Node 22
- `scripts/build/generate-openapi.js` — CMS v18 Swashbuckle → `/umbraco/openapi` endpoint migration
- `scripts/install-demo-site.{sh,ps1}` Search add-on exclusion — v18 compat only

## Already on `v17/dev` (no action needed)
- Git-hook `vN/` branch naming (merged via #221)
- `demos/vN/` path in `install-demo-site` scripts

## Verification
- `azure-pipelines.yml` now differs from `v18/dev` **only** on the `NODE_VERSION` line
- `install-package-test-site.{sh,ps1}` are byte-identical to `v18/dev`
- `bash -n` and PowerShell parse checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)