### PR TITLE
fix(imagegeneration): Make tracking middleware DI-constructable

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Core/ImageGeneration/AITrackingImageGenerationMiddleware.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/ImageGeneration/AITrackingImageGenerationMiddleware.cs
@@ -11,11 +11,14 @@ namespace Umbraco.AI.Core.ImageGeneration;
 /// operations, via the shared <see cref="AIImageGenerationTracker"/>.
 /// </summary>
 [Experimental(AIImageGenerationDiagnostics.DiagnosticId)]
-public sealed class AITrackingImageGenerationMiddleware : IAIImageGenerationMiddleware
+internal sealed class AITrackingImageGenerationMiddleware : IAIImageGenerationMiddleware
 {
     private readonly AIImageGenerationTracker _tracker;
 
-    internal AITrackingImageGenerationMiddleware(AIImageGenerationTracker tracker)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AITrackingImageGenerationMiddleware"/> class.
+    /// </summary>
+    public AITrackingImageGenerationMiddleware(AIImageGenerationTracker tracker)
     {
         _tracker = tracker;
     }


### PR DESCRIPTION
## Summary

Backports the DI fix from #224 (v18) to the v17 line, per the "keep active versions in sync" policy.

`AITrackingImageGenerationMiddleware` (added in #206) was declared `public sealed` with an **`internal` constructor**, but it's registered via the image-generation middleware collection builder and constructed by **MS DI — which only uses public constructors**. Resolving the image-generation pipeline therefore throws (`A suitable constructor … could not be located`).

- On **v18** this crashed at app startup because CMS 18 enables `ServiceProvider` `ValidateOnBuild` (eager validation) — that's how #224 surfaced it.
- On **v17** it's **latent**: nothing eagerly validates it, so it will throw the **first time image generation is actually invoked**.

## Fix

Made the middleware `internal` with a **public** constructor (public-on-an-internal-type has effective internal accessibility, so no CS0051 against the internal `AIImageGenerationTracker`), so DI can construct it — without promoting the tracker to public API ahead of the planned `IAIOperationTracker` generalisation (#195). Identical to the v18 change in #224.

## Testing

- `dotnet build Umbraco.AI.slnx` — 0 errors.
- **888 unit tests** pass.
- The equivalent change on v18 (#224) was confirmed by a clean demo-site boot (DI validation passes).

## Note

Not caught by build or unit/integration tests — only by constructing the DI pipeline (app boot / first image-gen call). No behaviour change beyond making the middleware resolvable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)