### PR TITLE
fix(deploy): Deploy capability-specific profile settings and default profiles

### DIFF
--- a/Umbraco.AI.Deploy/src/Umbraco.AI.Deploy/Artifacts/AISettingsArtifact.cs
+++ b/Umbraco.AI.Deploy/src/Umbraco.AI.Deploy/Artifacts/AISettingsArtifact.cs
@@ -21,6 +21,16 @@ public class AISettingsArtifact(GuidUdi udi, IEnumerable<ArtifactDependency>? de
     public GuidUdi? DefaultEmbeddingProfileUdi { get; set; }
 
     /// <summary>
+    /// The UDI of the default speech-to-text profile (optional).
+    /// </summary>
+    public GuidUdi? DefaultSpeechToTextProfileUdi { get; set; }
+
+    /// <summary>
+    /// The UDI of the default image-generation profile (optional).
+    /// </summary>
+    public GuidUdi? DefaultImageGenerationProfileUdi { get; set; }
+
+    /// <summary>
     /// The UDI of the classifier chat profile (optional).
     /// </summary>
     public GuidUdi? ClassifierChatProfileUdi { get; set; }

--- a/Umbraco.AI.Deploy/src/Umbraco.AI.Deploy/Connectors/ServiceConnectors/UmbracoAIProfileServiceConnector.cs
+++ b/Umbraco.AI.Deploy/src/Umbraco.AI.Deploy/Connectors/ServiceConnectors/UmbracoAIProfileServiceConnector.cs
@@ -88,7 +88,12 @@ public class UmbracoAIProfileServiceConnector(
             ModelProviderId = entity.Model.ProviderId,
             ModelModelId = entity.Model.ModelId,
             ConnectionUdi = connectionUdi,
-            Settings = entity.Settings != null ? JsonSerializer.SerializeToElement(entity.Settings) : null,
+            // Serialize against the runtime type (Settings is declared as the marker interface
+            // IAIProfileSettings, which would otherwise serialize as an empty object) using the
+            // core serializer options so the artifact round-trips through AIProfileSettingsSerializer.
+            Settings = entity.Settings != null
+                ? JsonSerializer.SerializeToElement(entity.Settings, entity.Settings.GetType(), Umbraco.AI.Core.Constants.DefaultJsonSerializerOptions)
+                : null,
             Tags = entity.Tags.ToList()
         };
 
@@ -128,18 +133,14 @@ public class UmbracoAIProfileServiceConnector(
             throw new InvalidOperationException($"Connection with ID {artifact.ConnectionUdi.Guid} not found. Ensure the connection is deployed before the profile.");
         }
 
-        // Deserialize settings from JsonElement based on capability
+        // Deserialize settings from JsonElement based on capability.
+        // Delegate to the core serializer (rather than duplicating the capability switch here)
+        // so support for every capability — including ImageGeneration — stays in sync with the core.
         IAIProfileSettings? settings = null;
         if (artifact.Settings.HasValue)
         {
             var capability = (AICapability)artifact.Capability;
-            settings = capability switch
-            {
-                AICapability.Chat => artifact.Settings.Value.Deserialize<AIChatProfileSettings>(),
-                AICapability.Embedding => artifact.Settings.Value.Deserialize<AIEmbeddingProfileSettings>(),
-                AICapability.SpeechToText => artifact.Settings.Value.Deserialize<AISpeechToTextProfileSettings>(),
-                _ => null
-            };
+            settings = AIProfileSettingsSerializer.Deserialize(capability, artifact.Settings.Value.GetRawText());
         }
 
         // Create AIModelRef from artifact properties

--- a/Umbraco.AI.Deploy/src/Umbraco.AI.Deploy/Connectors/ServiceConnectors/UmbracoAISettingsServiceConnector.cs
+++ b/Umbraco.AI.Deploy/src/Umbraco.AI.Deploy/Connectors/ServiceConnectors/UmbracoAISettingsServiceConnector.cs
@@ -88,6 +88,20 @@ public class UmbracoAISettingsServiceConnector(
             dependencies.Add(new UmbracoAIArtifactDependency(embeddingProfileUdi, ArtifactDependencyMode.Match));
         }
 
+        GuidUdi? speechToTextProfileUdi = null;
+        if (entity.DefaultSpeechToTextProfileId.HasValue)
+        {
+            speechToTextProfileUdi = new GuidUdi(UmbracoAIConstants.UdiEntityType.Profile, entity.DefaultSpeechToTextProfileId.Value);
+            dependencies.Add(new UmbracoAIArtifactDependency(speechToTextProfileUdi, ArtifactDependencyMode.Match));
+        }
+
+        GuidUdi? imageGenerationProfileUdi = null;
+        if (entity.DefaultImageGenerationProfileId.HasValue)
+        {
+            imageGenerationProfileUdi = new GuidUdi(UmbracoAIConstants.UdiEntityType.Profile, entity.DefaultImageGenerationProfileId.Value);
+            dependencies.Add(new UmbracoAIArtifactDependency(imageGenerationProfileUdi, ArtifactDependencyMode.Match));
+        }
+
         GuidUdi? classifierChatProfileUdi = null;
         if (entity.ClassifierChatProfileId.HasValue)
         {
@@ -99,6 +113,8 @@ public class UmbracoAISettingsServiceConnector(
         {
             DefaultChatProfileUdi = chatProfileUdi,
             DefaultEmbeddingProfileUdi = embeddingProfileUdi,
+            DefaultSpeechToTextProfileUdi = speechToTextProfileUdi,
+            DefaultImageGenerationProfileUdi = imageGenerationProfileUdi,
             ClassifierChatProfileUdi = classifierChatProfileUdi
         };
 
@@ -151,6 +167,30 @@ public class UmbracoAISettingsServiceConnector(
         else
         {
             settings.DefaultEmbeddingProfileId = null;
+        }
+
+        // Resolve optional speech-to-text profile dependency
+        if (state.Artifact.DefaultSpeechToTextProfileUdi != null)
+        {
+            state.Artifact.DefaultSpeechToTextProfileUdi.EnsureType(UmbracoAIConstants.UdiEntityType.Profile);
+            var speechToTextProfile = await profileService.GetProfileAsync(state.Artifact.DefaultSpeechToTextProfileUdi.Guid, ct);
+            settings.DefaultSpeechToTextProfileId = speechToTextProfile?.Id;
+        }
+        else
+        {
+            settings.DefaultSpeechToTextProfileId = null;
+        }
+
+        // Resolve optional image-generation profile dependency
+        if (state.Artifact.DefaultImageGenerationProfileUdi != null)
+        {
+            state.Artifact.DefaultImageGenerationProfileUdi.EnsureType(UmbracoAIConstants.UdiEntityType.Profile);
+            var imageGenerationProfile = await profileService.GetProfileAsync(state.Artifact.DefaultImageGenerationProfileUdi.Guid, ct);
+            settings.DefaultImageGenerationProfileId = imageGenerationProfile?.Id;
+        }
+        else
+        {
+            settings.DefaultImageGenerationProfileId = null;
         }
 
         // Resolve optional classifier chat profile dependency

--- a/Umbraco.AI.Deploy/tests/Umbraco.AI.Deploy.Tests.Unit/Connectors/ServiceConnectors/UmbracoAIProfileServiceConnectorTests.cs
+++ b/Umbraco.AI.Deploy/tests/Umbraco.AI.Deploy.Tests.Unit/Connectors/ServiceConnectors/UmbracoAIProfileServiceConnectorTests.cs
@@ -6,9 +6,11 @@ using Shouldly;
 using Umbraco.AI.Core.Connections;
 using Umbraco.AI.Core.Models;
 using Umbraco.AI.Core.Profiles;
+using Umbraco.AI.Deploy.Artifacts;
 using Umbraco.AI.Deploy.Configuration;
 using Umbraco.AI.Deploy.Connectors.ServiceConnectors;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Deploy;
 using Xunit;
 
 namespace Umbraco.AI.Deploy.Tests.Unit.Connectors.ServiceConnectors;
@@ -137,5 +139,117 @@ public class UmbracoAIProfileServiceConnectorTests
     {
         // Assert
         _connector.UdiEntityType.ShouldBe("umbraco-ai-profile");
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ImageGenerationProfile_RoundTripsSettings()
+    {
+        // Arrange
+        var connectionId = Guid.NewGuid();
+        var profile = new AIProfile
+        {
+            Alias = "image-profile",
+            Name = "Image Profile",
+            Capability = AICapability.ImageGeneration,
+            Model = new AIModelRef("openai", "gpt-image-1"),
+            ConnectionId = connectionId,
+            Settings = new AIImageGenerationProfileSettings
+            {
+                Size = "1024x1024",
+                Quality = "hd",
+                Style = "vivid",
+                MediaType = "image/png"
+            }
+        };
+
+        var udi = new GuidUdi("umbraco-ai-profile", profile.Id);
+        var artifact = await _connector.GetArtifactAsync(udi, profile);
+        artifact.ShouldNotBeNull();
+
+        _connectionServiceMock
+            .Setup(x => x.GetConnectionAsync(connectionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AIConnection
+            {
+                Alias = "conn",
+                Name = "Conn",
+                ProviderId = "openai"
+            });
+
+        AIProfile? savedProfile = null;
+        _profileServiceMock
+            .Setup(x => x.SaveProfileAsync(It.IsAny<AIProfile>(), It.IsAny<CancellationToken>()))
+            .Callback<AIProfile, CancellationToken>((p, _) => savedProfile = p)
+            .ReturnsAsync((AIProfile p, CancellationToken _) => p);
+
+        var state = new ArtifactDeployState<AIProfileArtifact, AIProfile>(
+            artifact, null, _connector, 2);
+
+        // Act
+        await _connector.ProcessAsync(state, Mock.Of<IDeployContext>(), 2);
+
+        // Assert
+        savedProfile.ShouldNotBeNull();
+        var settings = savedProfile.Settings.ShouldBeOfType<AIImageGenerationProfileSettings>();
+        settings.Size.ShouldBe("1024x1024");
+        settings.Quality.ShouldBe("hd");
+        settings.Style.ShouldBe("vivid");
+        settings.MediaType.ShouldBe("image/png");
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ChatProfile_RoundTripsSettings()
+    {
+        // Arrange - guards against the marker-interface being serialized as an empty object,
+        // which would silently drop all concrete settings for every capability.
+        var connectionId = Guid.NewGuid();
+        var guardrailId = Guid.NewGuid();
+        var profile = new AIProfile
+        {
+            Alias = "chat-profile",
+            Name = "Chat Profile",
+            Capability = AICapability.Chat,
+            Model = new AIModelRef("openai", "gpt-4"),
+            ConnectionId = connectionId,
+            Settings = new AIChatProfileSettings
+            {
+                Temperature = 0.7f,
+                MaxTokens = 1000,
+                SystemPromptTemplate = "You are helpful.",
+                GuardrailIds = [guardrailId]
+            }
+        };
+
+        var udi = new GuidUdi("umbraco-ai-profile", profile.Id);
+        var artifact = await _connector.GetArtifactAsync(udi, profile);
+        artifact.ShouldNotBeNull();
+
+        _connectionServiceMock
+            .Setup(x => x.GetConnectionAsync(connectionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AIConnection
+            {
+                Alias = "conn",
+                Name = "Conn",
+                ProviderId = "openai"
+            });
+
+        AIProfile? savedProfile = null;
+        _profileServiceMock
+            .Setup(x => x.SaveProfileAsync(It.IsAny<AIProfile>(), It.IsAny<CancellationToken>()))
+            .Callback<AIProfile, CancellationToken>((p, _) => savedProfile = p)
+            .ReturnsAsync((AIProfile p, CancellationToken _) => p);
+
+        var state = new ArtifactDeployState<AIProfileArtifact, AIProfile>(
+            artifact, null, _connector, 2);
+
+        // Act
+        await _connector.ProcessAsync(state, Mock.Of<IDeployContext>(), 2);
+
+        // Assert
+        savedProfile.ShouldNotBeNull();
+        var settings = savedProfile.Settings.ShouldBeOfType<AIChatProfileSettings>();
+        settings.Temperature.ShouldBe(0.7f);
+        settings.MaxTokens.ShouldBe(1000);
+        settings.SystemPromptTemplate.ShouldBe("You are helpful.");
+        settings.GuardrailIds.ShouldBe([guardrailId]);
     }
 }

--- a/Umbraco.AI.Deploy/tests/Umbraco.AI.Deploy.Tests.Unit/Connectors/ServiceConnectors/UmbracoAISettingsServiceConnectorTests.cs
+++ b/Umbraco.AI.Deploy/tests/Umbraco.AI.Deploy.Tests.Unit/Connectors/ServiceConnectors/UmbracoAISettingsServiceConnectorTests.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Shouldly;
+using Umbraco.AI.Core.Models;
+using Umbraco.AI.Core.Profiles;
+using Umbraco.AI.Core.Settings;
+using Umbraco.AI.Deploy.Artifacts;
+using Umbraco.AI.Deploy.Configuration;
+using Umbraco.AI.Deploy.Connectors.ServiceConnectors;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Deploy;
+using Xunit;
+
+namespace Umbraco.AI.Deploy.Tests.Unit.Connectors.ServiceConnectors;
+
+public class UmbracoAISettingsServiceConnectorTests
+{
+    private readonly Mock<IAISettingsService> _settingsServiceMock;
+    private readonly Mock<IAIProfileService> _profileServiceMock;
+    private readonly Mock<UmbracoAIDeploySettingsAccessor> _settingsAccessorMock;
+    private readonly UmbracoAISettingsServiceConnector _connector;
+
+    public UmbracoAISettingsServiceConnectorTests()
+    {
+        _settingsServiceMock = new Mock<IAISettingsService>();
+        _profileServiceMock = new Mock<IAIProfileService>();
+        _settingsAccessorMock = new Mock<UmbracoAIDeploySettingsAccessor>(MockBehavior.Strict, null!);
+
+        _settingsAccessorMock.Setup(x => x.Settings).Returns(new UmbracoAIDeploySettings());
+
+        _connector = new UmbracoAISettingsServiceConnector(
+            _settingsServiceMock.Object,
+            _profileServiceMock.Object,
+            _settingsAccessorMock.Object);
+    }
+
+    [Fact]
+    public async Task GetArtifactAsync_WithImageGenerationDefault_AddsUdiAndDependency()
+    {
+        // Arrange
+        var imageProfileId = Guid.NewGuid();
+        var settings = new AISettings
+        {
+            DefaultImageGenerationProfileId = imageProfileId
+        };
+
+        var udi = new GuidUdi(UmbracoAIConstants.UdiEntityType.Settings, AISettings.SettingsId);
+
+        // Act
+        var artifact = await _connector.GetArtifactAsync(udi, settings);
+
+        // Assert
+        artifact.ShouldNotBeNull();
+        artifact.DefaultImageGenerationProfileUdi.ShouldNotBeNull();
+        artifact.DefaultImageGenerationProfileUdi.Guid.ShouldBe(imageProfileId);
+        artifact.DefaultImageGenerationProfileUdi.EntityType.ShouldBe(UmbracoAIConstants.UdiEntityType.Profile);
+
+        artifact.Dependencies.ShouldContain(d =>
+            d.Udi.EntityType == UmbracoAIConstants.UdiEntityType.Profile &&
+            ((GuidUdi)d.Udi).Guid == imageProfileId);
+    }
+
+    [Fact]
+    public async Task GetArtifactAsync_WithSpeechToTextDefault_AddsUdiAndDependency()
+    {
+        // Arrange
+        var speechProfileId = Guid.NewGuid();
+        var settings = new AISettings
+        {
+            DefaultSpeechToTextProfileId = speechProfileId
+        };
+
+        var udi = new GuidUdi(UmbracoAIConstants.UdiEntityType.Settings, AISettings.SettingsId);
+
+        // Act
+        var artifact = await _connector.GetArtifactAsync(udi, settings);
+
+        // Assert
+        artifact.ShouldNotBeNull();
+        artifact.DefaultSpeechToTextProfileUdi.ShouldNotBeNull();
+        artifact.DefaultSpeechToTextProfileUdi.Guid.ShouldBe(speechProfileId);
+        artifact.DefaultSpeechToTextProfileUdi.EntityType.ShouldBe(UmbracoAIConstants.UdiEntityType.Profile);
+
+        artifact.Dependencies.ShouldContain(d =>
+            d.Udi.EntityType == UmbracoAIConstants.UdiEntityType.Profile &&
+            ((GuidUdi)d.Udi).Guid == speechProfileId);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ResolvesSpeechToTextDefaultProfile()
+    {
+        // Arrange
+        var speechProfileId = Guid.NewGuid();
+        var settings = new AISettings();
+        _settingsServiceMock
+            .Setup(x => x.GetSettingsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(settings);
+
+        var resolvedProfile = new AIProfile
+        {
+            Alias = "speech-profile",
+            Name = "Speech Profile",
+            Capability = AICapability.SpeechToText,
+            Model = new AIModelRef("openai", "whisper-1"),
+            ConnectionId = Guid.NewGuid()
+        };
+        _profileServiceMock
+            .Setup(x => x.GetProfileAsync(speechProfileId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(resolvedProfile);
+
+        AISettings? savedSettings = null;
+        _settingsServiceMock
+            .Setup(x => x.SaveSettingsAsync(It.IsAny<AISettings>(), It.IsAny<CancellationToken>()))
+            .Callback<AISettings, CancellationToken>((s, _) => savedSettings = s)
+            .ReturnsAsync((AISettings s, CancellationToken _) => s);
+
+        var udi = new GuidUdi(UmbracoAIConstants.UdiEntityType.Settings, AISettings.SettingsId);
+        var artifact = new AISettingsArtifact(udi)
+        {
+            DefaultSpeechToTextProfileUdi = new GuidUdi(UmbracoAIConstants.UdiEntityType.Profile, speechProfileId)
+        };
+
+        var state = new ArtifactDeployState<AISettingsArtifact, AISettings>(
+            artifact, settings, _connector, 3);
+
+        // Act
+        await _connector.ProcessAsync(state, Mock.Of<IDeployContext>(), 3);
+
+        // Assert
+        _profileServiceMock.Verify(
+            x => x.GetProfileAsync(speechProfileId, It.IsAny<CancellationToken>()),
+            Times.Once);
+        savedSettings.ShouldNotBeNull();
+        savedSettings.DefaultSpeechToTextProfileId.ShouldBe(resolvedProfile.Id);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ResolvesImageGenerationDefaultProfile()
+    {
+        // Arrange
+        var imageProfileId = Guid.NewGuid();
+        var settings = new AISettings();
+        _settingsServiceMock
+            .Setup(x => x.GetSettingsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(settings);
+
+        var resolvedProfile = new AIProfile
+        {
+            Alias = "image-profile",
+            Name = "Image Profile",
+            Capability = AICapability.ImageGeneration,
+            Model = new AIModelRef("openai", "gpt-image-1"),
+            ConnectionId = Guid.NewGuid()
+        };
+        _profileServiceMock
+            .Setup(x => x.GetProfileAsync(imageProfileId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(resolvedProfile);
+
+        AISettings? savedSettings = null;
+        _settingsServiceMock
+            .Setup(x => x.SaveSettingsAsync(It.IsAny<AISettings>(), It.IsAny<CancellationToken>()))
+            .Callback<AISettings, CancellationToken>((s, _) => savedSettings = s)
+            .ReturnsAsync((AISettings s, CancellationToken _) => s);
+
+        var udi = new GuidUdi(UmbracoAIConstants.UdiEntityType.Settings, AISettings.SettingsId);
+        var artifact = new AISettingsArtifact(udi)
+        {
+            DefaultImageGenerationProfileUdi = new GuidUdi(UmbracoAIConstants.UdiEntityType.Profile, imageProfileId)
+        };
+
+        var state = new ArtifactDeployState<AISettingsArtifact, AISettings>(
+            artifact, settings, _connector, 3);
+
+        // Act
+        await _connector.ProcessAsync(state, Mock.Of<IDeployContext>(), 3);
+
+        // Assert
+        _profileServiceMock.Verify(
+            x => x.GetProfileAsync(imageProfileId, It.IsAny<CancellationToken>()),
+            Times.Once);
+        savedSettings.ShouldNotBeNull();
+        savedSettings.DefaultImageGenerationProfileId.ShouldBe(resolvedProfile.Id);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the Deploy gap opened by the Image Generation capability, plus a broader latent bug it surfaced.

### What was broken
- **Profile settings serialized empty for _all_ capabilities.** `AIProfile.Settings` is declared as the marker interface `IAIProfileSettings`, so `SerializeToElement(entity.Settings)` serialized against the interface type and emitted `{}`, silently dropping every concrete setting (Chat, Embedding, SpeechToText). Never caught because no test asserted settings _content_.
- **ImageGeneration settings dropped on import.** The deserialize side used a hardcoded capability switch that didn't include `ImageGeneration` (or `Media`/`Moderation`), so image-gen profile settings resolved to `null`.
- **Default profiles not deployed.** `AISettingsArtifact` had slots only for chat/embedding/classifier — `DefaultImageGenerationProfileId` and `DefaultSpeechToTextProfileId` were never transferred.

### Fix
- Serialize profile settings against the **runtime type** using the core serializer options.
- Delegate deserialization to `AIProfileSettingsSerializer` instead of duplicating the capability switch, so every capability stays in sync with the core automatically.
- Add `DefaultSpeechToTextProfileUdi` and `DefaultImageGenerationProfileUdi` slots to `AISettingsArtifact` and wire up export/import in `UmbracoAISettingsServiceConnector`.

### Tests
Added round-trip tests (TDD) for ImageGeneration and Chat profile settings (incl. `GuardrailIds`), plus a new `UmbracoAISettingsServiceConnectorTests` covering the SpeechToText and ImageGeneration default-profile slots. 17/17 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)