### PR TITLE
fix(search, deps): Target released Umbraco.Cms.Search 18.x and set stable version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,7 +35,7 @@
 
   <!-- Umbraco Search -->
   <ItemGroup>
-    <PackageVersion Include="Umbraco.Cms.Search.Core" Version="[1.0.0, 1.999.999)" />
+    <PackageVersion Include="Umbraco.Cms.Search.Core" Version="[18.0.0, 18.999.999)" />
   </ItemGroup>
 
   <!-- Microsoft.Extensions.AI -->

--- a/Umbraco.AI.Search/version.json
+++ b/Umbraco.AI.Search/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "18.0.0-beta1",
+    "version": "18.0.0",
     "assemblyVersion": {
         "precision": "build"
     },


### PR DESCRIPTION
## Summary

`Umbraco.Cms.Search.Core` has shipped stable, CMS-major-aligned releases (`17.0.0`, `18.0.0`). Our previous range `[1.0.0, 1.999.999)` **excluded** those majors and resolved to the pre-release-era `1.0.0`.

- Bump the `Umbraco.Cms.Search.Core` range to `[18.0.0, 18.999.999)` so Search targets the released v18 CMS Search.
- Promote `Umbraco.AI.Search` from `18.0.0-beta1` to a stable `18.0.0`, aligning it with the other v18 products.

## Verification

- Solution builds against `Umbraco.Cms.Search.Core` 18.0.0 with **0 errors** (resolved version confirmed via `obj/*.nuget.g.props`).
- All **47** unit tests pass.

## Backport

The equivalent range bump (`[17.0.0, 17.999.999)`) is being applied to `v17/dev` separately — its `version.json` is already stable at `17.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)