### PR TITLE
fix(ci): Port v18 versionPrefix-aware change detection to v17

### DIFF
--- a/.azure-pipelines/scripts/detect-changes.ps1
+++ b/.azure-pipelines/scripts/detect-changes.ps1
@@ -430,7 +430,7 @@ function Get-ChangedProducts {
             $changedFiles = git diff --name-only $comparisonBase HEAD 2>&1
         }
     }
-    elseif ($SourceBranch -match '^refs/heads/(v\d+/)?(main|dev)$') {
+    elseif ($SourceBranch -match '^refs/heads/v\d+/(main|dev)$') {
         # For main/dev pushes: compare against the source version of the previous completed
         # build on this branch. origin/<branch> is unreliable here: by the time this job's
         # checkout fetches, the remote tracking ref already contains the commit being built
@@ -490,10 +490,10 @@ function Get-ChangedProducts {
             $changedFiles = git diff --name-only HEAD~1 HEAD 2>&1
         }
     }
-    elseif ($SourceBranch -match '^refs/heads/(v\d+/)?(release|hotfix)/') {
+    elseif ($SourceBranch -match '^refs/heads/v\d+/(release|hotfix)/') {
         # Release/hotfix branches: per-product tag-based comparison
         # Each product compares against its own latest release tag
-        $branchType = if ($SourceBranch -match 'release/') { "Release" } else { "Hotfix" }
+        $branchType = if ($SourceBranch -match '/release/') { "Release" } else { "Hotfix" }
         Write-Host "  $branchType branch detected - using per-product tag comparison" -ForegroundColor Cyan
 
         # Process each product independently
@@ -504,10 +504,11 @@ function Get-ChangedProducts {
             $latestTag = git describe --tags --abbrev=0 --match="$($product.DisplayName)@*" 2>&1
 
             if ($LASTEXITCODE -ne 0 -or -not ($latestTag -is [string])) {
-                Write-Host "  ! $($product.DisplayName): No release tag found, falling back to merge-base with main" -ForegroundColor Yellow
+                $versionPrefix = if ($SourceBranch -match '^refs/heads/(v\d+)/') { $Matches[1] } else { 'v17' }
+                Write-Host "  ! $($product.DisplayName): No release tag found, falling back to merge-base with $versionPrefix/main" -ForegroundColor Yellow
 
-                # Fallback: use merge-base with main for this product
-                $mergeBase = git merge-base "origin/main" HEAD 2>&1
+                # Fallback: use merge-base with vN/main for this product
+                $mergeBase = git merge-base "origin/$versionPrefix/main" HEAD 2>&1
                 if ($LASTEXITCODE -eq 0) {
                     $comparisonBase = $mergeBase.Trim()
                     $productChangedFiles = git diff --name-only "$comparisonBase..HEAD" -- $product.Path 2>&1
@@ -583,13 +584,14 @@ function Get-ChangedProducts {
         return $changed
     }
     else {
-        # For feature branches: compare with merge-base against dev
-        Write-Host "  Feature branch detected, comparing against dev" -ForegroundColor Cyan
+        # For feature branches: compare with merge-base against vN/dev
+        $versionPrefix = if ($SourceBranch -match '^refs/heads/(v\d+)/') { $Matches[1] } else { 'v17' }
+        Write-Host "  Feature branch detected, comparing against $versionPrefix/dev" -ForegroundColor Cyan
 
-        $mergeBase = git merge-base "origin/dev" HEAD 2>&1
+        $mergeBase = git merge-base "origin/$versionPrefix/dev" HEAD 2>&1
         if ($LASTEXITCODE -eq 0) {
             $comparisonBase = $mergeBase.Trim()
-            Write-Host "  Using merge-base with dev: $comparisonBase" -ForegroundColor Cyan
+            Write-Host "  Using merge-base with $versionPrefix/dev: $comparisonBase" -ForegroundColor Cyan
             $changedFiles = git diff --name-only $comparisonBase HEAD 2>&1
         }
     }
@@ -943,7 +945,7 @@ $changedProducts = Get-ChangedProducts -Products $products -SourceBranch $Source
 
 # 5. Release/hotfix branch manifest enforcement
 $manifestPath = Join-Path $RootPath "release-manifest.json"
-if ($SourceBranch -match '^refs/heads/(v\d+/)?release/') {
+if ($SourceBranch -match '^refs/heads/v\d+/release/') {
     Write-Host "Release branch detected - enforcing release-manifest.json" -ForegroundColor Cyan
 
     $manifest = Get-ReleasePackageKeys -RootPath $RootPath -Products $products -ProductsByName $productsByName
@@ -969,7 +971,7 @@ if ($SourceBranch -match '^refs/heads/(v\d+/)?release/') {
     $releaseDisplay = $releaseKeys | ForEach-Object { $products[$_].DisplayName }
     Write-Host "Release packages: $($releaseDisplay -join ', ')" -ForegroundColor Yellow
 }
-elseif ($SourceBranch -match '^refs/heads/(v\d+/)?hotfix/') {
+elseif ($SourceBranch -match '^refs/heads/v\d+/hotfix/') {
     if (Test-Path $manifestPath) {
         Write-Host "Hotfix branch detected - applying release-manifest.json" -ForegroundColor Cyan
 


### PR DESCRIPTION
## What

Ports the **`detect-changes.ps1`** improvements from `v18/dev` to the v17 line.

v18's change-detection script derives the version prefix from the branch name and targets `origin/<vN>/main` and `origin/<vN>/dev` in its merge-base fallbacks. v17's copy still referenced the **nonexistent** `origin/main` / `origin/dev`, so:

- the **feature-branch** path silently failed its merge-base and dropped to `HEAD~1`, and
- the **"no release tag" per-product fallback** did the same.

This is the more complete form of the vN/ branch-model port (v17 previously only got the four branch regexes, via release 2026.07.2). The only functional delta from v18 is the version-prefix fallback default, set to `v17` here.

## Why NuGet.config is deliberately NOT ported

I originally flagged v18's 3-feed `NuGet.config` as a candidate, but on inspection it's **v18-specific**, not a clean improvement for v17:

- v18 maps `Umbraco.Deploy*` → the **Prereleases** MyGet feed because v18's Deploy was in **rc** there. **v17's Deploy is stable and canonical on nuget.org** (Prereleases doesn't even carry `17.0.1`/`17.0.2`), so that mapping would misresolve v17 Deploy.
- v17's `Umbraco.Automate.Core` betas resolve from **immutable nuget.org** today, which is *more* lockfile-stable than the MyGet feeds. Adding MyGet sources for the same versions risks the exact contentHash republish-thrash v18's own config comments warn about.

So v17's `NuGet.config` is already correct for v17's package reality.

## Verification

- PowerShell parses clean.
- Regexes match `v17/dev` (main/dev), `v17/release/*`, `v17/hotfix/*`; `v17/feature/*` correctly falls to the feature path (now targeting `origin/v17/dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)