### PR TITLE
fix(core): Differentiate AI transport failure messages

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Core/AuditLog/AIAuditLogService.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/AuditLog/AIAuditLogService.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.AI.Core.Guardrails;
+using Umbraco.AI.Core.Providers.Errors;
 using Umbraco.AI.Core.TaskQueue;
 
 namespace Umbraco.AI.Core.AuditLog;
@@ -331,6 +332,24 @@ internal sealed class AIAuditLogService : IAIAuditLogService
 
     private static AIAuditLogErrorCategory CategorizeError(Exception exception)
     {
+        // A provider error has already been classified into an AIProviderErrorCategory (see
+        // ProviderErrorMapping) - map that directly instead of re-deriving a category by matching
+        // substrings against its own user-facing message, which drifts whenever that message wording
+        // changes and doesn't happen to contain one of the strings checked for below.
+        if (exception is AIProviderException providerException)
+        {
+            return providerException.Category switch
+            {
+                AIProviderErrorCategory.Authentication => AIAuditLogErrorCategory.Authentication,
+                AIProviderErrorCategory.RateLimited => AIAuditLogErrorCategory.RateLimiting,
+                AIProviderErrorCategory.NotFound => AIAuditLogErrorCategory.ModelNotFound,
+                AIProviderErrorCategory.InvalidRequest => AIAuditLogErrorCategory.InvalidRequest,
+                AIProviderErrorCategory.Transient => AIAuditLogErrorCategory.ServerError,
+                AIProviderErrorCategory.NetworkError => AIAuditLogErrorCategory.NetworkError,
+                _ => AIAuditLogErrorCategory.Unknown,
+            };
+        }
+
         // Basic error categorization - can be enhanced based on exception types
         var exceptionType = exception.GetType().Name;
         var message = exception.Message.ToLower();

--- a/Umbraco.AI/src/Umbraco.AI.Core/Chat/AIErrorClassifyingChatClient.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Chat/AIErrorClassifyingChatClient.cs
@@ -17,8 +17,12 @@ namespace Umbraco.AI.Core.Chat;
 /// model round-trip made inside function-invoking middleware passes back through it.
 /// </para>
 /// <para>
-/// Cancellation propagates untouched; an already-classified <see cref="AIProviderException"/>
-/// passes through unchanged so it is never double-wrapped.
+/// Cancellation propagates untouched only when the caller's own <see cref="CancellationToken"/>
+/// was actually signalled; an <see cref="OperationCanceledException"/> raised for any other reason
+/// (most commonly a client-side HTTP timeout, which the underlying SDK reports as a
+/// <see cref="TaskCanceledException"/>) is still classified so it gets a meaningful message instead
+/// of leaking the runtime's raw cancellation text. An already-classified
+/// <see cref="AIProviderException"/> passes through unchanged so it is never double-wrapped.
 /// </para>
 /// </remarks>
 internal sealed class AIErrorClassifyingChatClient : DelegatingChatClient
@@ -41,7 +45,7 @@ internal sealed class AIErrorClassifyingChatClient : DelegatingChatClient
         {
             return await base.GetResponseAsync(messages, options, cancellationToken);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }
@@ -79,7 +83,7 @@ internal sealed class AIErrorClassifyingChatClient : DelegatingChatClient
 
                     update = enumerator.Current;
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
                     throw;
                 }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Providers/Errors/ProviderErrorMapping.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Providers/Errors/ProviderErrorMapping.cs
@@ -1,5 +1,7 @@
 using System.ClientModel;
 using System.Net.Http;
+using System.Net.Sockets;
+using System.Security.Authentication;
 using System.Text.Json;
 
 namespace Umbraco.AI.Core.Providers.Errors;
@@ -31,12 +33,19 @@ public static class ProviderErrorMapping
                 case ClientResultException cre:
                     // Status == 0 means the request never made it to the server.
                     return cre.Status == 0
-                        ? new AIProviderErrorInfo(
-                            AIProviderErrorCategory.NetworkError,
-                            "Couldn't reach the AI service. Check your connection and try again.",
-                            ProviderCode: null,
-                            exception.Message)
+                        ? ClassifyTransportFailure(exception)
                         : FromHttpStatus(cre.Status, exception.Message, TryExtractOpenAIErrorCode(cre));
+
+                // A TimeoutException surfacing as (or wrapped by) an OperationCanceledException is how
+                // HttpClient reports its own request timeout, not a real cancellation - check it first
+                // so genuine timeouts aren't misreported as "request was cancelled".
+                case OperationCanceledException when HasInner<TimeoutException>(current):
+                case TimeoutException:
+                    return new AIProviderErrorInfo(
+                        AIProviderErrorCategory.Transient,
+                        "The AI service took too long to respond. Try again in a moment.",
+                        ProviderCode: "timeout",
+                        exception.Message);
 
                 case OperationCanceledException:
                     return new AIProviderErrorInfo(
@@ -45,22 +54,11 @@ public static class ProviderErrorMapping
                         ProviderCode: null,
                         exception.Message);
 
-                case TimeoutException:
-                    return new AIProviderErrorInfo(
-                        AIProviderErrorCategory.Transient,
-                        "The AI service took too long to respond. Try again in a moment.",
-                        ProviderCode: "timeout",
-                        exception.Message);
-
                 case HttpRequestException { StatusCode: { } code }:
                     return FromHttpStatus((int)code, exception.Message);
 
                 case HttpRequestException:
-                    return new AIProviderErrorInfo(
-                        AIProviderErrorCategory.NetworkError,
-                        "Couldn't reach the AI service. Check your connection and try again.",
-                        ProviderCode: null,
-                        exception.Message);
+                    return ClassifyTransportFailure(exception);
             }
         }
 
@@ -69,6 +67,91 @@ public static class ProviderErrorMapping
             "An unexpected error occurred talking to the AI service.",
             ProviderCode: null,
             exception.Message);
+    }
+
+    /// <summary>
+    /// Differentiates a connectivity failure - one where the request never reached the server - by
+    /// walking <paramref name="exception"/>'s inner-exception chain for a recognisable transport
+    /// cause (DNS resolution, connection refused/unreachable, TLS handshake). Falls back to a generic
+    /// network message when nothing more specific is recognised.
+    /// </summary>
+    /// <remarks>
+    /// All outcomes stay in <see cref="AIProviderErrorCategory.NetworkError"/> - only the user-facing
+    /// message and <see cref="AIProviderErrorInfo.ProviderCode"/> are differentiated, since every case
+    /// here shares the same retry semantics (check connectivity/config, then try again).
+    /// </remarks>
+    private static AIProviderErrorInfo ClassifyTransportFailure(Exception exception)
+    {
+        for (var current = exception; current is not null; current = current.InnerException)
+        {
+            switch (current)
+            {
+                case AuthenticationException:
+                    return new AIProviderErrorInfo(
+                        AIProviderErrorCategory.NetworkError,
+                        "Secure (TLS/SSL) connection to the AI service failed. Check certificates and the endpoint URL.",
+                        ProviderCode: "tls",
+                        exception.Message);
+
+                case SocketException { SocketErrorCode: SocketError.HostNotFound or SocketError.TryAgain or SocketError.NoData }:
+                    return new AIProviderErrorInfo(
+                        AIProviderErrorCategory.NetworkError,
+                        "Couldn't resolve the AI service address. Check the endpoint/host and your DNS.",
+                        ProviderCode: "dns",
+                        exception.Message);
+
+                case SocketException:
+                    return new AIProviderErrorInfo(
+                        AIProviderErrorCategory.NetworkError,
+                        "Couldn't connect to the AI service. It may be down, unreachable, or blocked by a firewall.",
+                        ProviderCode: "connection",
+                        exception.Message);
+
+                case HttpRequestException { HttpRequestError: HttpRequestError.NameResolutionError }:
+                    return new AIProviderErrorInfo(
+                        AIProviderErrorCategory.NetworkError,
+                        "Couldn't resolve the AI service address. Check the endpoint/host and your DNS.",
+                        ProviderCode: "dns",
+                        exception.Message);
+
+                case HttpRequestException { HttpRequestError: HttpRequestError.SecureConnectionError }:
+                    return new AIProviderErrorInfo(
+                        AIProviderErrorCategory.NetworkError,
+                        "Secure (TLS/SSL) connection to the AI service failed. Check certificates and the endpoint URL.",
+                        ProviderCode: "tls",
+                        exception.Message);
+
+                case HttpRequestException { HttpRequestError: HttpRequestError.ConnectionError }:
+                    return new AIProviderErrorInfo(
+                        AIProviderErrorCategory.NetworkError,
+                        "Couldn't connect to the AI service. It may be down, unreachable, or blocked by a firewall.",
+                        ProviderCode: "connection",
+                        exception.Message);
+            }
+        }
+
+        return new AIProviderErrorInfo(
+            AIProviderErrorCategory.NetworkError,
+            "Couldn't reach the AI service. Check your connection and try again.",
+            ProviderCode: null,
+            exception.Message);
+    }
+
+    /// <summary>
+    /// Whether <paramref name="exception"/>'s inner-exception chain contains a <typeparamref name="T"/>.
+    /// </summary>
+    private static bool HasInner<T>(Exception exception)
+        where T : Exception
+    {
+        for (var current = exception.InnerException; current is not null; current = current.InnerException)
+        {
+            if (current is T)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/AuditLog/AIAuditLogServiceTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/AuditLog/AIAuditLogServiceTests.cs
@@ -1,0 +1,65 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Umbraco.AI.Core.AuditLog;
+using Umbraco.AI.Core.Providers.Errors;
+using Umbraco.AI.Core.TaskQueue;
+
+namespace Umbraco.AI.Tests.Unit.AuditLog;
+
+public class AIAuditLogServiceTests
+{
+    private readonly Mock<IAIAuditLogRepository> _repositoryMock;
+    private readonly AIAuditLogService _service;
+
+    public AIAuditLogServiceTests()
+    {
+        _repositoryMock = new Mock<IAIAuditLogRepository>();
+        _repositoryMock
+            .Setup(x => x.SaveAsync(It.IsAny<AIAuditLog>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AIAuditLog audit, CancellationToken _) => audit);
+
+        var optionsMock = new Mock<IOptionsMonitor<AIAuditLogOptions>>();
+        optionsMock.Setup(x => x.CurrentValue).Returns(new AIAuditLogOptions());
+
+        _service = new AIAuditLogService(
+            _repositoryMock.Object,
+            optionsMock.Object,
+            new Mock<IBackgroundTaskQueue>().Object,
+            NullLoggerFactory.Instance);
+    }
+
+    [Theory]
+    [InlineData(AIProviderErrorCategory.Authentication, AIAuditLogErrorCategory.Authentication)]
+    [InlineData(AIProviderErrorCategory.RateLimited, AIAuditLogErrorCategory.RateLimiting)]
+    [InlineData(AIProviderErrorCategory.NotFound, AIAuditLogErrorCategory.ModelNotFound)]
+    [InlineData(AIProviderErrorCategory.InvalidRequest, AIAuditLogErrorCategory.InvalidRequest)]
+    [InlineData(AIProviderErrorCategory.Transient, AIAuditLogErrorCategory.ServerError)]
+    [InlineData(AIProviderErrorCategory.NetworkError, AIAuditLogErrorCategory.NetworkError)]
+    [InlineData(AIProviderErrorCategory.Cancelled, AIAuditLogErrorCategory.Unknown)]
+    [InlineData(AIProviderErrorCategory.Unknown, AIAuditLogErrorCategory.Unknown)]
+    public async Task RecordAuditLogFailureAsync_WithClassifiedProviderException_ReadsCategoryDirectly(
+        AIProviderErrorCategory providerCategory, AIAuditLogErrorCategory expected)
+    {
+        // A friendly message that intentionally contains none of the substrings the legacy
+        // string-matching fallback looks for, proving the category comes from the exception's
+        // own Category rather than being re-derived from its message text.
+        var exception = new AIProviderException(new AIProviderErrorInfo(
+            providerCategory, "Something specific happened.", ProviderCode: null, RawMessage: "raw"));
+        var audit = new AIAuditLog { Id = Guid.NewGuid() };
+
+        await _service.RecordAuditLogFailureAsync(audit, prompt: null, exception);
+
+        audit.ErrorCategory.ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task RecordAuditLogFailureAsync_WithUnclassifiedException_FallsBackToMessageMatching()
+    {
+        var exception = new InvalidOperationException("Request failed with rate limit exceeded");
+        var audit = new AIAuditLog { Id = Guid.NewGuid() };
+
+        await _service.RecordAuditLogFailureAsync(audit, prompt: null, exception);
+
+        audit.ErrorCategory.ShouldBe(AIAuditLogErrorCategory.RateLimiting);
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Middleware/AIErrorClassifyingChatClientTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Middleware/AIErrorClassifyingChatClientTests.cs
@@ -1,0 +1,113 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+using Umbraco.AI.Core.Chat;
+using Umbraco.AI.Core.Providers.Errors;
+using Umbraco.AI.Tests.Common.Fakes;
+
+namespace Umbraco.AI.Tests.Unit.Middleware;
+
+public class AIErrorClassifyingChatClientTests
+{
+    [Fact]
+    public async Task GetResponseAsync_OnGenericException_ThrowsClassifiedAIProviderException()
+    {
+        var innerClient = new FakeChatClient((_, _, _) =>
+            Task.FromException<ChatResponse>(new InvalidOperationException("boom")));
+        var client = CreateClient(innerClient);
+
+        var thrown = await Should.ThrowAsync<AIProviderException>(
+            () => client.GetResponseAsync([new ChatMessage(ChatRole.User, "hello")]));
+
+        thrown.Category.ShouldBe(AIProviderErrorCategory.Unknown);
+        thrown.InnerException.ShouldBeOfType<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_OnRealCancellation_RethrowsUntouched()
+    {
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var innerClient = new FakeChatClient((_, _, ct) =>
+            Task.FromException<ChatResponse>(new OperationCanceledException(ct)));
+        var client = CreateClient(innerClient);
+
+        await Should.ThrowAsync<OperationCanceledException>(
+            () => client.GetResponseAsync([new ChatMessage(ChatRole.User, "hello")], cancellationToken: cts.Token));
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_OnTimeoutManifestingAsTaskCanceled_ClassifiesAsTransient()
+    {
+        // HttpClient reports its own request timeout as a TaskCanceledException even though the
+        // caller's token was never signalled — this must still be classified, not leaked raw.
+        var innerClient = new FakeChatClient((_, _, _) =>
+            Task.FromException<ChatResponse>(new TaskCanceledException("A task was canceled.", new TimeoutException())));
+        var client = CreateClient(innerClient);
+
+        var thrown = await Should.ThrowAsync<AIProviderException>(
+            () => client.GetResponseAsync([new ChatMessage(ChatRole.User, "hello")], cancellationToken: CancellationToken.None));
+
+        thrown.Category.ShouldBe(AIProviderErrorCategory.Transient);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_OnAlreadyClassifiedException_PassesThroughUnwrapped()
+    {
+        var original = new AIProviderException(new AIProviderErrorInfo(
+            AIProviderErrorCategory.RateLimited, "Rate limit reached.", "429", "raw"));
+        var innerClient = new FakeChatClient((_, _, _) => Task.FromException<ChatResponse>(original));
+        var client = CreateClient(innerClient);
+
+        var thrown = await Should.ThrowAsync<AIProviderException>(
+            () => client.GetResponseAsync([new ChatMessage(ChatRole.User, "hello")]));
+
+        thrown.ShouldBeSameAs(original);
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_OnMidStreamException_ThrowsClassifiedAIProviderException()
+    {
+        var innerClient = new ThrowingStreamingChatClient(new HttpRequestException("connection refused"));
+        var client = CreateClient(innerClient);
+
+        await Should.ThrowAsync<AIProviderException>(async () =>
+        {
+            await foreach (var _ in client.GetStreamingResponseAsync([new ChatMessage(ChatRole.User, "hi")]))
+            {
+            }
+        });
+    }
+
+    private static AIErrorClassifyingChatClient CreateClient(IChatClient innerClient)
+        => new(innerClient, new FakeAIProvider());
+
+    /// <summary>
+    /// Minimal <see cref="IChatClient"/> that throws mid-enumeration, for exercising the manual
+    /// enumerator catch in <see cref="AIErrorClassifyingChatClient.GetStreamingResponseAsync"/>.
+    /// </summary>
+    private sealed class ThrowingStreamingChatClient : IChatClient
+    {
+        private readonly Exception _exception;
+
+        public ThrowingStreamingChatClient(Exception exception) => _exception = exception;
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> chatMessages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+            => Task.FromException<ChatResponse>(_exception);
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> chatMessages, ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            throw _exception;
+#pragma warning disable CS0162
+            yield break;
+#pragma warning restore CS0162
+        }
+
+        public ChatClientMetadata Metadata => new("ThrowingClient", null, null);
+        public object? GetService(Type serviceType, object? key = null) => null;
+        public void Dispose() { }
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Providers/Errors/ProviderErrorMappingTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Providers/Errors/ProviderErrorMappingTests.cs
@@ -2,6 +2,8 @@ using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Net;
 using System.Net.Http;
+using System.Net.Sockets;
+using System.Security.Authentication;
 using Umbraco.AI.Core.Providers.Errors;
 
 namespace Umbraco.AI.Tests.Unit.Providers.Errors;
@@ -34,6 +36,56 @@ public class ProviderErrorMappingTests
         var result = ProviderErrorMapping.FromException(ex);
 
         result.Category.ShouldBe(AIProviderErrorCategory.NetworkError);
+    }
+
+    [Fact]
+    public void FromException_ClientResultException_WithZeroStatus_AndUnrecognisedInner_UsesGenericNetworkMessage()
+    {
+        // No differentiable transport cause in the inner chain - falls back to the original,
+        // still-generic network message rather than guessing.
+        var ex = new ClientResultException("transport failure", response: null, new Exception("boom"));
+
+        var result = ProviderErrorMapping.FromException(ex);
+
+        result.Category.ShouldBe(AIProviderErrorCategory.NetworkError);
+        result.UserMessage.ShouldBe("Couldn't reach the AI service. Check your connection and try again.");
+    }
+
+    [Fact]
+    public void FromException_ClientResultException_WrappingConnectionRefused_DifferentiatesMessage()
+    {
+        var socketEx = new SocketException((int)SocketError.ConnectionRefused);
+        var ex = new ClientResultException("transport failure", response: null, socketEx);
+
+        var result = ProviderErrorMapping.FromException(ex);
+
+        result.Category.ShouldBe(AIProviderErrorCategory.NetworkError);
+        result.ProviderCode.ShouldBe("connection");
+        result.UserMessage.ShouldNotBe("Couldn't reach the AI service. Check your connection and try again.");
+    }
+
+    [Fact]
+    public void FromException_ClientResultException_WrappingHostNotFound_IsDnsMessage()
+    {
+        var socketEx = new SocketException((int)SocketError.HostNotFound);
+        var ex = new ClientResultException("transport failure", response: null, socketEx);
+
+        var result = ProviderErrorMapping.FromException(ex);
+
+        result.Category.ShouldBe(AIProviderErrorCategory.NetworkError);
+        result.ProviderCode.ShouldBe("dns");
+    }
+
+    [Fact]
+    public void FromException_ClientResultException_WrappingAuthenticationFailure_IsTlsMessage()
+    {
+        var authEx = new AuthenticationException("The remote certificate is invalid.");
+        var ex = new ClientResultException("transport failure", response: null, authEx);
+
+        var result = ProviderErrorMapping.FromException(ex);
+
+        result.Category.ShouldBe(AIProviderErrorCategory.NetworkError);
+        result.ProviderCode.ShouldBe("tls");
     }
 
     [Fact]
@@ -93,6 +145,20 @@ public class ProviderErrorMappingTests
     }
 
     [Fact]
+    public void FromException_TaskCanceled_WrappingTimeout_ReturnsTransient()
+    {
+        // HttpClient reports its own request timeout as a TaskCanceledException wrapping a
+        // TimeoutException — this must be classified as a timeout, not a plain cancellation.
+        var timeout = new TimeoutException("The request timed out.");
+        var ex = new TaskCanceledException("A task was canceled.", timeout);
+
+        var result = ProviderErrorMapping.FromException(ex);
+
+        result.Category.ShouldBe(AIProviderErrorCategory.Transient);
+        result.ProviderCode.ShouldBe("timeout");
+    }
+
+    [Fact]
     public void FromException_Timeout_ReturnsTransient()
     {
         var result = ProviderErrorMapping.FromException(new TimeoutException("upstream timeout"));
@@ -124,6 +190,28 @@ public class ProviderErrorMappingTests
         var result = ProviderErrorMapping.FromException(new HttpRequestException("connection refused"));
 
         result.Category.ShouldBe(AIProviderErrorCategory.NetworkError);
+    }
+
+    [Fact]
+    public void FromException_HttpRequestException_WithNameResolutionError_IsDnsMessage()
+    {
+        var ex = new HttpRequestException(HttpRequestError.NameResolutionError, "no such host", inner: null, statusCode: null);
+
+        var result = ProviderErrorMapping.FromException(ex);
+
+        result.Category.ShouldBe(AIProviderErrorCategory.NetworkError);
+        result.ProviderCode.ShouldBe("dns");
+    }
+
+    [Fact]
+    public void FromException_HttpRequestException_WithSecureConnectionError_IsTlsMessage()
+    {
+        var ex = new HttpRequestException(HttpRequestError.SecureConnectionError, "handshake failed", inner: null, statusCode: null);
+
+        var result = ProviderErrorMapping.FromException(ex);
+
+        result.Category.ShouldBe(AIProviderErrorCategory.NetworkError);
+        result.ProviderCode.ShouldBe("tls");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Backport of #243 to `v17/dev`. Fixes #240 — every AI-service failure logged the identical generic message ("Couldn't reach the AI service. Check your connection and try again."), regardless of actual cause. The reporter on #240 is on Umbraco.AI 17.1.0, so this is where they'll actually see the fix.

The `Umbraco.AI.Core` error-classification files were byte-identical between `v17/dev` and `v18/dev` prior to #243, so this is a clean cherry-pick of `2f4d98a1` with no adaptation needed.

- `ProviderErrorMapping.FromException` now walks the inner-exception chain of connectivity failures (`ClientResultException` with `Status == 0`, bare `HttpRequestException`) to differentiate DNS resolution, connection refused/unreachable, and TLS/SSL handshake failures into distinct, more specific messages. Still falls back to the original generic message when nothing more specific is recognised — category stays `NetworkError` throughout, only the message/`ProviderCode` differ.
- `AIErrorClassifyingChatClient` no longer treats every `OperationCanceledException` as an untouched cancellation. A client-side HTTP timeout commonly surfaces as `TaskCanceledException` (an `OperationCanceledException` subtype); it's now only passed through untouched when the caller's own `CancellationToken` was actually signalled, otherwise it's classified.
- `AIAuditLogService.CategorizeError` now reads an `AIProviderException`'s already-classified `Category` directly instead of re-deriving a category by substring-matching its own user-facing message.

## Test plan

- [x] `dotnet build Umbraco.AI.slnx` — 0 errors
- [x] `dotnet test Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Umbraco.AI.Tests.Unit.csproj` — 933/933 passing
- [x] `Umbraco.AI.Anthropic` unit tests (11/11) — unaffected
- [ ] Demo-site end-to-end repro against a real v17 connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)