### PR TITLE
feat(prompt): Enable AI wand on all property editors via value schemas

### DIFF
--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Configuration/UmbracoBuilderExtensions.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Configuration/UmbracoBuilderExtensions.cs
@@ -48,6 +48,9 @@ public static class UmbracoBuilderExtensions
         // Register scope validator
         builder.Services.AddScoped<IAIPromptScopeValidator, AIPromptScopeValidator>();
 
+        // Register property value schema resolver (backs schema-driven generation for non-string editors)
+        builder.Services.AddSingleton<IAIPromptPropertyValueSchemaResolver, AIPromptPropertyValueSchemaResolver>();
+
         // Register service (Singleton to match IAIProfileService pattern and allow use in context resolvers)
         builder.Services.AddSingleton<IAIPromptService, AIPromptService>();
 

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptDynamicResponseSchemas.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptDynamicResponseSchemas.cs
@@ -1,0 +1,75 @@
+using System.Text.Json.Nodes;
+
+namespace Umbraco.AI.Prompt.Core.Prompts;
+
+/// <summary>
+/// Builds runtime JSON Schema response shapes for prompt execution, wrapping a target property's
+/// own value schema (from <see cref="IAIPromptPropertyValueSchemaResolver"/>) so the LLM is
+/// constrained to the exact structure the property editor expects, instead of the fixed
+/// string-only shapes in <see cref="AIPromptResponseSchemas"/>.
+/// </summary>
+/// <remarks>
+/// A wrapper object is necessary because many AI services require that the JSON schema have a
+/// top-level 'type=object' — mirrors the rationale on <see cref="SingleValueResponse"/>.
+/// </remarks>
+internal static class AIPromptDynamicResponseSchemas
+{
+    /// <summary>
+    /// Builds the wrapped response schema for a single-value prompt (OptionCount=1):
+    /// <c>{ "value": &lt;valuePropertySchema&gt; }</c>.
+    /// </summary>
+    public static JsonObject BuildSingleValueSchema(JsonObject valuePropertySchema)
+    {
+        return new JsonObject
+        {
+            ["type"] = "object",
+            ["properties"] = new JsonObject
+            {
+                ["value"] = CloneWithoutSchemaKeyword(valuePropertySchema),
+            },
+            ["required"] = new JsonArray("value"),
+        };
+    }
+
+    /// <summary>
+    /// Builds the wrapped response schema for a multi-option prompt (OptionCount>=2):
+    /// <c>{ "options": [{ "label", "value": &lt;valuePropertySchema&gt;, "description" }] }</c>.
+    /// </summary>
+    public static JsonObject BuildMultiOptionSchema(JsonObject valuePropertySchema)
+    {
+        var optionSchema = new JsonObject
+        {
+            ["type"] = "object",
+            ["properties"] = new JsonObject
+            {
+                ["label"] = new JsonObject { ["type"] = "string" },
+                ["value"] = CloneWithoutSchemaKeyword(valuePropertySchema),
+                ["description"] = new JsonObject { ["type"] = new JsonArray("string", "null") },
+            },
+            ["required"] = new JsonArray("label", "value"),
+        };
+
+        return new JsonObject
+        {
+            ["type"] = "object",
+            ["properties"] = new JsonObject
+            {
+                ["options"] = new JsonObject
+                {
+                    ["type"] = "array",
+                    ["items"] = optionSchema,
+                },
+            },
+            ["required"] = new JsonArray("options"),
+        };
+    }
+
+    // "$schema" is only meaningful at a document root; strip it when nesting the property's own
+    // schema inside a wrapper so it doesn't confuse provider-side schema validation.
+    private static JsonObject CloneWithoutSchemaKeyword(JsonObject schema)
+    {
+        var clone = (JsonObject)schema.DeepClone();
+        clone.Remove("$schema");
+        return clone;
+    }
+}

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptPropertyResolver.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptPropertyResolver.cs
@@ -1,0 +1,39 @@
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.AI.Prompt.Core.Prompts;
+
+/// <summary>
+/// Resolves the <see cref="IPropertyType"/> for a content/media/member/block type alias and property alias.
+/// Shared by <see cref="AIPromptScopeValidator"/> (editor UI alias lookup) and
+/// <see cref="AIPromptPropertyValueSchemaResolver"/> (value schema lookup) so both resolve the
+/// same property type the same way.
+/// </summary>
+internal static class AIPromptPropertyResolver
+{
+    /// <summary>
+    /// Resolves the property type for the given content type alias, entity type, and property alias.
+    /// </summary>
+    public static IPropertyType? ResolvePropertyType(
+        IContentTypeService contentTypeService,
+        IMediaTypeService mediaTypeService,
+        IMemberTypeService memberTypeService,
+        string contentTypeAlias,
+        string entityType,
+        string propertyAlias)
+    {
+        IContentTypeBase? contentType = entityType.ToLowerInvariant() switch
+        {
+            "document" or "block" => contentTypeService.Get(contentTypeAlias),
+            "media" => mediaTypeService.Get(contentTypeAlias),
+            "member" => memberTypeService.Get(contentTypeAlias),
+            _ => contentTypeService.Get(contentTypeAlias), // Default fallback
+        };
+
+        return contentType is IContentTypeComposition compositionContentType
+            ? compositionContentType.CompositionPropertyTypes.FirstOrDefault(
+                pt => pt.Alias.Equals(propertyAlias, StringComparison.OrdinalIgnoreCase))
+            : contentType?.PropertyTypes.FirstOrDefault(
+                pt => pt.Alias.Equals(propertyAlias, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptPropertyValueSchemaResolver.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptPropertyValueSchemaResolver.cs
@@ -1,0 +1,51 @@
+using System.Text.Json.Nodes;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.AI.Prompt.Core.Prompts;
+
+/// <inheritdoc cref="IAIPromptPropertyValueSchemaResolver" />
+internal sealed class AIPromptPropertyValueSchemaResolver : IAIPromptPropertyValueSchemaResolver
+{
+    private readonly IContentTypeService _contentTypeService;
+    private readonly IMediaTypeService _mediaTypeService;
+    private readonly IMemberTypeService _memberTypeService;
+    private readonly IPropertyEditorSchemaService _propertyEditorSchemaService;
+
+    public AIPromptPropertyValueSchemaResolver(
+        IContentTypeService contentTypeService,
+        IMediaTypeService mediaTypeService,
+        IMemberTypeService memberTypeService,
+        IPropertyEditorSchemaService propertyEditorSchemaService)
+    {
+        _contentTypeService = contentTypeService;
+        _mediaTypeService = mediaTypeService;
+        _memberTypeService = memberTypeService;
+        _propertyEditorSchemaService = propertyEditorSchemaService;
+    }
+
+    /// <inheritdoc />
+    public async Task<JsonObject?> ResolveValueSchemaAsync(
+        string contentTypeAlias,
+        string entityType,
+        string propertyAlias,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(contentTypeAlias) || string.IsNullOrEmpty(propertyAlias))
+        {
+            return null;
+        }
+
+        var propertyType = AIPromptPropertyResolver.ResolvePropertyType(
+            _contentTypeService, _mediaTypeService, _memberTypeService,
+            contentTypeAlias, entityType, propertyAlias);
+
+        if (propertyType is null)
+        {
+            return null;
+        }
+
+        var attempt = await _propertyEditorSchemaService.GetSchemaAsync(propertyType.DataTypeKey);
+
+        return attempt.Success ? attempt.Result?.JsonSchema : null;
+    }
+}

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptScopeValidator.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptScopeValidator.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.Logging;
-using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.AI.Prompt.Core.Prompts;
@@ -109,19 +108,9 @@ internal sealed class AIPromptScopeValidator : IAIPromptScopeValidator
         string propertyAlias,
         CancellationToken cancellationToken)
     {
-        IContentTypeBase? contentType = entityType.ToLowerInvariant() switch
-        {
-            "document" or "block" => _contentTypeService.Get(contentTypeAlias),
-            "media" => _mediaTypeService.Get(contentTypeAlias),
-            "member" => _memberTypeService.Get(contentTypeAlias),
-            _ => _contentTypeService.Get(contentTypeAlias), // Default fallback
-        };
-
-        var propertyType = contentType is IContentTypeComposition compositionContentType
-            ? compositionContentType.CompositionPropertyTypes.FirstOrDefault(
-                pt => pt.Alias.Equals(propertyAlias, StringComparison.OrdinalIgnoreCase))
-            : contentType?.PropertyTypes.FirstOrDefault(
-                pt => pt.Alias.Equals(propertyAlias, StringComparison.OrdinalIgnoreCase));
+        var propertyType = AIPromptPropertyResolver.ResolvePropertyType(
+            _contentTypeService, _mediaTypeService, _memberTypeService,
+            contentTypeAlias, entityType, propertyAlias);
 
         if (propertyType is null)
         {

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptService.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptService.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.AI.Core.Chat;
@@ -31,6 +33,7 @@ internal sealed class AIPromptService : IAIPromptService
     private readonly AIRuntimeContextContributorCollection _contextContributors;
     private readonly IBackOfficeSecurityAccessor? _backOfficeSecurityAccessor;
     private readonly IEventAggregator _eventAggregator;
+    private readonly IAIPromptPropertyValueSchemaResolver _propertyValueSchemaResolver;
 
     public AIPromptService(
         IAIPromptRepository repository,
@@ -43,6 +46,7 @@ internal sealed class AIPromptService : IAIPromptService
         IAIRuntimeContextScopeProvider runtimeContextScopeProvider,
         AIRuntimeContextContributorCollection contextContributors,
         IEventAggregator eventAggregator,
+        IAIPromptPropertyValueSchemaResolver propertyValueSchemaResolver,
         IBackOfficeSecurityAccessor? backOfficeSecurityAccessor = null)
     {
         _repository = repository;
@@ -55,6 +59,7 @@ internal sealed class AIPromptService : IAIPromptService
         _runtimeContextScopeProvider = runtimeContextScopeProvider;
         _contextContributors = contextContributors;
         _eventAggregator = eventAggregator;
+        _propertyValueSchemaResolver = propertyValueSchemaResolver;
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
@@ -349,6 +354,18 @@ internal sealed class AIPromptService : IAIPromptService
             }
         }
 
+        // 9. Resolve the target property's own value schema (when its editor exposes one via
+        // IPropertyEditorSchemaService) so generation can be constrained to the exact shape the
+        // property expects (e.g. a ColorPicker's {value,label}) instead of assuming a plain string.
+        // Editors that don't expose a schema fall back to the string-only shapes below.
+        JsonObject? propertyValueSchema = prompt.OptionCount >= 1
+            ? await _propertyValueSchemaResolver.ResolveValueSchemaAsync(
+                request.ContentTypeAlias,
+                request.ElementType ?? request.EntityType,
+                request.PropertyAlias,
+                cancellationToken)
+            : null;
+
         // 10. Execute and build result based on option count.
         // For OptionCount 1 and 2+, use structured output via GetStructuredResponseAsync<T>
         // which delegates to M.E.AI's structured output extensions (schema, ResponseFormat, deserialization).
@@ -374,11 +391,32 @@ internal sealed class AIPromptService : IAIPromptService
                 var response = await _chatService.GetChatResponseAsync(chat =>
                 {
                     ConfigureChat(chat);
-                    chat.WithOutputSchema(AIOutputSchema.FromType<SingleValueResponse>());
+                    chat.WithOutputSchema(propertyValueSchema is not null
+                        ? AIOutputSchema.FromJsonSchema(ToJsonElement(AIPromptDynamicResponseSchemas.BuildSingleValueSchema(propertyValueSchema)))
+                        : AIOutputSchema.FromType<SingleValueResponse>());
                 }, messages, cancellationToken);
                 var responseText = response.Text ?? string.Empty;
 
-                var displayValue = response.TryGetResult<SingleValueResponse>(out var parsed) ? parsed.Value : responseText;
+                object? value;
+                string displayValue;
+                if (propertyValueSchema is not null &&
+                    response.TryGetResult(out JsonElement structuredResult) &&
+                    structuredResult.TryGetProperty("value", out var valueElement))
+                {
+                    value = valueElement;
+                    displayValue = FormatDisplayValue(valueElement);
+                }
+                else if (response.TryGetResult<SingleValueResponse>(out var parsed))
+                {
+                    value = parsed.Value;
+                    displayValue = parsed.Value;
+                }
+                else
+                {
+                    value = responseText;
+                    displayValue = responseText;
+                }
+
                 result = new AIPromptExecutionResult
                 {
                     Content = responseText,
@@ -394,7 +432,7 @@ internal sealed class AIPromptService : IAIPromptService
                             ValueChange = new AIValueChange
                             {
                                 Path = request.PropertyAlias,
-                                Value = displayValue,
+                                Value = value,
                                 Culture = request.Culture,
                                 Segment = request.Segment
                             }
@@ -409,11 +447,27 @@ internal sealed class AIPromptService : IAIPromptService
                 var response = await _chatService.GetChatResponseAsync(chat =>
                 {
                     ConfigureChat(chat);
-                    chat.WithOutputSchema(AIOutputSchema.FromType<MultiOptionResponse>());
+                    chat.WithOutputSchema(propertyValueSchema is not null
+                        ? AIOutputSchema.FromJsonSchema(ToJsonElement(AIPromptDynamicResponseSchemas.BuildMultiOptionSchema(propertyValueSchema)))
+                        : AIOutputSchema.FromType<MultiOptionResponse>());
                 }, messages, cancellationToken);
                 var responseText = response.Text ?? string.Empty;
 
-                if (response.TryGetResult<MultiOptionResponse>(out var parsed) && parsed.Options is { Count: > 0 })
+                var structuredOptions = propertyValueSchema is not null
+                    ? TryParseStructuredMultiOptionResult(response, request)
+                    : null;
+
+                if (structuredOptions is { Count: > 0 })
+                {
+                    result = new AIPromptExecutionResult
+                    {
+                        Content = responseText,
+                        Usage = response.Usage,
+                        Messages = messages,
+                        ResultOptions = structuredOptions
+                    };
+                }
+                else if (response.TryGetResult<MultiOptionResponse>(out var parsed) && parsed.Options is { Count: > 0 })
                 {
                     result = new AIPromptExecutionResult
                     {
@@ -680,5 +734,69 @@ internal sealed class AIPromptService : IAIPromptService
             OutputTokenCount = (usage1.OutputTokenCount ?? 0) + (usage2.OutputTokenCount ?? 0),
             TotalTokenCount = (usage1.TotalTokenCount ?? 0) + (usage2.TotalTokenCount ?? 0)
         };
+    }
+
+    /// <summary>
+    /// Parses a multi-option response constrained to a dynamic property value schema
+    /// (<see cref="AIPromptDynamicResponseSchemas.BuildMultiOptionSchema"/>). Unlike
+    /// <see cref="MultiOptionResponse"/>, each option's value may be any JSON shape, not just a string.
+    /// </summary>
+    private static IReadOnlyList<AIPromptExecutionResult.AIPromptResultOption>? TryParseStructuredMultiOptionResult(
+        ChatResponse response,
+        AIPromptExecutionRequest request)
+    {
+        if (!response.TryGetResult(out JsonElement structuredResult) ||
+            !structuredResult.TryGetProperty("options", out var optionsElement) ||
+            optionsElement.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        var options = new List<AIPromptExecutionResult.AIPromptResultOption>();
+        foreach (var optionElement in optionsElement.EnumerateArray())
+        {
+            if (!optionElement.TryGetProperty("label", out var labelElement) ||
+                !optionElement.TryGetProperty("value", out var valueElement))
+            {
+                continue;
+            }
+
+            var description = optionElement.TryGetProperty("description", out var descriptionElement) &&
+                descriptionElement.ValueKind == JsonValueKind.String
+                    ? descriptionElement.GetString()
+                    : null;
+
+            options.Add(new AIPromptExecutionResult.AIPromptResultOption
+            {
+                Label = labelElement.GetString() ?? "Option",
+                DisplayValue = FormatDisplayValue(valueElement),
+                Description = description,
+                ValueChange = new AIValueChange
+                {
+                    Path = request.PropertyAlias,
+                    Value = valueElement,
+                    Culture = request.Culture,
+                    Segment = request.Segment
+                }
+            });
+        }
+
+        return options;
+    }
+
+    /// <summary>
+    /// Formats a structured value for display — strings render as-is, everything else as compact JSON.
+    /// </summary>
+    private static string FormatDisplayValue(JsonElement value) =>
+        value.ValueKind == JsonValueKind.String ? value.GetString() ?? string.Empty : value.GetRawText();
+
+    /// <summary>
+    /// Converts a <see cref="JsonNode"/>-built schema into a <see cref="JsonElement"/> for
+    /// <see cref="AIOutputSchema.FromJsonSchema"/>, cloning the root so it outlives the source document.
+    /// </summary>
+    private static JsonElement ToJsonElement(JsonNode node)
+    {
+        using var doc = JsonDocument.Parse(node.ToJsonString());
+        return doc.RootElement.Clone();
     }
 }

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/IAIPromptPropertyValueSchemaResolver.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/IAIPromptPropertyValueSchemaResolver.cs
@@ -1,0 +1,29 @@
+using System.Text.Json.Nodes;
+
+namespace Umbraco.AI.Prompt.Core.Prompts;
+
+/// <summary>
+/// Resolves the JSON Schema describing the value a property editor accepts, so prompt execution
+/// can constrain LLM output to the exact shape the target property expects instead of assuming
+/// a plain string.
+/// </summary>
+public interface IAIPromptPropertyValueSchemaResolver
+{
+    /// <summary>
+    /// Resolves the value schema for the property identified by the given content type alias,
+    /// entity type, and property alias.
+    /// </summary>
+    /// <param name="contentTypeAlias">The content/media/member/element type alias.</param>
+    /// <param name="entityType">The entity type (e.g. "document", "media", "member", "block").</param>
+    /// <param name="propertyAlias">The property alias.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The JSON Schema (draft 2020-12) describing the property's value, or <c>null</c> when the
+    /// property can't be resolved or its editor doesn't expose a value schema.
+    /// </returns>
+    Task<JsonObject?> ResolveValueSchemaAsync(
+        string contentTypeAlias,
+        string entityType,
+        string propertyAlias,
+        CancellationToken cancellationToken = default);
+}

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/core/components/property-editor-ui-tags-input/property-editor-ui-tags-input.element.ts
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/core/components/property-editor-ui-tags-input/property-editor-ui-tags-input.element.ts
@@ -1,8 +1,9 @@
 import { css, customElement, html, property } from "@umbraco-cms/backoffice/external/lit";
 import { UmbLitElement } from "@umbraco-cms/backoffice/lit-element";
 import { UmbChangeEvent } from "@umbraco-cms/backoffice/event";
+import { umbExtensionsRegistry } from "@umbraco-cms/backoffice/extension-registry";
+import type { ManifestPropertyEditorUi } from "@umbraco-cms/backoffice/property-editor";
 import "@umbraco-ai/core";
-import { TEXT_BASED_PROPERTY_EDITOR_UIS } from "../../../prompt/property-actions/constants.js";
 
 /**
  * Tag item for lookup results.
@@ -18,8 +19,18 @@ interface TagItem {
 type TagLookupCallback = (query: string) => Promise<TagItem[]>;
 
 /**
- * A tags input component for selecting text-based property editor UI aliases.
- * Wraps uai-tags-input with a restricted lookup that only allows text-based editors.
+ * Gets all registered property editor UIs that back a value-holding property editor
+ * (i.e. have a property editor schema alias — excludes settings-only UIs).
+ */
+function getAvailablePropertyEditorUis(): ManifestPropertyEditorUi[] {
+    return umbExtensionsRegistry
+        .getByType<"propertyEditorUi", ManifestPropertyEditorUi>("propertyEditorUi")
+        .filter((manifest) => !!manifest.meta.propertyEditorSchemaAlias);
+}
+
+/**
+ * A tags input component for selecting property editor UI aliases.
+ * Wraps uai-tags-input with a lookup restricted to registered property editor UIs.
  *
  * @fires change - Fires when tags are added or removed
  */
@@ -30,10 +41,9 @@ export class UaiPropertyEditorUiTagsInputElement extends UmbLitElement {
      */
     @property({ type: Array })
     public set items(value: string[]) {
-        // Filter to only allow valid text-based property editor UIs
-        this.#items = (value ?? []).filter((item) =>
-            TEXT_BASED_PROPERTY_EDITOR_UIS.includes(item as (typeof TEXT_BASED_PROPERTY_EDITOR_UIS)[number]),
-        );
+        // Filter to only allow currently-registered property editor UIs
+        const validAliases = new Set(getAvailablePropertyEditorUis().map((manifest) => manifest.alias));
+        this.#items = (value ?? []).filter((item) => validAliases.has(item));
     }
     public get items(): string[] {
         return this.#items;
@@ -53,52 +63,41 @@ export class UaiPropertyEditorUiTagsInputElement extends UmbLitElement {
     readonly = false;
 
     /**
-     * Lookup callback for fetching text-based property editor UI aliases.
-     * Only returns aliases from the TEXT_BASED_PROPERTY_EDITOR_UIS list.
+     * Lookup callback for fetching registered property editor UI aliases, matched by alias or label.
      */
     #lookup: TagLookupCallback = async (query: string): Promise<TagItem[]> => {
         const lowerQuery = query.toLowerCase();
 
-        return TEXT_BASED_PROPERTY_EDITOR_UIS.filter((alias) => {
-            // Match against full alias or simplified name
-            const simpleName = alias.replace("Umb.PropertyEditorUi.", "");
-            return alias.toLowerCase().includes(lowerQuery) || simpleName.toLowerCase().includes(lowerQuery);
-        })
-            .filter((alias) => !this.#items.includes(alias)) // Exclude already selected
-            .map((alias) => ({
-                id: alias,
-                text: alias.replace("Umb.PropertyEditorUi.", ""), // Show simplified name
-            }));
+        return getAvailablePropertyEditorUis()
+            .filter(
+                (manifest) =>
+                    manifest.alias.toLowerCase().includes(lowerQuery) ||
+                    manifest.meta.label.toLowerCase().includes(lowerQuery),
+            )
+            .filter((manifest) => !this.#items.includes(manifest.alias)) // Exclude already selected
+            .map((manifest) => ({ id: manifest.alias, text: manifest.meta.label }));
     };
 
     #onChange(event: Event) {
         event.stopPropagation();
         const target = event.target as HTMLElement & { items: string[] };
+        const editors = getAvailablePropertyEditorUis();
+        const aliasByLabel = new Map(editors.map((manifest) => [manifest.meta.label, manifest.alias]));
+        const validAliases = new Set(editors.map((manifest) => manifest.alias));
 
-        // Map simplified names back to full aliases and validate
+        // Map display labels back to full aliases and validate
         const newItems = target.items
-            .map((item) => {
-                // If it's already a full alias, use it
-                if (TEXT_BASED_PROPERTY_EDITOR_UIS.includes(item as (typeof TEXT_BASED_PROPERTY_EDITOR_UIS)[number])) {
-                    return item;
-                }
-                // Try to find matching full alias from simplified name
-                const fullAlias = TEXT_BASED_PROPERTY_EDITOR_UIS.find(
-                    (alias) => alias.replace("Umb.PropertyEditorUi.", "") === item,
-                );
-                return fullAlias ?? item;
-            })
-            .filter((item) =>
-                TEXT_BASED_PROPERTY_EDITOR_UIS.includes(item as (typeof TEXT_BASED_PROPERTY_EDITOR_UIS)[number]),
-            );
+            .map((item) => (validAliases.has(item) ? item : aliasByLabel.get(item) ?? item))
+            .filter((item) => validAliases.has(item));
 
         this.#items = newItems;
         this.dispatchEvent(new UmbChangeEvent());
     }
 
     render() {
-        // Display simplified names in the tags
-        const displayItems = this.#items.map((item) => item.replace("Umb.PropertyEditorUi.", ""));
+        // Display friendly labels in the tags
+        const labelByAlias = new Map(getAvailablePropertyEditorUis().map((manifest) => [manifest.alias, manifest.meta.label]));
+        const displayItems = this.#items.map((item) => labelByAlias.get(item) ?? item);
 
         return html`
             <uai-tags-input

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/prompt/property-actions/constants.ts
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/prompt/property-actions/constants.ts
@@ -1,14 +1,4 @@
 /**
- * Property Editor UI aliases for text-based editors that support prompt insertion.
- */
-export const TEXT_BASED_PROPERTY_EDITOR_UIS = [
-    "Umb.PropertyEditorUi.TextBox",
-    "Umb.PropertyEditorUi.TextArea",
-    "Umb.PropertyEditorUi.Tiptap", // Rich Text Editor (replaced TinyMCE in v16+)
-    "Umb.PropertyEditorUi.MarkdownEditor",
-] as const;
-
-/**
  * Alias prefix for dynamically registered prompt property actions.
  */
 export const UAI_PROMPT_PROPERTY_ACTION_PREFIX = "UmbracoAIPrompt.PropertyAction";

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/prompt/property-actions/generate-prompt-property-action-manifest.ts
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/prompt/property-actions/generate-prompt-property-action-manifest.ts
@@ -1,9 +1,7 @@
 import type { ManifestPropertyAction } from "@umbraco-cms/backoffice/property-action";
-import {
-    TEXT_BASED_PROPERTY_EDITOR_UIS,
-    UAI_PROMPT_PROPERTY_ACTION_PREFIX,
-    UAI_PROMPT_SCOPE_CONDITION_ALIAS,
-} from "./constants.js";
+import { umbExtensionsRegistry } from "@umbraco-cms/backoffice/extension-registry";
+import type { ManifestPropertyEditorUi } from "@umbraco-cms/backoffice/property-editor";
+import { UAI_PROMPT_PROPERTY_ACTION_PREFIX, UAI_PROMPT_SCOPE_CONDITION_ALIAS } from "./constants.js";
 import type { UaiPromptRegistrationModel, UaiPromptPropertyActionMeta } from "./types.js";
 import type { UaiPromptScopeConditionConfig } from "./prompt-scope.condition.js";
 
@@ -31,10 +29,14 @@ function getPropertyEditorUisForScope(prompt: UaiPromptRegistrationModel): strin
         }
     }
 
-    // If no specific editors defined, the scope applies to all text-based editors
-    // (filtered further by content type or property alias via the condition)
+    // If no specific editors defined, the scope applies to every registered property editor UI
+    // (filtered further by content type or property alias via the condition). Generation is
+    // constrained per-editor via its value schema (see IPropertyEditorSchemaService), falling
+    // back to plain-string generation for editors that don't expose one.
     if (editorAliases.size === 0) {
-        return [...TEXT_BASED_PROPERTY_EDITOR_UIS];
+        return umbExtensionsRegistry
+            .getByType<"propertyEditorUi", ManifestPropertyEditorUi>("propertyEditorUi")
+            .map((manifest) => manifest.alias);
     }
 
     return Array.from(editorAliases);

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/prompt/repository/detail/prompt-detail.server.data-source.ts
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/prompt/repository/detail/prompt-detail.server.data-source.ts
@@ -5,7 +5,6 @@ import { PromptsService } from "../../../api/index.js";
 import { UaiPromptTypeMapper } from "../../type-mapper.js";
 import type { UaiPromptDetailModel } from "../../types.js";
 import { UAI_PROMPT_ENTITY_TYPE } from "../../constants.js";
-import { TEXT_BASED_PROPERTY_EDITOR_UIS } from "../../property-actions/constants.js";
 import { UAI_EMPTY_GUID } from "@umbraco-ai/core";
 
 /**
@@ -36,7 +35,7 @@ export class UaiPromptDetailServerDataSource implements UmbDetailDataSource<UaiP
             scope: {
                 allowRules: [
                     {
-                        propertyEditorUiAliases: [...TEXT_BASED_PROPERTY_EDITOR_UIS],
+                        propertyEditorUiAliases: null,
                         propertyAliases: null,
                         contentTypeAliases: null,
                     },

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/prompt/workspace/prompt/views/prompt-availability-workspace-view.element.ts
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/prompt/workspace/prompt/views/prompt-availability-workspace-view.element.ts
@@ -4,17 +4,16 @@ import { UmbTextStyles } from "@umbraco-cms/backoffice/style";
 import { UaiPartialUpdateCommand } from "@umbraco-ai/core";
 import type { UaiPromptDetailModel } from "../../../types.js";
 import type { UaiPromptScope, UaiScopeRule } from "../../../property-actions/types.js";
-import { TEXT_BASED_PROPERTY_EDITOR_UIS } from "../../../property-actions/constants.js";
 import { UAI_PROMPT_WORKSPACE_CONTEXT } from "../prompt-workspace.context-token.js";
 
 /**
- * Creates a default scope with one allow rule for all text-based editors.
+ * Creates a default scope with one allow rule matching every property editor.
  */
 function createDefaultScope(): UaiPromptScope {
     return {
         allowRules: [
             {
-                propertyEditorUiAliases: [...TEXT_BASED_PROPERTY_EDITOR_UIS],
+                propertyEditorUiAliases: null,
                 propertyAliases: null,
                 contentTypeAliases: null,
             },

--- a/Umbraco.AI.Prompt/tests/Umbraco.AI.Prompt.Tests.Unit/Prompts/AIPromptDynamicResponseSchemasTests.cs
+++ b/Umbraco.AI.Prompt/tests/Umbraco.AI.Prompt.Tests.Unit/Prompts/AIPromptDynamicResponseSchemasTests.cs
@@ -1,0 +1,60 @@
+using System.Text.Json.Nodes;
+using Shouldly;
+using Umbraco.AI.Prompt.Core.Prompts;
+using Xunit;
+
+namespace Umbraco.AI.Prompt.Tests.Unit.Prompts;
+
+public class AIPromptDynamicResponseSchemasTests
+{
+    private static JsonObject ColorPickerValueSchema() => new()
+    {
+        ["$schema"] = "https://json-schema.org/draft/2020-12/schema",
+        ["type"] = new JsonArray("object", "null"),
+        ["properties"] = new JsonObject
+        {
+            ["value"] = new JsonObject { ["type"] = new JsonArray("string", "null") },
+            ["label"] = new JsonObject { ["type"] = new JsonArray("string", "null") },
+        },
+    };
+
+    [Fact]
+    public void BuildSingleValueSchema_WrapsPropertySchemaUnderValue()
+    {
+        var wrapped = AIPromptDynamicResponseSchemas.BuildSingleValueSchema(ColorPickerValueSchema());
+
+        wrapped["type"]!.GetValue<string>().ShouldBe("object");
+        wrapped["required"]!.AsArray().Select(n => n!.GetValue<string>()).ShouldBe(["value"]);
+        var value = wrapped["properties"]!["value"]!.AsObject();
+        value["properties"]!["label"].ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void BuildSingleValueSchema_StripsSchemaKeywordFromNestedPropertySchema()
+    {
+        var wrapped = AIPromptDynamicResponseSchemas.BuildSingleValueSchema(ColorPickerValueSchema());
+
+        wrapped["properties"]!["value"]!.AsObject().ContainsKey("$schema").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void BuildSingleValueSchema_DoesNotMutateSourceSchema()
+    {
+        var source = ColorPickerValueSchema();
+
+        AIPromptDynamicResponseSchemas.BuildSingleValueSchema(source);
+
+        source.ContainsKey("$schema").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void BuildMultiOptionSchema_WrapsPropertySchemaUnderOptionsValue()
+    {
+        var wrapped = AIPromptDynamicResponseSchemas.BuildMultiOptionSchema(ColorPickerValueSchema());
+
+        wrapped["required"]!.AsArray().Select(n => n!.GetValue<string>()).ShouldBe(["options"]);
+        var optionSchema = wrapped["properties"]!["options"]!["items"]!.AsObject();
+        optionSchema["required"]!.AsArray().Select(n => n!.GetValue<string>()).ShouldBe(["label", "value"]);
+        optionSchema["properties"]!["value"]!.AsObject().ContainsKey("$schema").ShouldBeFalse();
+    }
+}

--- a/Umbraco.AI.Prompt/tests/Umbraco.AI.Prompt.Tests.Unit/Prompts/AIPromptPropertyValueSchemaResolverTests.cs
+++ b/Umbraco.AI.Prompt/tests/Umbraco.AI.Prompt.Tests.Unit/Prompts/AIPromptPropertyValueSchemaResolverTests.cs
@@ -1,0 +1,138 @@
+using System.Text.Json.Nodes;
+using Moq;
+using Shouldly;
+using Umbraco.AI.Prompt.Core.Prompts;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Xunit;
+
+namespace Umbraco.AI.Prompt.Tests.Unit.Prompts;
+
+public class AIPromptPropertyValueSchemaResolverTests
+{
+    private readonly Mock<IContentTypeService> _mockContentTypeService = new();
+    private readonly Mock<IMediaTypeService> _mockMediaTypeService = new();
+    private readonly Mock<IMemberTypeService> _mockMemberTypeService = new();
+    private readonly Mock<IPropertyEditorSchemaService> _mockPropertyEditorSchemaService = new();
+    private readonly AIPromptPropertyValueSchemaResolver _resolver;
+
+    public AIPromptPropertyValueSchemaResolverTests()
+    {
+        _resolver = new AIPromptPropertyValueSchemaResolver(
+            _mockContentTypeService.Object,
+            _mockMediaTypeService.Object,
+            _mockMemberTypeService.Object,
+            _mockPropertyEditorSchemaService.Object);
+    }
+
+    private static Mock<IPropertyType> CreatePropertyType(string alias, Guid dataTypeKey)
+    {
+        var propertyType = new Mock<IPropertyType>();
+        propertyType.SetupGet(p => p.Alias).Returns(alias);
+        propertyType.SetupGet(p => p.DataTypeKey).Returns(dataTypeKey);
+        return propertyType;
+    }
+
+    [Fact]
+    public async Task ResolveValueSchemaAsync_DocumentPropertyWithSchema_ReturnsJsonSchema()
+    {
+        var dataTypeKey = Guid.NewGuid();
+        var propertyType = CreatePropertyType("colour", dataTypeKey);
+
+        var contentType = new Mock<IContentType>();
+        contentType.SetupGet(c => c.CompositionPropertyTypes).Returns([propertyType.Object]);
+        _mockContentTypeService.Setup(s => s.Get("page")).Returns(contentType.Object);
+
+        var schema = new JsonObject { ["type"] = "object" };
+        _mockPropertyEditorSchemaService
+            .Setup(s => s.GetSchemaAsync(dataTypeKey))
+            .ReturnsAsync(Attempt.SucceedWithStatus(
+                PropertyEditorSchemaOperationStatus.Success,
+                new PropertyValueSchema(typeof(JsonObject), schema)));
+
+        var result = await _resolver.ResolveValueSchemaAsync("page", "document", "colour");
+
+        result.ShouldBe(schema);
+    }
+
+    [Fact]
+    public async Task ResolveValueSchemaAsync_MediaEntityType_QueriesMediaTypeService()
+    {
+        var dataTypeKey = Guid.NewGuid();
+        var propertyType = CreatePropertyType("colour", dataTypeKey);
+
+        var mediaType = new Mock<IMediaType>();
+        mediaType.SetupGet(c => c.CompositionPropertyTypes).Returns([propertyType.Object]);
+        _mockMediaTypeService.Setup(s => s.Get("image")).Returns(mediaType.Object);
+
+        var schema = new JsonObject { ["type"] = "string" };
+        _mockPropertyEditorSchemaService
+            .Setup(s => s.GetSchemaAsync(dataTypeKey))
+            .ReturnsAsync(Attempt.SucceedWithStatus(
+                PropertyEditorSchemaOperationStatus.Success,
+                new PropertyValueSchema(typeof(string), schema)));
+
+        var result = await _resolver.ResolveValueSchemaAsync("image", "media", "colour");
+
+        result.ShouldBe(schema);
+        _mockContentTypeService.Verify(s => s.Get(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveValueSchemaAsync_PropertyNotFoundOnContentType_ReturnsNull()
+    {
+        var contentType = new Mock<IContentType>();
+        contentType.SetupGet(c => c.CompositionPropertyTypes).Returns([]);
+        _mockContentTypeService.Setup(s => s.Get("page")).Returns(contentType.Object);
+
+        var result = await _resolver.ResolveValueSchemaAsync("page", "document", "missing");
+
+        result.ShouldBeNull();
+        _mockPropertyEditorSchemaService.Verify(
+            s => s.GetSchemaAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveValueSchemaAsync_ContentTypeNotFound_ReturnsNull()
+    {
+        _mockContentTypeService.Setup(s => s.Get("page")).Returns((IContentType?)null);
+
+        var result = await _resolver.ResolveValueSchemaAsync("page", "document", "colour");
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ResolveValueSchemaAsync_EditorDoesNotSupportSchema_ReturnsNull()
+    {
+        var dataTypeKey = Guid.NewGuid();
+        var propertyType = CreatePropertyType("colour", dataTypeKey);
+
+        var contentType = new Mock<IContentType>();
+        contentType.SetupGet(c => c.CompositionPropertyTypes).Returns([propertyType.Object]);
+        _mockContentTypeService.Setup(s => s.Get("page")).Returns(contentType.Object);
+
+        _mockPropertyEditorSchemaService
+            .Setup(s => s.GetSchemaAsync(dataTypeKey))
+            .ReturnsAsync(Attempt.FailWithStatus(
+                PropertyEditorSchemaOperationStatus.SchemaNotSupported,
+                new PropertyValueSchema(null, null)));
+
+        var result = await _resolver.ResolveValueSchemaAsync("page", "document", "colour");
+
+        result.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public async Task ResolveValueSchemaAsync_MissingContentTypeAlias_ReturnsNullWithoutQuerying(string? alias)
+    {
+        var result = await _resolver.ResolveValueSchemaAsync(alias!, "document", "colour");
+
+        result.ShouldBeNull();
+        _mockContentTypeService.Verify(s => s.Get(It.IsAny<string>()), Times.Never);
+    }
+}


### PR DESCRIPTION
## Summary

Backport of #245 to v17.

- Removes the hard-coded `TEXT_BASED_PROPERTY_EDITOR_UIS` allowlist that excluded ColorPicker and every other non-string property editor from the AI Prompt "Insert Prompt" wand.
- The wand now targets any registered property editor UI. Generation is constrained to the target property's own value schema (via `IPropertyEditorSchemaService`, introduced in CMS 17.4.0 — v17/dev already floors at `[17.4.0, ...)`) when the editor exposes one, falling back to plain-string generation for editors that don't.
- Adds `AIPromptPropertyValueSchemaResolver` + `AIPromptDynamicResponseSchemas` to resolve and wrap a property's schema for single/multi-option prompt execution, and extracts the shared content-type/property-type resolution (`AIPromptPropertyResolver`) so the scope validator and the new resolver don't duplicate it.
- Frontend: the scope-rule editor picker now offers every registered property editor UI instead of the 4 text-based ones; unrestricted scope now means "matches everything" rather than defaulting to the old text-only list.

Fixes #239.

## Test plan
- [x] Cherry-picked cleanly from `v18/feature/prompt-schema-driven-wand` (628dc1c6), no conflicts
- [x] `dotnet build Umbraco.AI.Prompt/Umbraco.AI.Prompt.slnx` — clean
- [x] `dotnet test Umbraco.AI.Prompt/Umbraco.AI.Prompt.slnx` — 71 passing (11 new)
- [x] `npm run build:core && npm run build:prompt` — clean typecheck + build
- [x] Full manual demo-site verification (EyeDropper + standard ColorPicker) already done on the v18 PR (#245) against the identical CMS API surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)