### PR TITLE
fix(copilot): stage invariant/shared properties with null culture (PropertyTypeCultureVarianceMismatch)

### DIFF
--- a/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/package.json
+++ b/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/package.json
@@ -11,7 +11,8 @@
         "watch": "tsc && vite build --watch",
         "build": "npm run build:api && npm run build:app",
         "build:app": "tsc -p tsconfig.json && vite build",
-        "build:api": "tsc -p tsconfig.api.json && (api-extractor run -c api-extractor.json --verbose || exit 0)"
+        "build:api": "tsc -p tsconfig.api.json && (api-extractor run -c api-extractor.json --verbose || exit 0)",
+        "test": "vitest run"
     },
     "dependencies": {
         "@umbraco-ai/agent": "*",
@@ -21,7 +22,9 @@
     },
     "devDependencies": {
         "@microsoft/api-extractor": "^7.55.1",
+        "happy-dom": "^20.10.6",
         "typescript": "^5.9.2",
-        "vite": "^8.0.16"
+        "vite": "^8.0.16",
+        "vitest": "^4.1.10"
     }
 }

--- a/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/copilot/tools/entity/internal/property-value-tool-base.test.ts
+++ b/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/copilot/tools/entity/internal/property-value-tool-base.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { normalizeVariantForProperty } from "./property-value-tool-base.js";
+
+describe("normalizeVariantForProperty", () => {
+    const active = { culture: "pt-PT", segment: null };
+
+    it("nulls culture/segment for an invariant property (the bug this fixes)", () => {
+        expect(normalizeVariantForProperty(active, false, false)).toEqual({
+            culture: null,
+            segment: null,
+        });
+    });
+
+    it("keeps the culture for a culture-variant property", () => {
+        expect(normalizeVariantForProperty(active, true, false)).toEqual({
+            culture: "pt-PT",
+            segment: null,
+        });
+    });
+
+    it("keeps the segment (and nulls culture) for a segment-only property", () => {
+        expect(
+            normalizeVariantForProperty({ culture: "pt-PT", segment: "seg-1" }, false, true),
+        ).toEqual({ culture: null, segment: "seg-1" });
+    });
+
+    it("keeps both for a culture+segment property", () => {
+        expect(
+            normalizeVariantForProperty({ culture: "pt-PT", segment: "seg-1" }, true, true),
+        ).toEqual({ culture: "pt-PT", segment: "seg-1" });
+    });
+
+    it("returns nulls for an invariant property when no variant is supplied", () => {
+        expect(normalizeVariantForProperty(undefined, false, false)).toEqual({
+            culture: null,
+            segment: null,
+        });
+    });
+});

--- a/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/copilot/tools/entity/internal/property-value-tool-base.ts
+++ b/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/copilot/tools/entity/internal/property-value-tool-base.ts
@@ -37,6 +37,30 @@ interface WorkspaceContextLike {
             | undefined;
     };
     variants?: unknown;
+    // Content/media/block workspaces expose a structure manager that knows each property's
+    // variance. Used to avoid staging an invariant property under a culture/segment.
+    structure?: {
+        getPropertyStructureByAlias?: (
+            alias: string,
+        ) => Promise<{ variesByCulture?: boolean; variesBySegment?: boolean } | undefined>;
+    };
+}
+
+/**
+ * Normalises a staged variant against a property's variance. An invariant property must be staged
+ * with `culture`/`segment` of `null`; otherwise the save is rejected by the Management API with
+ * `PropertyTypeCultureVarianceMismatch`. Genuinely variant properties keep their culture/segment.
+ * Exported for unit testing.
+ */
+export function normalizeVariantForProperty(
+    variant: VariantId | undefined,
+    variesByCulture: boolean,
+    variesBySegment: boolean,
+): VariantId {
+    return {
+        culture: variesByCulture ? (variant?.culture ?? null) : null,
+        segment: variesBySegment ? (variant?.segment ?? null) : null,
+    };
 }
 
 /**
@@ -119,18 +143,60 @@ export abstract class PropertyValueOperationToolBase
 
         const variantHint = built.variant ?? this.#resolveActiveVariant(workspace);
 
+        // Normalise the variant against the ROOT property's variance. Falling back to the active
+        // variant (above) tags EVERY value with the active culture/segment — but an invariant
+        // (shared) property must be staged with culture/segment = null, or the save fails with
+        // PropertyTypeCultureVarianceMismatch. Genuinely variant properties keep their variant.
+        let rootPropertyType: { variesByCulture?: boolean; variesBySegment?: boolean } | undefined;
+        try {
+            rootPropertyType = await workspace.structure?.getPropertyStructureByAlias?.(rootProperty);
+        } catch (error) {
+            // Keep execute()'s convention: every failure path returns a structured error to the agent.
+            return JSON.stringify({
+                success: false,
+                error: {
+                    code: "property-variance-unresolved",
+                    message:
+                        `Failed to resolve the variance of property '${rootProperty}' from the workspace ` +
+                        `structure: ${error instanceof Error ? error.message : String(error)}. Refusing to ` +
+                        `stage the value to avoid a culture variance mismatch on save.`,
+                },
+            });
+        }
+        if (!rootPropertyType) {
+            // Do NOT silently fall back to the active variant: if the property is actually invariant,
+            // staging it under a culture reintroduces the PropertyTypeCultureVarianceMismatch this
+            // guards against. Fail deterministically instead so the miss is visible, not intermittent.
+            return JSON.stringify({
+                success: false,
+                error: {
+                    code: "property-variance-unresolved",
+                    message:
+                        `Could not resolve the variance of property '${rootProperty}' from the workspace ` +
+                        `structure. Refusing to stage the value, because staging under the wrong culture/segment ` +
+                        `would fail on save with a culture variance mismatch. Verify the property exists on the ` +
+                        `content type.`,
+                },
+            });
+        }
+        const variant = normalizeVariantForProperty(
+            variantHint,
+            rootPropertyType.variesByCulture ?? false,
+            rootPropertyType.variesBySegment ?? false,
+        );
+
         // The workspace's getValues() only lists properties with staged values; properties the
         // user hasn't touched are absent. The dispatcher canonicalises root editor alias resolution
         // server-side from documentMetadata.contentTypeKey + path[0], so we only need to send the
         // staged root value (or undefined for never-touched properties).
-        const rootEntry = this.#findValueEntry(values, rootProperty, variantHint);
+        const rootEntry = this.#findValueEntry(values, rootProperty, variant);
         const rootValue = rootEntry?.value;
 
         const documentMetadata: DocumentMetadata = {
             contentTypeKey: workspace.getContentTypeUnique?.() ?? "",
             variants: this.#resolveVariants(workspace),
-            isVariant: variantHint?.culture != null,
-            isSegmented: variantHint?.segment != null,
+            isVariant: variant?.culture != null,
+            isSegmented: variant?.segment != null,
             name: workspace.getName?.(),
         };
 
@@ -150,8 +216,8 @@ export abstract class PropertyValueOperationToolBase
         const applyResult = await adapterContext.applyValueChange({
             path: rootProperty,
             value: response.newRootValue,
-            culture: variantHint?.culture ?? undefined,
-            segment: variantHint?.segment ?? undefined,
+            culture: variant?.culture ?? undefined,
+            segment: variant?.segment ?? undefined,
         });
 
         if (!applyResult.success) {

--- a/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/copilot/tools/entity/internal/property-value-tool-base.ts
+++ b/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/copilot/tools/entity/internal/property-value-tool-base.ts
@@ -9,6 +9,9 @@ import {
     type PropertyValueOperationResponse,
     type VariantId,
 } from "./property-value-operation.client.js";
+import { normalizeVariantForProperty } from "./variant-normalization.js";
+
+export { normalizeVariantForProperty } from "./variant-normalization.js";
 
 /**
  * Loose structural shape of a workspace context's `getValues()` entry. Both document and block
@@ -43,23 +46,6 @@ interface WorkspaceContextLike {
         getPropertyStructureByAlias?: (
             alias: string,
         ) => Promise<{ variesByCulture?: boolean; variesBySegment?: boolean } | undefined>;
-    };
-}
-
-/**
- * Normalises a staged variant against a property's variance. An invariant property must be staged
- * with `culture`/`segment` of `null`; otherwise the save is rejected by the Management API with
- * `PropertyTypeCultureVarianceMismatch`. Genuinely variant properties keep their culture/segment.
- * Exported for unit testing.
- */
-export function normalizeVariantForProperty(
-    variant: VariantId | undefined,
-    variesByCulture: boolean,
-    variesBySegment: boolean,
-): VariantId {
-    return {
-        culture: variesByCulture ? (variant?.culture ?? null) : null,
-        segment: variesBySegment ? (variant?.segment ?? null) : null,
     };
 }
 

--- a/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/copilot/tools/entity/internal/variant-normalization.test.ts
+++ b/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/copilot/tools/entity/internal/variant-normalization.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { normalizeVariantForProperty } from "./property-value-tool-base.js";
+import { normalizeVariantForProperty } from "./variant-normalization.js";
 
 describe("normalizeVariantForProperty", () => {
     const active = { culture: "pt-PT", segment: null };

--- a/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/copilot/tools/entity/internal/variant-normalization.ts
+++ b/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/copilot/tools/entity/internal/variant-normalization.ts
@@ -1,0 +1,19 @@
+import type { VariantId } from "./property-value-operation.client.js";
+
+/**
+ * Normalises a staged variant against a property's variance. An invariant property must be staged
+ * with `culture`/`segment` of `null`; otherwise the save is rejected by the Management API with
+ * `PropertyTypeCultureVarianceMismatch`. Genuinely variant properties keep their culture/segment.
+ *
+ * Kept in its own module (no CMS/runtime imports) so it stays trivially unit-testable.
+ */
+export function normalizeVariantForProperty(
+    variant: VariantId | undefined,
+    variesByCulture: boolean,
+    variesBySegment: boolean,
+): VariantId {
+    return {
+        culture: variesByCulture ? (variant?.culture ?? null) : null,
+        segment: variesBySegment ? (variant?.segment ?? null) : null,
+    };
+}

--- a/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/tsconfig.json
+++ b/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/tsconfig.json
@@ -22,5 +22,6 @@
 
         "types": ["@umbraco-cms/backoffice/extension-types"]
     },
-    "include": ["src"]
+    "include": ["src"],
+    "exclude": ["src/**/*.test.ts"]
 }

--- a/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/vitest.config.ts
+++ b/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        environment: "happy-dom",
+        include: ["src/**/*.test.ts"],
+    },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -339,21 +339,21 @@
             }
         },
         "node_modules/@emnapi/core": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/wasi-threads": "1.2.1",
+                "@emnapi/wasi-threads": "1.2.2",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -362,9 +362,9 @@
             }
         },
         "node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -510,6 +510,13 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/@hey-api/types/-/types-0.1.4.tgz",
             "integrity": "sha512-thWfawrDIP7wSI9ioT13I5soaaqB5vAPIiZmgD8PbeEVKNrkonc0N/Sjj97ezl7oQgusZmaNphGdMKipPO6IBg==",
+            "license": "MIT"
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@jsdevtools/ono": {
@@ -661,14 +668,14 @@
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-            "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+            "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@tybys/wasm-util": "^0.10.2"
+                "@tybys/wasm-util": "^0.10.3"
             },
             "funding": {
                 "type": "github",
@@ -680,9 +687,9 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.133.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-            "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+            "version": "0.139.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+            "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -699,9 +706,9 @@
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
-            "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+            "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
             "cpu": [
                 "arm64"
             ],
@@ -716,9 +723,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
-            "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+            "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
             "cpu": [
                 "arm64"
             ],
@@ -733,9 +740,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-            "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+            "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
             "cpu": [
                 "x64"
             ],
@@ -750,9 +757,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
-            "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+            "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
             "cpu": [
                 "x64"
             ],
@@ -767,9 +774,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
-            "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+            "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
             "cpu": [
                 "arm"
             ],
@@ -784,13 +791,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
-            "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+            "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -801,13 +811,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
-            "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+            "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -818,13 +831,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
-            "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+            "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -835,13 +851,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
-            "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+            "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -852,13 +871,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
-            "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+            "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -869,13 +891,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
-            "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+            "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -886,9 +911,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
-            "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+            "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
             "cpu": [
                 "arm64"
             ],
@@ -903,9 +928,9 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
-            "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+            "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
             "cpu": [
                 "wasm32"
             ],
@@ -913,18 +938,18 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "1.10.0",
-                "@emnapi/runtime": "1.10.0",
-                "@napi-rs/wasm-runtime": "^1.1.4"
+                "@emnapi/core": "1.11.1",
+                "@emnapi/runtime": "1.11.1",
+                "@napi-rs/wasm-runtime": "^1.1.6"
             },
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
-            "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+            "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
             "cpu": [
                 "arm64"
             ],
@@ -939,9 +964,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-            "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+            "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
             "cpu": [
                 "x64"
             ],
@@ -1104,6 +1129,13 @@
             "funding": {
                 "url": "https://ko-fi.com/dangreen"
             }
+        },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@tiptap/core": {
             "version": "3.22.5",
@@ -1585,9 +1617,9 @@
             }
         },
         "node_modules/@tybys/wasm-util": {
-            "version": "0.10.2",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -1602,12 +1634,37 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/diff": {
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
             "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
@@ -1621,7 +1678,6 @@
             "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~7.19.0"
             }
@@ -1644,6 +1700,23 @@
             "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
             "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
             "license": "MIT"
+        },
+        "node_modules/@types/whatwg-mimetype": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+            "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/ws": {
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@umbraco-ai/agent": {
             "resolved": "Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Client",
@@ -1713,6 +1786,119 @@
             "engines": {
                 "node": ">=24.13",
                 "npm": ">=11"
+            }
+        },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+            "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+            "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.10",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+            "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+            "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.10",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+            "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+            "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+            "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/abort-controller": {
@@ -1830,6 +2016,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/balanced-match": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -1851,6 +2047,19 @@
             },
             "engines": {
                 "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/buffer-image-size": {
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+            "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            },
+            "engines": {
+                "node": ">=4.0"
             }
         },
         "node_modules/bundle-name": {
@@ -1904,6 +2113,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/chalk": {
@@ -2295,6 +2514,13 @@
                 "node": ">=18"
             }
         },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/cosmiconfig": {
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
@@ -2511,6 +2737,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/entities": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+            "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
         "node_modules/env-paths": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -2541,6 +2780,13 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/es-module-lexer": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/es-toolkit": {
             "version": "1.46.1",
             "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
@@ -2562,6 +2808,16 @@
                 "node": ">=6"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
         "node_modules/event-target-shim": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -2578,6 +2834,16 @@
             "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
             "license": "MIT",
             "peer": true,
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+            "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+            "dev": true,
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=12.0.0"
             }
@@ -2801,6 +3067,47 @@
             },
             "optionalDependencies": {
                 "uglify-js": "^3.1.4"
+            }
+        },
+        "node_modules/happy-dom": {
+            "version": "20.10.6",
+            "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
+            "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": ">=20.0.0",
+                "@types/whatwg-mimetype": "^3.0.2",
+                "@types/ws": "^8.18.1",
+                "buffer-image-size": "^0.6.4",
+                "entities": "^7.0.1",
+                "whatwg-mimetype": "^3.0.0",
+                "ws": "^8.21.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/happy-dom/node_modules/ws": {
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "node_modules/has-flag": {
@@ -3422,6 +3729,16 @@
                 "node": ">=12"
             }
         },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
         "node_modules/marked": {
             "version": "18.0.5",
             "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
@@ -3499,9 +3816,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.12",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "dev": true,
             "funding": [
                 {
@@ -3558,6 +3875,20 @@
             },
             "engines": {
                 "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/obug": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+            "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20.0"
             }
         },
         "node_modules/ohash": {
@@ -3661,9 +3992,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3682,6 +4013,35 @@
                 "confbox": "^0.2.4",
                 "exsolve": "^1.0.8",
                 "pathe": "^2.0.3"
+            }
+        },
+        "node_modules/postcss": {
+            "version": "8.5.19",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+            "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.12",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
             }
         },
         "node_modules/powershell-utils": {
@@ -3975,13 +4335,13 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
-            "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+            "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.133.0",
+                "@oxc-project/types": "=0.139.0",
                 "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
@@ -3991,21 +4351,21 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.3",
-                "@rolldown/binding-darwin-arm64": "1.0.3",
-                "@rolldown/binding-darwin-x64": "1.0.3",
-                "@rolldown/binding-freebsd-x64": "1.0.3",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.3",
-                "@rolldown/binding-linux-arm64-musl": "1.0.3",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.3",
-                "@rolldown/binding-linux-x64-gnu": "1.0.3",
-                "@rolldown/binding-linux-x64-musl": "1.0.3",
-                "@rolldown/binding-openharmony-arm64": "1.0.3",
-                "@rolldown/binding-wasm32-wasi": "1.0.3",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.3",
-                "@rolldown/binding-win32-x64-msvc": "1.0.3"
+                "@rolldown/binding-android-arm64": "1.1.5",
+                "@rolldown/binding-darwin-arm64": "1.1.5",
+                "@rolldown/binding-darwin-x64": "1.1.5",
+                "@rolldown/binding-freebsd-x64": "1.1.5",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+                "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+                "@rolldown/binding-linux-arm64-musl": "1.1.5",
+                "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+                "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-musl": "1.1.5",
+                "@rolldown/binding-openharmony-arm64": "1.1.5",
+                "@rolldown/binding-wasm32-wasi": "1.1.5",
+                "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+                "@rolldown/binding-win32-x64-msvc": "1.1.5"
             }
         },
         "node_modules/rope-sequence": {
@@ -4089,6 +4449,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4151,6 +4518,20 @@
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
             "dev": true,
             "license": "BSD-3-Clause"
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/string-argv": {
             "version": "0.3.2",
@@ -4219,6 +4600,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tinyexec": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
@@ -4227,6 +4615,33 @@
             "license": "MIT",
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/tough-cookie": {
@@ -4311,8 +4726,7 @@
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
             "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/universalify": {
             "version": "2.0.1",
@@ -4366,6 +4780,174 @@
                 "spdx-expression-parse": "^3.0.0"
             }
         },
+        "node_modules/vite": {
+            "version": "8.1.4",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+            "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.5",
+                "postcss": "^8.5.16",
+                "rolldown": "~1.1.4",
+                "tinyglobby": "^0.2.17"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.3.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitest": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+            "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.10",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/runner": "4.1.10",
+                "@vitest/snapshot": "4.1.10",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.10",
+                "@vitest/browser-preview": "4.1.10",
+                "@vitest/browser-webdriverio": "4.1.10",
+                "@vitest/coverage-istanbul": "4.1.10",
+                "@vitest/coverage-v8": "4.1.10",
+                "@vitest/ui": "4.1.10",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
         "node_modules/w3c-keyname": {
             "version": "2.2.8",
             "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -4389,6 +4971,16 @@
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
             "license": "BSD-2-Clause",
             "peer": true
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+            "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/whatwg-url": {
             "version": "5.0.0",
@@ -4414,6 +5006,23 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/wordwrap": {
@@ -4538,54 +5147,10 @@
             },
             "devDependencies": {
                 "@microsoft/api-extractor": "^7.55.1",
+                "happy-dom": "^20.10.6",
                 "typescript": "^5.9.2",
-                "vite": "^8.0.16"
-            }
-        },
-        "Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/node_modules/postcss": {
-            "version": "8.5.15",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "nanoid": "^3.3.12",
-                "picocolors": "^1.1.1",
-                "source-map-js": "^1.2.1"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
-            }
-        },
-        "Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/node_modules/tinyglobby": {
-            "version": "0.2.17",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
+                "vite": "^8.0.16",
+                "vitest": "^4.1.10"
             }
         },
         "Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/node_modules/typescript": {
@@ -4598,84 +5163,6 @@
             },
             "engines": {
                 "node": ">=14.17"
-            }
-        },
-        "Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/node_modules/vite": {
-            "version": "8.0.16",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-            "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "lightningcss": "^1.32.0",
-                "picomatch": "^4.0.4",
-                "postcss": "^8.5.15",
-                "rolldown": "1.0.3",
-                "tinyglobby": "^0.2.17"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.1.18",
-                "esbuild": "^0.27.0 || ^0.28.0",
-                "jiti": ">=1.21.0",
-                "less": "^4.0.0",
-                "sass": "^1.70.0",
-                "sass-embedded": "^1.70.0",
-                "stylus": ">=0.54.8",
-                "sugarss": "^5.0.0",
-                "terser": "^5.16.0",
-                "tsx": "^4.8.1",
-                "yaml": "^2.4.2"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "@vitejs/devtools": {
-                    "optional": true
-                },
-                "esbuild": {
-                    "optional": true
-                },
-                "jiti": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                },
-                "tsx": {
-                    "optional": true
-                },
-                "yaml": {
-                    "optional": true
-                }
             }
         },
         "Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client": {
@@ -4694,52 +5181,6 @@
                 "vite": "^8.0.16"
             }
         },
-        "Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/node_modules/postcss": {
-            "version": "8.5.15",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "nanoid": "^3.3.12",
-                "picocolors": "^1.1.1",
-                "source-map-js": "^1.2.1"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
-            }
-        },
-        "Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/node_modules/tinyglobby": {
-            "version": "0.2.17",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
         "Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/node_modules/typescript": {
             "version": "5.9.3",
             "dev": true,
@@ -4750,84 +5191,6 @@
             },
             "engines": {
                 "node": ">=14.17"
-            }
-        },
-        "Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/node_modules/vite": {
-            "version": "8.0.16",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-            "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "lightningcss": "^1.32.0",
-                "picomatch": "^4.0.4",
-                "postcss": "^8.5.15",
-                "rolldown": "1.0.3",
-                "tinyglobby": "^0.2.17"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.1.18",
-                "esbuild": "^0.27.0 || ^0.28.0",
-                "jiti": ">=1.21.0",
-                "less": "^4.0.0",
-                "sass": "^1.70.0",
-                "sass-embedded": "^1.70.0",
-                "stylus": ">=0.54.8",
-                "sugarss": "^5.0.0",
-                "terser": "^5.16.0",
-                "tsx": "^4.8.1",
-                "yaml": "^2.4.2"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "@vitejs/devtools": {
-                    "optional": true
-                },
-                "esbuild": {
-                    "optional": true
-                },
-                "jiti": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                },
-                "tsx": {
-                    "optional": true
-                },
-                "yaml": {
-                    "optional": true
-                }
             }
         },
         "Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Client": {
@@ -4893,52 +5256,6 @@
                 "@protobuf-ts/protoc": "^2.11.1"
             }
         },
-        "Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Client/node_modules/postcss": {
-            "version": "8.5.15",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "nanoid": "^3.3.12",
-                "picocolors": "^1.1.1",
-                "source-map-js": "^1.2.1"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
-            }
-        },
-        "Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Client/node_modules/tinyglobby": {
-            "version": "0.2.17",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
         "Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Client/node_modules/typescript": {
             "version": "5.9.3",
             "dev": true,
@@ -4962,84 +5279,6 @@
                 "uuid": "dist/esm/bin/uuid"
             }
         },
-        "Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Client/node_modules/vite": {
-            "version": "8.0.16",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-            "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "lightningcss": "^1.32.0",
-                "picomatch": "^4.0.4",
-                "postcss": "^8.5.15",
-                "rolldown": "1.0.3",
-                "tinyglobby": "^0.2.17"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.1.18",
-                "esbuild": "^0.27.0 || ^0.28.0",
-                "jiti": ">=1.21.0",
-                "less": "^4.0.0",
-                "sass": "^1.70.0",
-                "sass-embedded": "^1.70.0",
-                "stylus": ">=0.54.8",
-                "sugarss": "^5.0.0",
-                "terser": "^5.16.0",
-                "tsx": "^4.8.1",
-                "yaml": "^2.4.2"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "@vitejs/devtools": {
-                    "optional": true
-                },
-                "esbuild": {
-                    "optional": true
-                },
-                "jiti": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                },
-                "tsx": {
-                    "optional": true
-                },
-                "yaml": {
-                    "optional": true
-                }
-            }
-        },
         "Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client": {
             "name": "@umbraco-ai/prompt",
             "version": "17.0.0",
@@ -5056,52 +5295,6 @@
                 "vite": "^8.0.16"
             }
         },
-        "Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/node_modules/postcss": {
-            "version": "8.5.15",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "nanoid": "^3.3.12",
-                "picocolors": "^1.1.1",
-                "source-map-js": "^1.2.1"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
-            }
-        },
-        "Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/node_modules/tinyglobby": {
-            "version": "0.2.17",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
         "Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/node_modules/typescript": {
             "version": "5.9.3",
             "dev": true,
@@ -5112,84 +5305,6 @@
             },
             "engines": {
                 "node": ">=14.17"
-            }
-        },
-        "Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/node_modules/vite": {
-            "version": "8.0.16",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-            "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "lightningcss": "^1.32.0",
-                "picomatch": "^4.0.4",
-                "postcss": "^8.5.15",
-                "rolldown": "1.0.3",
-                "tinyglobby": "^0.2.17"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.1.18",
-                "esbuild": "^0.27.0 || ^0.28.0",
-                "jiti": ">=1.21.0",
-                "less": "^4.0.0",
-                "sass": "^1.70.0",
-                "sass-embedded": "^1.70.0",
-                "stylus": ">=0.54.8",
-                "sugarss": "^5.0.0",
-                "terser": "^5.16.0",
-                "tsx": "^4.8.1",
-                "yaml": "^2.4.2"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "@vitejs/devtools": {
-                    "optional": true
-                },
-                "esbuild": {
-                    "optional": true
-                },
-                "jiti": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                },
-                "tsx": {
-                    "optional": true
-                },
-                "yaml": {
-                    "optional": true
-                }
             }
         },
         "Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client": {
@@ -5210,52 +5325,6 @@
                 "vite": "^8.0.16"
             }
         },
-        "Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/node_modules/postcss": {
-            "version": "8.5.15",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "nanoid": "^3.3.12",
-                "picocolors": "^1.1.1",
-                "source-map-js": "^1.2.1"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
-            }
-        },
-        "Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/node_modules/tinyglobby": {
-            "version": "0.2.17",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
         "Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/node_modules/typescript": {
             "version": "5.9.3",
             "dev": true,
@@ -5266,84 +5335,6 @@
             },
             "engines": {
                 "node": ">=14.17"
-            }
-        },
-        "Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/node_modules/vite": {
-            "version": "8.0.16",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-            "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "lightningcss": "^1.32.0",
-                "picomatch": "^4.0.4",
-                "postcss": "^8.5.15",
-                "rolldown": "1.0.3",
-                "tinyglobby": "^0.2.17"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.1.18",
-                "esbuild": "^0.27.0 || ^0.28.0",
-                "jiti": ">=1.21.0",
-                "less": "^4.0.0",
-                "sass": "^1.70.0",
-                "sass-embedded": "^1.70.0",
-                "stylus": ">=0.54.8",
-                "sugarss": "^5.0.0",
-                "terser": "^5.16.0",
-                "tsx": "^4.8.1",
-                "yaml": "^2.4.2"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "@vitejs/devtools": {
-                    "optional": true
-                },
-                "esbuild": {
-                    "optional": true
-                },
-                "jiti": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                },
-                "tsx": {
-                    "optional": true
-                },
-                "yaml": {
-                    "optional": true
-                }
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "watch:agent": "npm run watch -w @umbraco-ai/agent",
         "watch:agent-ui": "npm run watch -w @umbraco-ai/agent-ui",
         "watch:copilot": "npm run watch -w @umbraco-ai/agent-copilot",
+        "test:copilot": "npm run test -w @umbraco-ai/agent-copilot",
         "generate-client": "concurrently --names \"core,prompt,agent\" -c \"blue,green,yellow\" \"npm run generate-client:core\" \"npm run generate-client:prompt\" \"npm run generate-client:agent\"",
         "generate-client:core": "npm run generate-client -w @umbraco-ai/core",
         "generate-client:prompt": "npm run generate-client -w @umbraco-ai/prompt",


### PR DESCRIPTION
## Problem
On a culture-variant document, the Copilot's property-value tools (`set_value`, `add_item`, …) fall back to the **active variant** (the culture being edited) when the LLM doesn't pass a culture, and stage the value under that culture **regardless of the property's own variance**. For an **invariant / shared** property this stages the value under a culture, so the save is rejected by the Management API:

```
400 PropertyTypeCultureVarianceMismatch
"One or more property values specify a culture for an invariant property…"
```

The Copilot reports the change as staged/done, but the save fails.

Reproduced against a real site (Management API PUT on the same document): invariant property with `culture:"pt-PT"` → **400**; identical PUT with `culture:null` → **200 OK**.

## Fix
Before staging, read the root property's `variesByCulture` / `variesBySegment` from the workspace's content-type structure and normalise the staged variant: an invariant property is staged with `culture`/`segment` = `null`; genuinely variant properties are unchanged. One file: `property-value-tool-base.ts`, plus an exported pure helper `normalizeVariantForProperty`.

## Validation
- **Logic (unit):** `normalizeVariantForProperty` — invariant + active `pt-PT` → `{culture:null,segment:null}`; culture-variant keeps its culture; segment cases correct (5/5).
- **Behaviour (HTTP):** the resulting `culture:null` payload saves (200) where the pre-fix `culture:"pt-PT"` payload failed (400).

## Notes
- Confirm the `getPropertyStructureByAlias` accessor name on `@umbraco-cms/backoffice@^18`; adjust if the signature differs.
- Add a Vitest unit test for `normalizeVariantForProperty` (package currently ships no test runner).
- _Validation PR opened on a fork; not yet targeted at `umbraco/Umbraco.AI`._

## Related
Client-side counterpart to umbraco/Umbraco-CMS#22076 / umbraco/Umbraco-CMS#22100, which added the descriptive `PropertyTypeCultureVarianceMismatch` 400 (the error surfaced here). Core now reports the mismatch clearly; this PR stops the Copilot from producing it in the first place.

---
_v17/dev counterpart: #248_
