### PR TITLE
feat(core,prompt): Simplified property value transformers for AI Prompt generation (v17)

### DIFF
--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptPropertyValueSchemaResolver.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptPropertyValueSchemaResolver.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Nodes;
+using Umbraco.AI.Core.PropertyValueOperations;
 using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.AI.Prompt.Core.Prompts;
@@ -10,21 +11,36 @@ internal sealed class AIPromptPropertyValueSchemaResolver : IAIPromptPropertyVal
     private readonly IMediaTypeService _mediaTypeService;
     private readonly IMemberTypeService _memberTypeService;
     private readonly IPropertyEditorSchemaService _propertyEditorSchemaService;
+    private readonly AISimplifiedPropertyValueTransformerCollection _transformers;
 
     public AIPromptPropertyValueSchemaResolver(
         IContentTypeService contentTypeService,
         IMediaTypeService mediaTypeService,
         IMemberTypeService memberTypeService,
-        IPropertyEditorSchemaService propertyEditorSchemaService)
+        IPropertyEditorSchemaService propertyEditorSchemaService,
+        AISimplifiedPropertyValueTransformerCollection transformers)
     {
         _contentTypeService = contentTypeService;
         _mediaTypeService = mediaTypeService;
         _memberTypeService = memberTypeService;
         _propertyEditorSchemaService = propertyEditorSchemaService;
+        _transformers = transformers;
     }
 
     /// <inheritdoc />
+    [Obsolete("Use ResolvePropertyValueSchemaAsync. Will be removed in v19.")]
     public async Task<JsonObject?> ResolveValueSchemaAsync(
+        string contentTypeAlias,
+        string entityType,
+        string propertyAlias,
+        CancellationToken cancellationToken = default)
+    {
+        var resolution = await ResolvePropertyValueSchemaAsync(contentTypeAlias, entityType, propertyAlias, cancellationToken);
+        return resolution?.Schema;
+    }
+
+    /// <inheritdoc />
+    public async Task<AIPromptPropertyValueSchemaResolution?> ResolvePropertyValueSchemaAsync(
         string contentTypeAlias,
         string entityType,
         string propertyAlias,
@@ -44,8 +60,26 @@ internal sealed class AIPromptPropertyValueSchemaResolver : IAIPromptPropertyVal
             return null;
         }
 
-        var attempt = await _propertyEditorSchemaService.GetSchemaAsync(propertyType.DataTypeKey);
+        var dataTypeKey = propertyType.DataTypeKey;
+        var editorAlias = propertyType.PropertyEditorAlias;
 
-        return attempt.Success ? attempt.Result?.JsonSchema : null;
+        // A registered transformer wins (always, when present) — it defines the simplified schema the
+        // LLM should generate against, even for editors whose write schema is representable.
+        var transformer = _transformers.GetByEditorSchemaAlias(editorAlias);
+        if (transformer is not null)
+        {
+            var simplified = await transformer.GetSimplifiedSchemaAsync(dataTypeKey, cancellationToken);
+
+            // Guard the JsonObject conversion: a non-object schema node (or an opt-out returning null)
+            // falls through to the editor's write schema rather than throwing.
+            if (simplified is JsonObject simplifiedObject)
+            {
+                return new AIPromptPropertyValueSchemaResolution(simplifiedObject, IsSimplified: true, dataTypeKey, editorAlias);
+            }
+        }
+
+        var attempt = await _propertyEditorSchemaService.GetSchemaAsync(dataTypeKey);
+        var writeSchema = attempt.Success ? attempt.Result?.JsonSchema : null;
+        return new AIPromptPropertyValueSchemaResolution(writeSchema, IsSimplified: false, dataTypeKey, editorAlias);
     }
 }

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptSchemaCompatibility.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptSchemaCompatibility.cs
@@ -1,0 +1,120 @@
+using System.Text.Json.Nodes;
+
+namespace Umbraco.AI.Prompt.Core.Prompts;
+
+/// <summary>
+/// Determines whether a property's resolved JSON Schema can be faithfully expressed as a
+/// <em>strict</em> structured-output schema — the subset enforced by providers such as OpenAI's
+/// Responses API (every node must have a resolvable <c>type</c>; arrays must declare <c>items</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Some CMS property editors expose a value schema that contains intentionally unconstrained nodes.
+/// The block editors (Block List / Block Grid) are the canonical example: their per-property
+/// <c>values[].value</c> node is an empty schema (<c>{}</c>) because the shape depends on which
+/// element property editor occupies the slot (see <c>BlockJsonSchemaHelper.CreateBlockItemDataSchema</c>
+/// in Umbraco CMS). There is no faithful strict-schema equivalent for "any JSON value", so embedding
+/// such a schema in a structured-output request is rejected by strict providers with an
+/// <c>invalid_json_schema</c> error.
+/// </para>
+/// <para>
+/// This check is deliberately narrow. It flags only the cases a strict provider genuinely cannot
+/// repair — a node with no resolvable type, or an array without <c>items</c>. It does <em>not</em>
+/// require <c>additionalProperties: false</c> or that every property appears in <c>required</c>,
+/// because the provider integration (M.E.AI) normalises those automatically. This keeps
+/// well-typed editor schemas (e.g. ColorPicker's <c>{ value, label }</c>) representable while
+/// rejecting genuinely polymorphic ones.
+/// </para>
+/// </remarks>
+internal static class AIPromptSchemaCompatibility
+{
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="schema"/> can be faithfully represented as a strict
+    /// structured-output schema; <c>false</c> when it contains an unconstrained node (e.g. a block
+    /// editor's <c>{}</c> value) that a strict provider would reject.
+    /// </summary>
+    public static bool IsStrictRepresentable(JsonNode? schema) => IsNodeRepresentable(schema);
+
+    private static bool IsNodeRepresentable(JsonNode? node)
+    {
+        // A boolean schema (`true`/`false`) constrains nothing usable in strict mode.
+        if (node is not JsonObject schema)
+        {
+            return false;
+        }
+
+        // A `$ref` stands in for a named definition; assume it resolves to a representable schema.
+        if (schema.ContainsKey("$ref"))
+        {
+            return true;
+        }
+
+        // Combinators are representable when every branch is. `type` is optional alongside these.
+        foreach (var combinator in new[] { "anyOf", "oneOf", "allOf" })
+        {
+            if (schema[combinator] is JsonArray branches)
+            {
+                return branches.All(IsNodeRepresentable);
+            }
+        }
+
+        // `enum`/`const` pin the value to concrete literals, so a missing `type` is fine.
+        if (schema.ContainsKey("enum") || schema.ContainsKey("const"))
+        {
+            return true;
+        }
+
+        // Every remaining node must declare a type. An empty `{}` (the block editor "any value"
+        // node) has none — this is the case strict providers reject and we must detect.
+        if (!TryGetTypes(schema, out var types))
+        {
+            return false;
+        }
+
+        if (types.Contains("object") && schema["properties"] is JsonObject properties)
+        {
+            if (properties.Any(property => !IsNodeRepresentable(property.Value)))
+            {
+                return false;
+            }
+        }
+
+        if (types.Contains("array"))
+        {
+            // A strict array schema must declare its item shape.
+            if (schema["items"] is not JsonNode items)
+            {
+                return false;
+            }
+
+            return IsNodeRepresentable(items);
+        }
+
+        return true;
+    }
+
+    // `type` may be a single string ("string") or an array of strings (["object", "null"]).
+    private static bool TryGetTypes(JsonObject schema, out HashSet<string> types)
+    {
+        types = new HashSet<string>(StringComparer.Ordinal);
+
+        switch (schema["type"])
+        {
+            case JsonValue value when value.TryGetValue<string>(out var single):
+                types.Add(single);
+                return true;
+            case JsonArray array:
+                foreach (var entry in array)
+                {
+                    if (entry is JsonValue v && v.TryGetValue<string>(out var name))
+                    {
+                        types.Add(name);
+                    }
+                }
+
+                return types.Count > 0;
+            default:
+                return false;
+        }
+    }
+}

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptService.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptService.cs
@@ -366,6 +366,20 @@ internal sealed class AIPromptService : IAIPromptService
                 cancellationToken)
             : null;
 
+        // A resolved schema that isn't strict-representable (e.g. a block editor's unconstrained
+        // `{}` value node) would be rejected by strict providers like OpenAI with an opaque HTTP
+        // 400. Falling back to the string model here would silently produce a value the editor
+        // can't consume, so fail fast with a clear message instead. Editors that expose no schema
+        // (propertyValueSchema is null) still fall through to the string-based response models.
+        if (propertyValueSchema is not null &&
+            !AIPromptSchemaCompatibility.IsStrictRepresentable(propertyValueSchema))
+        {
+            throw new InvalidOperationException(
+                $"AI Prompt generation is not supported for property '{request.PropertyAlias}': its editor " +
+                "produces a value that cannot be constrained for structured generation (for example Block " +
+                "List or Block Grid). Scope this prompt to properties whose editors expose a constrainable value.");
+        }
+
         // 10. Execute and build result based on option count.
         // For OptionCount 1 and 2+, use structured output via GetStructuredResponseAsync<T>
         // which delegates to M.E.AI's structured output extensions (schema, ResponseFormat, deserialization).

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptService.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/AIPromptService.cs
@@ -3,7 +3,9 @@ using System.Text.Json.Nodes;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.AI.Core.Chat;
+using Umbraco.AI.Core.EntityAdapter;
 using Umbraco.AI.Core.InlineChat;
+using Umbraco.AI.Core.PropertyValueOperations;
 using Umbraco.AI.Core.RuntimeContext;
 using Umbraco.AI.Core.Tools;
 using Umbraco.AI.Core.Versioning;
@@ -34,6 +36,7 @@ internal sealed class AIPromptService : IAIPromptService
     private readonly IBackOfficeSecurityAccessor? _backOfficeSecurityAccessor;
     private readonly IEventAggregator _eventAggregator;
     private readonly IAIPromptPropertyValueSchemaResolver _propertyValueSchemaResolver;
+    private readonly AISimplifiedPropertyValueTransformerCollection _transformers;
 
     public AIPromptService(
         IAIPromptRepository repository,
@@ -47,6 +50,7 @@ internal sealed class AIPromptService : IAIPromptService
         AIRuntimeContextContributorCollection contextContributors,
         IEventAggregator eventAggregator,
         IAIPromptPropertyValueSchemaResolver propertyValueSchemaResolver,
+        AISimplifiedPropertyValueTransformerCollection transformers,
         IBackOfficeSecurityAccessor? backOfficeSecurityAccessor = null)
     {
         _repository = repository;
@@ -60,6 +64,7 @@ internal sealed class AIPromptService : IAIPromptService
         _contextContributors = contextContributors;
         _eventAggregator = eventAggregator;
         _propertyValueSchemaResolver = propertyValueSchemaResolver;
+        _transformers = transformers;
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
@@ -354,23 +359,30 @@ internal sealed class AIPromptService : IAIPromptService
             }
         }
 
-        // 9. Resolve the target property's own value schema (when its editor exposes one via
-        // IPropertyEditorSchemaService) so generation can be constrained to the exact shape the
-        // property expects (e.g. a ColorPicker's {value,label}) instead of assuming a plain string.
-        // Editors that don't expose a schema fall back to the string-only shapes below.
-        JsonObject? propertyValueSchema = prompt.OptionCount >= 1
-            ? await _propertyValueSchemaResolver.ResolveValueSchemaAsync(
+        // 9. Resolve the schema generation should be constrained to for the target property.
+        // A registered IAISimplifiedPropertyValueTransformer wins (a simplified, strict-representable
+        // schema the LLM generates against, later transformed back to the editor's write value);
+        // otherwise the editor's own write schema (e.g. a ColorPicker's {value,label}); otherwise the
+        // string-only shapes below. TipTapTool prompts insert markup at the cursor, so they run in
+        // plain-text output mode — skip the schema/transformer/guard entirely and use the string model.
+        var plainTextOutput = prompt.DisplayMode == AIPromptDisplayMode.TipTapTool;
+
+        AIPromptPropertyValueSchemaResolution? resolution = !plainTextOutput && prompt.OptionCount >= 1
+            ? await _propertyValueSchemaResolver.ResolvePropertyValueSchemaAsync(
                 request.ContentTypeAlias,
                 request.ElementType ?? request.EntityType,
                 request.PropertyAlias,
                 cancellationToken)
             : null;
 
-        // A resolved schema that isn't strict-representable (e.g. a block editor's unconstrained
-        // `{}` value node) would be rejected by strict providers like OpenAI with an opaque HTTP
-        // 400. Falling back to the string model here would silently produce a value the editor
-        // can't consume, so fail fast with a clear message instead. Editors that expose no schema
-        // (propertyValueSchema is null) still fall through to the string-based response models.
+        JsonObject? propertyValueSchema = resolution?.Schema;
+
+        // A schema that isn't strict-representable (e.g. a block editor's unconstrained `{}` value node)
+        // would be rejected by strict providers like OpenAI with an opaque HTTP 400. Run the check on
+        // whichever schema is used — including a simplified one, so a mis-behaving transformer that
+        // returns a non-strict schema fails fast cleanly rather than reintroducing the 400. Falling back
+        // to the string model here would silently produce a value the editor can't consume. Editors that
+        // expose no schema (propertyValueSchema is null) still fall through to the string-based models.
         if (propertyValueSchema is not null &&
             !AIPromptSchemaCompatibility.IsStrictRepresentable(propertyValueSchema))
         {
@@ -379,6 +391,14 @@ internal sealed class AIPromptService : IAIPromptService
                 "produces a value that cannot be constrained for structured generation (for example Block " +
                 "List or Block Grid). Scope this prompt to properties whose editors expose a constrainable value.");
         }
+
+        // For a simplified schema, the LLM value must be transformed back into the editor's write value.
+        // The current write-shape value (needed so the transform can preserve e.g. existing inline blocks)
+        // is already in the runtime context as the serialized entity/element that also feeds the
+        // "currentValue" template variable — reuse it (structured) rather than re-sending it.
+        JsonNode? currentPropertyValue = resolution?.IsSimplified == true
+            ? ExtractCurrentPropertyValue(runtimeContext, request.PropertyAlias)
+            : null;
 
         // 10. Execute and build result based on option count.
         // For OptionCount 1 and 2+, use structured output via GetStructuredResponseAsync<T>
@@ -417,18 +437,26 @@ internal sealed class AIPromptService : IAIPromptService
                     response.TryGetResult(out JsonElement structuredResult) &&
                     structuredResult.TryGetProperty("value", out var valueElement))
                 {
-                    value = valueElement;
+                    // DisplayValue reflects the raw (simplified) value; ValueChange gets the transformed
+                    // write value when a simplified transformer produced the schema.
                     displayValue = FormatDisplayValue(valueElement);
+                    value = resolution?.IsSimplified == true
+                        ? await TransformLlmValueAsync(resolution, ToJsonNode(valueElement), currentPropertyValue, request.PropertyAlias, cancellationToken)
+                        : valueElement;
                 }
                 else if (response.TryGetResult<SingleValueResponse>(out var parsed))
                 {
-                    value = parsed.Value;
                     displayValue = parsed.Value;
+                    value = resolution?.IsSimplified == true
+                        ? await TransformLlmValueAsync(resolution, JsonValue.Create(parsed.Value), currentPropertyValue, request.PropertyAlias, cancellationToken)
+                        : parsed.Value;
                 }
                 else
                 {
-                    value = responseText;
                     displayValue = responseText;
+                    value = resolution?.IsSimplified == true
+                        ? await TransformLlmValueAsync(resolution, JsonValue.Create(responseText), currentPropertyValue, request.PropertyAlias, cancellationToken)
+                        : responseText;
                 }
 
                 result = new AIPromptExecutionResult
@@ -468,7 +496,7 @@ internal sealed class AIPromptService : IAIPromptService
                 var responseText = response.Text ?? string.Empty;
 
                 var structuredOptions = propertyValueSchema is not null
-                    ? TryParseStructuredMultiOptionResult(response, request)
+                    ? await TryParseStructuredMultiOptionResultAsync(response, request, resolution, currentPropertyValue, cancellationToken)
                     : null;
 
                 if (structuredOptions is { Count: > 0 })
@@ -483,12 +511,16 @@ internal sealed class AIPromptService : IAIPromptService
                 }
                 else if (response.TryGetResult<MultiOptionResponse>(out var parsed) && parsed.Options is { Count: > 0 })
                 {
-                    result = new AIPromptExecutionResult
+                    var mappedOptions = new List<AIPromptExecutionResult.AIPromptResultOption>();
+                    foreach (var option in parsed.Options)
                     {
-                        Content = responseText,
-                        Usage = response.Usage,
-                        Messages = messages,
-                        ResultOptions = parsed.Options.Select(option => new AIPromptExecutionResult.AIPromptResultOption
+                        // DisplayValue is the raw (simplified) string; ValueChange gets the transformed
+                        // write value when a simplified transformer produced the schema.
+                        object? optionValue = resolution?.IsSimplified == true
+                            ? await TransformLlmValueAsync(resolution, JsonValue.Create(option.Value), currentPropertyValue, request.PropertyAlias, cancellationToken)
+                            : option.Value;
+
+                        mappedOptions.Add(new AIPromptExecutionResult.AIPromptResultOption
                         {
                             Label = option.Label,
                             DisplayValue = option.Value,
@@ -496,11 +528,19 @@ internal sealed class AIPromptService : IAIPromptService
                             ValueChange = new AIValueChange
                             {
                                 Path = request.PropertyAlias,
-                                Value = option.Value,
+                                Value = optionValue,
                                 Culture = request.Culture,
                                 Segment = request.Segment
                             }
-                        }).ToList()
+                        });
+                    }
+
+                    result = new AIPromptExecutionResult
+                    {
+                        Content = responseText,
+                        Usage = response.Usage,
+                        Messages = messages,
+                        ResultOptions = mappedOptions
                     };
                 }
                 else
@@ -754,10 +794,15 @@ internal sealed class AIPromptService : IAIPromptService
     /// Parses a multi-option response constrained to a dynamic property value schema
     /// (<see cref="AIPromptDynamicResponseSchemas.BuildMultiOptionSchema"/>). Unlike
     /// <see cref="MultiOptionResponse"/>, each option's value may be any JSON shape, not just a string.
+    /// When <paramref name="resolution"/> is simplified, each option's value is transformed back into
+    /// the editor's write value; a single option whose transform fails is skipped, not fatal.
     /// </summary>
-    private static IReadOnlyList<AIPromptExecutionResult.AIPromptResultOption>? TryParseStructuredMultiOptionResult(
+    private async Task<IReadOnlyList<AIPromptExecutionResult.AIPromptResultOption>?> TryParseStructuredMultiOptionResultAsync(
         ChatResponse response,
-        AIPromptExecutionRequest request)
+        AIPromptExecutionRequest request,
+        AIPromptPropertyValueSchemaResolution? resolution,
+        JsonNode? currentPropertyValue,
+        CancellationToken cancellationToken)
     {
         if (!response.TryGetResult(out JsonElement structuredResult) ||
             !structuredResult.TryGetProperty("options", out var optionsElement) ||
@@ -780,6 +825,25 @@ internal sealed class AIPromptService : IAIPromptService
                     ? descriptionElement.GetString()
                     : null;
 
+            // DisplayValue reflects the raw (simplified) value; ValueChange gets the transformed write
+            // value. Isolate per-option failures so one bad option doesn't discard its siblings.
+            object? optionValue;
+            if (resolution?.IsSimplified == true)
+            {
+                try
+                {
+                    optionValue = await TransformLlmValueAsync(resolution, ToJsonNode(valueElement), currentPropertyValue, request.PropertyAlias, cancellationToken);
+                }
+                catch (InvalidOperationException)
+                {
+                    continue;
+                }
+            }
+            else
+            {
+                optionValue = valueElement;
+            }
+
             options.Add(new AIPromptExecutionResult.AIPromptResultOption
             {
                 Label = labelElement.GetString() ?? "Option",
@@ -788,7 +852,7 @@ internal sealed class AIPromptService : IAIPromptService
                 ValueChange = new AIValueChange
                 {
                     Path = request.PropertyAlias,
-                    Value = valueElement,
+                    Value = optionValue,
                     Culture = request.Culture,
                     Segment = request.Segment
                 }
@@ -797,6 +861,95 @@ internal sealed class AIPromptService : IAIPromptService
 
         return options;
     }
+
+    /// <summary>
+    /// Transforms a value the LLM generated against a simplified schema back into the editor's write
+    /// value, via the registered <see cref="IAISimplifiedPropertyValueTransformer"/>. A transform failure
+    /// is surfaced as a clean <see cref="InvalidOperationException"/> (→ HTTP 400), never an opaque error.
+    /// </summary>
+    private async Task<object?> TransformLlmValueAsync(
+        AIPromptPropertyValueSchemaResolution resolution,
+        JsonNode? llmValue,
+        JsonNode? currentPropertyValue,
+        string propertyAlias,
+        CancellationToken cancellationToken)
+    {
+        var transformer = _transformers.GetByEditorSchemaAlias(resolution.EditorAlias);
+        if (transformer is null)
+        {
+            return llmValue;
+        }
+
+        try
+        {
+            return await transformer.TransformToWriteValueAsync(llmValue, currentPropertyValue, resolution.DataTypeKey, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"AI Prompt could not prepare the generated value for property '{propertyAlias}': {ex.Message}", ex);
+        }
+    }
+
+    /// <summary>
+    /// Extracts the target property's current write-shape value (structured) from the serialized
+    /// entity/element already in the runtime context — the same source that feeds the "currentValue"
+    /// template variable. Prefers the element (block) context, then the entity. Returns <c>null</c> when
+    /// no entity context is present or the property has no value.
+    /// </summary>
+    private static JsonNode? ExtractCurrentPropertyValue(AIRuntimeContext runtimeContext, string propertyAlias)
+    {
+        foreach (var key in new[] { CoreConstants.ContextKeys.SerializedElement, CoreConstants.ContextKeys.SerializedEntity })
+        {
+            if (runtimeContext.Data.TryGetValue(key, out var stored) &&
+                stored is AISerializedEntity entity &&
+                TryGetSerializedPropertyValue(entity, propertyAlias, out var value))
+            {
+                return value;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TryGetSerializedPropertyValue(AISerializedEntity entity, string propertyAlias, out JsonNode? value)
+    {
+        value = null;
+
+        if (entity.Data.ValueKind != JsonValueKind.Object ||
+            !entity.Data.TryGetProperty("properties", out var propertiesElement) ||
+            propertiesElement.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
+
+        JsonElement? match = null;
+        foreach (var propElement in propertiesElement.EnumerateArray())
+        {
+            if (propElement.ValueKind == JsonValueKind.Object &&
+                propElement.TryGetProperty("alias", out var aliasElement) &&
+                aliasElement.ValueKind == JsonValueKind.String &&
+                string.Equals(aliasElement.GetString(), propertyAlias, StringComparison.Ordinal))
+            {
+                // Mirror AIEntityContextHelper's "last entry wins" per alias so client and server agree.
+                match = propElement;
+            }
+        }
+
+        if (match is null || !match.Value.TryGetProperty("value", out var valueElement) ||
+            valueElement.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
+        {
+            return false;
+        }
+
+        value = ToJsonNode(valueElement);
+        return true;
+    }
+
+    /// <summary>
+    /// Converts a <see cref="JsonElement"/> to a <see cref="JsonNode"/> for transformer input.
+    /// </summary>
+    private static JsonNode? ToJsonNode(JsonElement element) => JsonSerializer.SerializeToNode(element);
 
     /// <summary>
     /// Formats a structured value for display — strings render as-is, everything else as compact JSON.

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/IAIPromptPropertyValueSchemaResolver.cs
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Core/Prompts/IAIPromptPropertyValueSchemaResolver.cs
@@ -3,6 +3,27 @@ using System.Text.Json.Nodes;
 namespace Umbraco.AI.Prompt.Core.Prompts;
 
 /// <summary>
+/// The resolved schema a prompt should constrain LLM output to for a target property, plus the
+/// identity needed to transform the LLM result back into the editor's write value.
+/// </summary>
+/// <param name="Schema">
+/// The JSON Schema (draft 2020-12) to constrain generation to — either a simplified schema from an
+/// <c>IAISimplifiedPropertyValueTransformer</c> (<paramref name="IsSimplified"/> is <c>true</c>) or the
+/// editor's own write schema. <c>null</c> when no schema could be resolved.
+/// </param>
+/// <param name="IsSimplified">
+/// <c>true</c> when <paramref name="Schema"/> came from a simplified transformer, meaning the LLM value
+/// must be transformed back to the editor's write value before use.
+/// </param>
+/// <param name="DataTypeKey">The target property's data type key.</param>
+/// <param name="EditorAlias">The target property's property editor alias.</param>
+public sealed record AIPromptPropertyValueSchemaResolution(
+    JsonObject? Schema,
+    bool IsSimplified,
+    Guid DataTypeKey,
+    string EditorAlias);
+
+/// <summary>
 /// Resolves the JSON Schema describing the value a property editor accepts, so prompt execution
 /// can constrain LLM output to the exact shape the target property expects instead of assuming
 /// a plain string.
@@ -21,7 +42,29 @@ public interface IAIPromptPropertyValueSchemaResolver
     /// The JSON Schema (draft 2020-12) describing the property's value, or <c>null</c> when the
     /// property can't be resolved or its editor doesn't expose a value schema.
     /// </returns>
+    [Obsolete("Use ResolvePropertyValueSchemaAsync, which also reports whether the schema is a simplified " +
+        "transformer schema and returns the property's data type key and editor alias. This method returns " +
+        "only the editor's write schema. Will be removed in v19.")]
     Task<JsonObject?> ResolveValueSchemaAsync(
+        string contentTypeAlias,
+        string entityType,
+        string propertyAlias,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolves the schema a prompt should constrain generation to for the target property. When the
+    /// property's editor has a registered <c>IAISimplifiedPropertyValueTransformer</c>, the simplified
+    /// schema is returned (with <see cref="AIPromptPropertyValueSchemaResolution.IsSimplified"/> set);
+    /// otherwise the editor's own write schema is returned.
+    /// </summary>
+    /// <param name="contentTypeAlias">The content/media/member/element type alias.</param>
+    /// <param name="entityType">The entity type (e.g. "document", "media", "member", "block").</param>
+    /// <param name="propertyAlias">The property alias.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The resolution, or <c>null</c> when the property can't be resolved.
+    /// </returns>
+    Task<AIPromptPropertyValueSchemaResolution?> ResolvePropertyValueSchemaAsync(
         string contentTypeAlias,
         string entityType,
         string propertyAlias,

--- a/Umbraco.AI.Prompt/tests/Umbraco.AI.Prompt.Tests.Unit/Prompts/AIPromptPropertyValueSchemaResolverTests.cs
+++ b/Umbraco.AI.Prompt/tests/Umbraco.AI.Prompt.Tests.Unit/Prompts/AIPromptPropertyValueSchemaResolverTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Nodes;
 using Moq;
 using Shouldly;
+using Umbraco.AI.Core.PropertyValueOperations;
 using Umbraco.AI.Prompt.Core.Prompts;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
@@ -16,123 +17,164 @@ public class AIPromptPropertyValueSchemaResolverTests
     private readonly Mock<IMediaTypeService> _mockMediaTypeService = new();
     private readonly Mock<IMemberTypeService> _mockMemberTypeService = new();
     private readonly Mock<IPropertyEditorSchemaService> _mockPropertyEditorSchemaService = new();
-    private readonly AIPromptPropertyValueSchemaResolver _resolver;
 
-    public AIPromptPropertyValueSchemaResolverTests()
-    {
-        _resolver = new AIPromptPropertyValueSchemaResolver(
+    private AIPromptPropertyValueSchemaResolver CreateResolver(params IAISimplifiedPropertyValueTransformer[] transformers)
+        => new(
             _mockContentTypeService.Object,
             _mockMediaTypeService.Object,
             _mockMemberTypeService.Object,
-            _mockPropertyEditorSchemaService.Object);
-    }
+            _mockPropertyEditorSchemaService.Object,
+            new AISimplifiedPropertyValueTransformerCollection(() => transformers));
 
-    private static Mock<IPropertyType> CreatePropertyType(string alias, Guid dataTypeKey)
+    private static Mock<IPropertyType> CreatePropertyType(string alias, Guid dataTypeKey, string editorAlias = "Umbraco.TextBox")
     {
         var propertyType = new Mock<IPropertyType>();
         propertyType.SetupGet(p => p.Alias).Returns(alias);
         propertyType.SetupGet(p => p.DataTypeKey).Returns(dataTypeKey);
+        propertyType.SetupGet(p => p.PropertyEditorAlias).Returns(editorAlias);
         return propertyType;
     }
 
-    [Fact]
-    public async Task ResolveValueSchemaAsync_DocumentPropertyWithSchema_ReturnsJsonSchema()
+    private void SetupDocumentProperty(string contentTypeAlias, IPropertyType propertyType)
     {
-        var dataTypeKey = Guid.NewGuid();
-        var propertyType = CreatePropertyType("colour", dataTypeKey);
-
         var contentType = new Mock<IContentType>();
-        contentType.SetupGet(c => c.CompositionPropertyTypes).Returns([propertyType.Object]);
-        _mockContentTypeService.Setup(s => s.Get("page")).Returns(contentType.Object);
+        contentType.SetupGet(c => c.CompositionPropertyTypes).Returns([propertyType]);
+        _mockContentTypeService.Setup(s => s.Get(contentTypeAlias)).Returns(contentType.Object);
+    }
 
-        var schema = new JsonObject { ["type"] = "object" };
-        _mockPropertyEditorSchemaService
+    private void SetupWriteSchema(Guid dataTypeKey, JsonObject? schema, bool success = true)
+        => _mockPropertyEditorSchemaService
             .Setup(s => s.GetSchemaAsync(dataTypeKey))
-            .ReturnsAsync(Attempt.SucceedWithStatus(
-                PropertyEditorSchemaOperationStatus.Success,
-                new PropertyValueSchema(typeof(JsonObject), schema)));
+            .ReturnsAsync(success
+                ? Attempt.SucceedWithStatus(PropertyEditorSchemaOperationStatus.Success, new PropertyValueSchema(typeof(JsonObject), schema))
+                : Attempt.FailWithStatus(PropertyEditorSchemaOperationStatus.SchemaNotSupported, new PropertyValueSchema(null, null)));
 
-        var result = await _resolver.ResolveValueSchemaAsync("page", "document", "colour");
-
-        result.ShouldBe(schema);
+    private sealed class FakeTransformer(string editorAlias, JsonNode? simplifiedSchema) : IAISimplifiedPropertyValueTransformer
+    {
+        public string ForPropertyEditorSchemaAlias => editorAlias;
+        public Task<JsonNode?> GetSimplifiedSchemaAsync(Guid dataTypeKey, CancellationToken cancellationToken = default)
+            => Task.FromResult(simplifiedSchema);
+        public Task<JsonNode?> TransformToWriteValueAsync(JsonNode? simplifiedValue, JsonNode? currentValue, Guid dataTypeKey, CancellationToken cancellationToken = default)
+            => Task.FromResult<JsonNode?>(simplifiedValue);
     }
 
     [Fact]
-    public async Task ResolveValueSchemaAsync_MediaEntityType_QueriesMediaTypeService()
+    public async Task ResolvePropertyValueSchemaAsync_DocumentPropertyWithSchema_ReturnsWriteSchema()
     {
         var dataTypeKey = Guid.NewGuid();
-        var propertyType = CreatePropertyType("colour", dataTypeKey);
+        SetupDocumentProperty("page", CreatePropertyType("colour", dataTypeKey).Object);
+        var schema = new JsonObject { ["type"] = "object" };
+        SetupWriteSchema(dataTypeKey, schema);
 
+        var result = await CreateResolver().ResolvePropertyValueSchemaAsync("page", "document", "colour");
+
+        result.ShouldNotBeNull();
+        result!.Schema.ShouldBe(schema);
+        result.IsSimplified.ShouldBeFalse();
+        result.DataTypeKey.ShouldBe(dataTypeKey);
+    }
+
+    [Fact]
+    public async Task ResolvePropertyValueSchemaAsync_MediaEntityType_QueriesMediaTypeService()
+    {
+        var dataTypeKey = Guid.NewGuid();
         var mediaType = new Mock<IMediaType>();
-        mediaType.SetupGet(c => c.CompositionPropertyTypes).Returns([propertyType.Object]);
+        mediaType.SetupGet(c => c.CompositionPropertyTypes).Returns([CreatePropertyType("colour", dataTypeKey).Object]);
         _mockMediaTypeService.Setup(s => s.Get("image")).Returns(mediaType.Object);
-
         var schema = new JsonObject { ["type"] = "string" };
-        _mockPropertyEditorSchemaService
-            .Setup(s => s.GetSchemaAsync(dataTypeKey))
-            .ReturnsAsync(Attempt.SucceedWithStatus(
-                PropertyEditorSchemaOperationStatus.Success,
-                new PropertyValueSchema(typeof(string), schema)));
+        SetupWriteSchema(dataTypeKey, schema);
 
-        var result = await _resolver.ResolveValueSchemaAsync("image", "media", "colour");
+        var result = await CreateResolver().ResolvePropertyValueSchemaAsync("image", "media", "colour");
 
-        result.ShouldBe(schema);
+        result!.Schema.ShouldBe(schema);
         _mockContentTypeService.Verify(s => s.Get(It.IsAny<string>()), Times.Never);
     }
 
     [Fact]
-    public async Task ResolveValueSchemaAsync_PropertyNotFoundOnContentType_ReturnsNull()
+    public async Task ResolvePropertyValueSchemaAsync_RegisteredTransformer_ReturnsSimplifiedSchema()
+    {
+        var dataTypeKey = Guid.NewGuid();
+        SetupDocumentProperty("page", CreatePropertyType("body", dataTypeKey, "Umbraco.RichText").Object);
+        var simplified = new JsonObject { ["type"] = "string" };
+
+        var result = await CreateResolver(new FakeTransformer("Umbraco.RichText", simplified))
+            .ResolvePropertyValueSchemaAsync("page", "document", "body");
+
+        result.ShouldNotBeNull();
+        result!.IsSimplified.ShouldBeTrue();
+        result.Schema.ShouldBe(simplified);
+        result.EditorAlias.ShouldBe("Umbraco.RichText");
+        // The write schema is not consulted when a transformer supplies a simplified schema.
+        _mockPropertyEditorSchemaService.Verify(s => s.GetSchemaAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolvePropertyValueSchemaAsync_TransformerReturnsNonObjectSchema_FallsBackToWriteSchema()
+    {
+        var dataTypeKey = Guid.NewGuid();
+        SetupDocumentProperty("page", CreatePropertyType("body", dataTypeKey, "Umbraco.RichText").Object);
+        var writeSchema = new JsonObject { ["type"] = "object" };
+        SetupWriteSchema(dataTypeKey, writeSchema);
+
+        // A non-JsonObject simplified schema (a bare string node) must not throw — fall back to the write schema.
+        var result = await CreateResolver(new FakeTransformer("Umbraco.RichText", JsonValue.Create("nonsense")))
+            .ResolvePropertyValueSchemaAsync("page", "document", "body");
+
+        result.ShouldNotBeNull();
+        result!.IsSimplified.ShouldBeFalse();
+        result.Schema.ShouldBe(writeSchema);
+    }
+
+    [Fact]
+    public async Task ResolvePropertyValueSchemaAsync_PropertyNotFound_ReturnsNull()
     {
         var contentType = new Mock<IContentType>();
         contentType.SetupGet(c => c.CompositionPropertyTypes).Returns([]);
         _mockContentTypeService.Setup(s => s.Get("page")).Returns(contentType.Object);
 
-        var result = await _resolver.ResolveValueSchemaAsync("page", "document", "missing");
+        var result = await CreateResolver().ResolvePropertyValueSchemaAsync("page", "document", "missing");
 
         result.ShouldBeNull();
-        _mockPropertyEditorSchemaService.Verify(
-            s => s.GetSchemaAsync(It.IsAny<Guid>()), Times.Never);
+        _mockPropertyEditorSchemaService.Verify(s => s.GetSchemaAsync(It.IsAny<Guid>()), Times.Never);
     }
 
     [Fact]
-    public async Task ResolveValueSchemaAsync_ContentTypeNotFound_ReturnsNull()
-    {
-        _mockContentTypeService.Setup(s => s.Get("page")).Returns((IContentType?)null);
-
-        var result = await _resolver.ResolveValueSchemaAsync("page", "document", "colour");
-
-        result.ShouldBeNull();
-    }
-
-    [Fact]
-    public async Task ResolveValueSchemaAsync_EditorDoesNotSupportSchema_ReturnsNull()
+    public async Task ResolvePropertyValueSchemaAsync_EditorDoesNotSupportSchema_ReturnsResolutionWithNullSchema()
     {
         var dataTypeKey = Guid.NewGuid();
-        var propertyType = CreatePropertyType("colour", dataTypeKey);
+        SetupDocumentProperty("page", CreatePropertyType("colour", dataTypeKey).Object);
+        SetupWriteSchema(dataTypeKey, null, success: false);
 
-        var contentType = new Mock<IContentType>();
-        contentType.SetupGet(c => c.CompositionPropertyTypes).Returns([propertyType.Object]);
-        _mockContentTypeService.Setup(s => s.Get("page")).Returns(contentType.Object);
+        var result = await CreateResolver().ResolvePropertyValueSchemaAsync("page", "document", "colour");
 
-        _mockPropertyEditorSchemaService
-            .Setup(s => s.GetSchemaAsync(dataTypeKey))
-            .ReturnsAsync(Attempt.FailWithStatus(
-                PropertyEditorSchemaOperationStatus.SchemaNotSupported,
-                new PropertyValueSchema(null, null)));
-
-        var result = await _resolver.ResolveValueSchemaAsync("page", "document", "colour");
-
-        result.ShouldBeNull();
+        result.ShouldNotBeNull();
+        result!.Schema.ShouldBeNull();
+        result.IsSimplified.ShouldBeFalse();
     }
 
     [Theory]
     [InlineData("")]
     [InlineData(null)]
-    public async Task ResolveValueSchemaAsync_MissingContentTypeAlias_ReturnsNullWithoutQuerying(string? alias)
+    public async Task ResolvePropertyValueSchemaAsync_MissingContentTypeAlias_ReturnsNullWithoutQuerying(string? alias)
     {
-        var result = await _resolver.ResolveValueSchemaAsync(alias!, "document", "colour");
+        var result = await CreateResolver().ResolvePropertyValueSchemaAsync(alias!, "document", "colour");
 
         result.ShouldBeNull();
         _mockContentTypeService.Verify(s => s.Get(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveValueSchemaAsync_Obsolete_StillReturnsWriteSchema()
+    {
+        var dataTypeKey = Guid.NewGuid();
+        SetupDocumentProperty("page", CreatePropertyType("colour", dataTypeKey).Object);
+        var schema = new JsonObject { ["type"] = "object" };
+        SetupWriteSchema(dataTypeKey, schema);
+
+#pragma warning disable CS0618 // deliberately exercising the obsolete delegating method
+        var result = await CreateResolver().ResolveValueSchemaAsync("page", "document", "colour");
+#pragma warning restore CS0618
+
+        result.ShouldBe(schema);
     }
 }

--- a/Umbraco.AI.Prompt/tests/Umbraco.AI.Prompt.Tests.Unit/Prompts/AIPromptSchemaCompatibilityTests.cs
+++ b/Umbraco.AI.Prompt/tests/Umbraco.AI.Prompt.Tests.Unit/Prompts/AIPromptSchemaCompatibilityTests.cs
@@ -1,0 +1,162 @@
+using System.Text.Json.Nodes;
+using Shouldly;
+using Umbraco.AI.Prompt.Core.Prompts;
+using Xunit;
+
+namespace Umbraco.AI.Prompt.Tests.Unit.Prompts;
+
+public class AIPromptSchemaCompatibilityTests
+{
+    [Fact]
+    public void IsStrictRepresentable_PlainStringSchema_ReturnsTrue()
+    {
+        var schema = new JsonObject { ["type"] = "string" };
+
+        AIPromptSchemaCompatibility.IsStrictRepresentable(schema).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsStrictRepresentable_WellTypedObjectSchema_ReturnsTrue()
+    {
+        // ColorPicker-style { value, label } — the schema the schema-driven wand is meant to keep.
+        var schema = new JsonObject
+        {
+            ["type"] = new JsonArray("object", "null"),
+            ["properties"] = new JsonObject
+            {
+                ["value"] = new JsonObject { ["type"] = new JsonArray("string", "null") },
+                ["label"] = new JsonObject { ["type"] = new JsonArray("string", "null") },
+            },
+        };
+
+        AIPromptSchemaCompatibility.IsStrictRepresentable(schema).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsStrictRepresentable_TypedArraySchema_ReturnsTrue()
+    {
+        var schema = new JsonObject
+        {
+            ["type"] = "array",
+            ["items"] = new JsonObject { ["type"] = "string" },
+        };
+
+        AIPromptSchemaCompatibility.IsStrictRepresentable(schema).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsStrictRepresentable_EmptySchema_ReturnsFalse()
+    {
+        // The block editor "any type" node: {} with no `type`.
+        AIPromptSchemaCompatibility.IsStrictRepresentable(new JsonObject()).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsStrictRepresentable_ArrayWithoutItems_ReturnsFalse()
+    {
+        var schema = new JsonObject { ["type"] = "array" };
+
+        AIPromptSchemaCompatibility.IsStrictRepresentable(schema).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsStrictRepresentable_NestedUnconstrainedNode_ReturnsFalse()
+    {
+        var schema = new JsonObject
+        {
+            ["type"] = "object",
+            ["properties"] = new JsonObject
+            {
+                ["alias"] = new JsonObject { ["type"] = "string" },
+                ["value"] = new JsonObject(), // unconstrained
+            },
+        };
+
+        AIPromptSchemaCompatibility.IsStrictRepresentable(schema).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsStrictRepresentable_EnumWithoutType_ReturnsTrue()
+    {
+        var schema = new JsonObject { ["enum"] = new JsonArray("a", "b") };
+
+        AIPromptSchemaCompatibility.IsStrictRepresentable(schema).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsStrictRepresentable_AnyOfWithRepresentableBranches_ReturnsTrue()
+    {
+        var schema = new JsonObject
+        {
+            ["anyOf"] = new JsonArray(
+                new JsonObject { ["type"] = "string" },
+                new JsonObject { ["type"] = "number" }),
+        };
+
+        AIPromptSchemaCompatibility.IsStrictRepresentable(schema).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsStrictRepresentable_AnyOfWithUnconstrainedBranch_ReturnsFalse()
+    {
+        var schema = new JsonObject
+        {
+            ["anyOf"] = new JsonArray(
+                new JsonObject { ["type"] = "string" },
+                new JsonObject()),
+        };
+
+        AIPromptSchemaCompatibility.IsStrictRepresentable(schema).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsStrictRepresentable_BlockListValueSchema_ReturnsFalse()
+    {
+        // Mirrors Umbraco CMS BlockJsonSchemaHelper output: the values[].value node is `{}`.
+        AIPromptSchemaCompatibility.IsStrictRepresentable(BlockListValueSchema()).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsStrictRepresentable_Null_ReturnsFalse()
+    {
+        AIPromptSchemaCompatibility.IsStrictRepresentable(null).ShouldBeFalse();
+    }
+
+    private static JsonObject BlockListValueSchema() => new()
+    {
+        ["$schema"] = "https://json-schema.org/draft/2020-12/schema",
+        ["type"] = new JsonArray("object", "null"),
+        ["properties"] = new JsonObject
+        {
+            ["contentData"] = new JsonObject
+            {
+                ["type"] = "array",
+                ["items"] = new JsonObject
+                {
+                    ["type"] = "object",
+                    ["required"] = new JsonArray("key", "contentTypeKey"),
+                    ["properties"] = new JsonObject
+                    {
+                        ["key"] = new JsonObject { ["type"] = "string" },
+                        ["contentTypeKey"] = new JsonObject { ["type"] = "string" },
+                        ["values"] = new JsonObject
+                        {
+                            ["type"] = "array",
+                            ["items"] = new JsonObject
+                            {
+                                ["type"] = "object",
+                                ["properties"] = new JsonObject
+                                {
+                                    ["alias"] = new JsonObject { ["type"] = "string" },
+                                    ["culture"] = new JsonObject { ["type"] = new JsonArray("string", "null") },
+                                    ["segment"] = new JsonObject { ["type"] = new JsonArray("string", "null") },
+                                    ["value"] = new JsonObject(), // Any type - depends on property editor
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    };
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.Collections.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.Collections.cs
@@ -185,4 +185,22 @@ public static partial class UmbracoBuilderExtensions
     /// </remarks>
     public static AIPropertyValueHandlerCollectionBuilder AIPropertyValueHandlers(this IUmbracoBuilder builder)
         => builder.WithCollectionBuilder<AIPropertyValueHandlerCollectionBuilder>();
+
+    /// <summary>
+    /// Gets the collection builder for AI simplified property value transformers.
+    /// </summary>
+    /// <param name="builder">The Umbraco builder.</param>
+    /// <returns>The AI simplified property value transformer collection builder.</returns>
+    /// <remarks>
+    /// Use this to add or exclude AI simplified property value transformers. Transformers are
+    /// auto-discovered via <see cref="Umbraco.Cms.Core.Composing.IDiscoverable"/> and registered
+    /// against an editor schema alias (e.g. <c>Umbraco.RichText</c>).
+    /// <code>
+    /// builder.AISimplifiedPropertyValueTransformers()
+    ///     .Add&lt;CustomEditorSimplifiedPropertyValueTransformer&gt;()
+    ///     .Exclude&lt;RichTextSimplifiedPropertyValueTransformer&gt;();
+    /// </code>
+    /// </remarks>
+    public static AISimplifiedPropertyValueTransformerCollectionBuilder AISimplifiedPropertyValueTransformers(this IUmbracoBuilder builder)
+        => builder.WithCollectionBuilder<AISimplifiedPropertyValueTransformerCollectionBuilder>();
 }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.cs
@@ -144,6 +144,10 @@ public static partial class UmbracoBuilderExtensions
         builder.AIPropertyValueHandlers()
             .Add(() => builder.TypeLoader.GetTypes<IAIPropertyValueHandler>());
 
+        // Simplified value transformers - simplified LLM schema + expand-to-write transform, per editor
+        builder.AISimplifiedPropertyValueTransformers()
+            .Add(() => builder.TypeLoader.GetTypes<IAISimplifiedPropertyValueTransformer>());
+
         // Tool scope infrastructure - auto-discover scopes via [AIToolScope] attribute
         builder.AIToolScopes()
             .Add(() => builder.TypeLoader.GetTypesWithAttribute<IAIToolScope, AIToolScopeAttribute>(cache: true));

--- a/Umbraco.AI/src/Umbraco.AI.Core/PropertyValueOperations/AISimplifiedPropertyValueTransformerCollection.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/PropertyValueOperations/AISimplifiedPropertyValueTransformerCollection.cs
@@ -1,0 +1,32 @@
+using Umbraco.Cms.Core.Composing;
+
+namespace Umbraco.AI.Core.PropertyValueOperations;
+
+/// <summary>
+/// A collection of simplified property value transformers, resolved per editor schema alias.
+/// </summary>
+/// <remarks>
+/// Transformers are auto-discovered via <see cref="IDiscoverable"/>. Use
+/// <see cref="AISimplifiedPropertyValueTransformerCollectionBuilder"/> to add or exclude transformers
+/// in a Composer.
+/// </remarks>
+public sealed class AISimplifiedPropertyValueTransformerCollection
+    : BuilderCollectionBase<IAISimplifiedPropertyValueTransformer>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AISimplifiedPropertyValueTransformerCollection"/> class.
+    /// </summary>
+    /// <param name="items">A factory function that returns the transformer instances.</param>
+    public AISimplifiedPropertyValueTransformerCollection(Func<IEnumerable<IAISimplifiedPropertyValueTransformer>> items)
+        : base(items)
+    { }
+
+    /// <summary>
+    /// Resolves the transformer registered for a given property editor schema alias.
+    /// </summary>
+    /// <param name="propertyEditorSchemaAlias">The schema alias (e.g. <c>Umbraco.RichText</c>).</param>
+    /// <returns>The transformer, or <c>null</c> if none is registered for the alias.</returns>
+    public IAISimplifiedPropertyValueTransformer? GetByEditorSchemaAlias(string propertyEditorSchemaAlias)
+        => this.FirstOrDefault(t =>
+            string.Equals(t.ForPropertyEditorSchemaAlias, propertyEditorSchemaAlias, StringComparison.OrdinalIgnoreCase));
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/PropertyValueOperations/AISimplifiedPropertyValueTransformerCollectionBuilder.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/PropertyValueOperations/AISimplifiedPropertyValueTransformerCollectionBuilder.cs
@@ -1,0 +1,20 @@
+using Umbraco.Cms.Core.Composing;
+
+namespace Umbraco.AI.Core.PropertyValueOperations;
+
+/// <summary>
+/// A lazy collection builder for simplified property value transformers.
+/// </summary>
+/// <remarks>
+/// Transformers are auto-discovered via <see cref="IDiscoverable"/> and registered against an editor
+/// schema alias (<see cref="IAISimplifiedPropertyValueTransformer.ForPropertyEditorSchemaAlias"/>). Use
+/// <see cref="LazyCollectionBuilderBase{TBuilder,TCollection,TItem}.Add{T}"/> to add transformers
+/// manually, or <see cref="LazyCollectionBuilderBase{TBuilder,TCollection,TItem}.Exclude{T}"/> to
+/// exclude auto-discovered transformers.
+/// </remarks>
+public class AISimplifiedPropertyValueTransformerCollectionBuilder
+    : LazyCollectionBuilderBase<AISimplifiedPropertyValueTransformerCollectionBuilder, AISimplifiedPropertyValueTransformerCollection, IAISimplifiedPropertyValueTransformer>
+{
+    /// <inheritdoc />
+    protected override AISimplifiedPropertyValueTransformerCollectionBuilder This => this;
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/PropertyValueOperations/IAISimplifiedPropertyValueTransformer.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/PropertyValueOperations/IAISimplifiedPropertyValueTransformer.cs
@@ -1,0 +1,76 @@
+using System.Text.Json.Nodes;
+using Umbraco.Cms.Core.Composing;
+
+namespace Umbraco.AI.Core.PropertyValueOperations;
+
+/// <summary>
+/// Provides a <em>simplified</em>, strict-representable LLM value contract for a specific Umbraco
+/// property editor: the JSON Schema the LLM should generate the property value against, plus the
+/// transform that expands the LLM's simplified value into the editor's real write value.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Some editors expose a CMS write schema that cannot be expressed in a provider's <em>strict</em>
+/// structured-output subset (e.g. the rich-text / block editors, whose nested block value is an
+/// unconstrained <c>{}</c> node). For those, a consumer that requires strict output (such as the AI
+/// Prompt schema-driven wand) cannot use the write schema directly. A transformer offers an
+/// alternative: a simple schema the LLM <em>can</em> satisfy (e.g. rich-text as a plain markup
+/// string), and a transform back to the editor's write value (e.g. <c>{ markup, blocks }</c>).
+/// </para>
+/// <para>
+/// The transform is <strong>total and idempotent</strong>: it accepts either a value the LLM
+/// produced against <see cref="GetSimplifiedSchemaAsync"/> <em>or</em> a value already in the
+/// editor's write shape (which it returns unchanged). This lets any producer feed it safely, and is
+/// what allows different consumers to present the simplified or the full schema by capability while
+/// sharing one normalisation path.
+/// </para>
+/// <para>
+/// Transformers are auto-discovered via <see cref="IDiscoverable"/>, registered through
+/// <c>builder.AISimplifiedPropertyValueTransformers()</c>, and resolved by editor schema alias
+/// (<see cref="ForPropertyEditorSchemaAlias"/>). They are pure — no database access.
+/// </para>
+/// </remarks>
+public interface IAISimplifiedPropertyValueTransformer : IDiscoverable
+{
+    /// <summary>
+    /// Gets the property editor schema alias this transformer applies to (e.g.
+    /// <c>Umbraco.RichText</c>).
+    /// </summary>
+    string ForPropertyEditorSchemaAlias { get; }
+
+    /// <summary>
+    /// Gets the simplified, strict-representable JSON Schema (draft 2020-12) the LLM should generate
+    /// the property value against.
+    /// </summary>
+    /// <param name="dataTypeKey">
+    /// The data type key, allowing the transformer to tailor the schema to the data type's
+    /// configuration.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The simplified schema, or <c>null</c> to opt out for this data type (the caller then falls
+    /// back to the editor's write schema).
+    /// </returns>
+    Task<JsonNode?> GetSimplifiedSchemaAsync(Guid dataTypeKey, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Transforms a value the LLM produced against <see cref="GetSimplifiedSchemaAsync"/> into the
+    /// editor's real write value. Pure; runs server-side.
+    /// </summary>
+    /// <param name="simplifiedValue">
+    /// The value the LLM generated against the simplified schema. Defensively, an already-write-shaped
+    /// value should be returned unchanged.
+    /// </param>
+    /// <param name="currentValue">
+    /// The property's existing write-shape value (may be <c>null</c>), so the transform can preserve
+    /// parts of it — e.g. keep a rich-text property's existing inline blocks.
+    /// </param>
+    /// <param name="dataTypeKey">The data type key.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The editor's write value.</returns>
+    Task<JsonNode?> TransformToWriteValueAsync(
+        JsonNode? simplifiedValue,
+        JsonNode? currentValue,
+        Guid dataTypeKey,
+        CancellationToken cancellationToken = default);
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/PropertyValueOperations/Transformers/RichTextSimplifiedPropertyValueTransformer.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/PropertyValueOperations/Transformers/RichTextSimplifiedPropertyValueTransformer.cs
@@ -1,0 +1,67 @@
+using System.Text.Json.Nodes;
+using CmsConstants = Umbraco.Cms.Core.Constants;
+
+namespace Umbraco.AI.Core.PropertyValueOperations.Transformers;
+
+/// <summary>
+/// Simplified value transformer for the <c>Umbraco.RichText</c> editor.
+/// </summary>
+/// <remarks>
+/// The rich-text write value is <c>{ markup, blocks }</c>, where <c>blocks</c> contains an
+/// unconstrained per-property value node that a strict structured-output provider rejects. This
+/// transformer offers the LLM a plain markup <b>string</b> instead, and wraps it back into the write
+/// shape — preserving any existing inline blocks from the current value.
+/// </remarks>
+public sealed class RichTextSimplifiedPropertyValueTransformer : IAISimplifiedPropertyValueTransformer
+{
+    private const string MarkupPropertyName = "markup";
+    private const string BlocksPropertyName = "blocks";
+
+    // The blocks layout dictionary is keyed by the RTE editor alias (CMS RichTextBlockValue.PropertyEditorAlias).
+    private const string BlocksLayoutKey = CmsConstants.PropertyEditors.Aliases.RichText;
+
+    /// <inheritdoc />
+    public string ForPropertyEditorSchemaAlias => CmsConstants.PropertyEditors.Aliases.RichText;
+
+    /// <inheritdoc />
+    public Task<JsonNode?> GetSimplifiedSchemaAsync(Guid dataTypeKey, CancellationToken cancellationToken = default)
+        => Task.FromResult<JsonNode?>(new JsonObject
+        {
+            ["type"] = "string",
+            ["description"] = "The rich-text body as an HTML markup string.",
+        });
+
+    /// <inheritdoc />
+    public Task<JsonNode?> TransformToWriteValueAsync(
+        JsonNode? simplifiedValue,
+        JsonNode? currentValue,
+        Guid dataTypeKey,
+        CancellationToken cancellationToken = default)
+    {
+        // Defensive: a value already in write shape (object with a markup property) passes through.
+        if (simplifiedValue is JsonObject writeShaped && writeShaped.ContainsKey(MarkupPropertyName))
+        {
+            return Task.FromResult<JsonNode?>(writeShaped.DeepClone());
+        }
+
+        var markup = simplifiedValue switch
+        {
+            JsonValue value when value.TryGetValue<string>(out var text) => text,
+            null => string.Empty,
+            _ => simplifiedValue.ToString(),
+        };
+
+        // Preserve existing inline blocks when the current value carries them; otherwise start empty.
+        // Guard the type: a non-object current value (e.g. a legacy plain-string RTE value) must not throw.
+        JsonNode blocks = currentValue is JsonObject currentObject
+            && currentObject[BlocksPropertyName] is JsonObject currentBlocks
+                ? currentBlocks.DeepClone()
+                : BlockEnvelopeOps.Empty(BlocksLayoutKey);
+
+        return Task.FromResult<JsonNode?>(new JsonObject
+        {
+            [MarkupPropertyName] = markup,
+            [BlocksPropertyName] = blocks,
+        });
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/adapters/block.adapter.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/adapters/block.adapter.ts
@@ -16,6 +16,8 @@ import type {
     UaiSerializedProperty,
 } from "../types.js";
 import { resolveAndPrepareValue } from "../value-preparers/resolver.js";
+import { resolveEditorSchemaAlias } from "../resolve-editor-schema-alias.js";
+import type { UmbControllerHost } from "@umbraco-cms/backoffice/controller-api";
 import { pickValueForVariant, type ActiveVariantInfo } from "./variant-selection.js";
 
 /**
@@ -274,8 +276,11 @@ export class UaiBlockAdapter implements UaiEntityAdapterApi {
         const values = ctx.content.getValues() ?? [];
         const existingValue = values.find((v) => v.alias === propertyAlias);
 
-        // Prepare value for the target editor type
-        const valueToSet = await resolveAndPrepareValue(change.value, existingValue?.editorAlias, existingValue?.value);
+        // Prepare value for the target editor type. Resolve the editor alias (falling back to the
+        // data type when the field is empty and has no existing value entry) so preparers still run.
+        const editorAlias = await resolveEditorSchemaAlias(
+            ctx as unknown as UmbControllerHost, existingValue?.editorAlias, property?.dataType?.unique);
+        const valueToSet = await resolveAndPrepareValue(change.value, editorAlias, existingValue?.value);
 
         try {
             await ctx.content.setPropertyValue(propertyAlias, valueToSet, variantId);

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/adapters/document.adapter.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/adapters/document.adapter.ts
@@ -18,6 +18,8 @@ import type {
     UaiSerializedProperty,
 } from "../types.js";
 import { resolveAndPrepareValue } from "../value-preparers/resolver.js";
+import { resolveEditorSchemaAlias } from "../resolve-editor-schema-alias.js";
+import type { UmbControllerHost } from "@umbraco-cms/backoffice/controller-api";
 import { pickValueForVariant, type ActiveVariantInfo } from "./variant-selection.js";
 
 // Supported text-based property editors for initial implementation
@@ -350,8 +352,11 @@ export class UaiDocumentAdapter implements UaiEntityAdapterApi {
         // Build variant ID from culture/segment (undefined = invariant)
         const variantId = new UmbVariantId(change.culture ?? null, change.segment ?? null);
 
-        // Prepare value for the target editor type
-        const valueToSet = await resolveAndPrepareValue(change.value, existingValue?.editorAlias, existingValue?.value);
+        // Prepare value for the target editor type. Resolve the editor alias (falling back to the
+        // data type when the field is empty and has no existing value entry) so preparers still run.
+        const editorAlias = await resolveEditorSchemaAlias(
+            ctx as unknown as UmbControllerHost, existingValue?.editorAlias, property?.dataType?.unique);
+        const valueToSet = await resolveAndPrepareValue(change.value, editorAlias, existingValue?.value);
 
         try {
             await ctx.setPropertyValue(propertyAlias, valueToSet, variantId);

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/adapters/media.adapter.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/adapters/media.adapter.ts
@@ -23,6 +23,8 @@ import type {
     UaiSerializedProperty,
 } from "../types.js";
 import { resolveAndPrepareValue } from "../value-preparers/resolver.js";
+import { resolveEditorSchemaAlias } from "../resolve-editor-schema-alias.js";
+import type { UmbControllerHost } from "@umbraco-cms/backoffice/controller-api";
 
 /**
  * Property editor aliases that represent the binary payload of a media item.
@@ -303,7 +305,10 @@ export class UaiMediaAdapter implements UaiEntityAdapterApi {
         // surfaces the right variant id without changes here.
         const variantId = new UmbVariantId(change.culture ?? null, change.segment ?? null);
 
-        const valueToSet = await resolveAndPrepareValue(change.value, existingValue?.editorAlias, existingValue?.value);
+        // Resolve the editor alias (falling back to the data type when the field is empty) so preparers still run.
+        const editorAlias = await resolveEditorSchemaAlias(
+            ctx as unknown as UmbControllerHost, existingValue?.editorAlias, property?.dataType?.unique);
+        const valueToSet = await resolveAndPrepareValue(change.value, editorAlias, existingValue?.value);
 
         try {
             await ctx.setPropertyValue(propertyAlias, valueToSet, variantId);

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/resolve-editor-schema-alias.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/resolve-editor-schema-alias.ts
@@ -1,0 +1,38 @@
+import type { UmbControllerHost } from "@umbraco-cms/backoffice/controller-api";
+import { UmbDataTypeItemRepository } from "@umbraco-cms/backoffice/data-type";
+
+/**
+ * Resolves the property editor schema alias for a property value being applied.
+ *
+ * Value preparers are matched by editor schema alias. The alias is normally taken from the existing
+ * value entry, but a property that currently has NO value (an empty field) has no such entry — so we
+ * fall back to resolving it from the property's data type via the data-type item repository. Without
+ * this, preparers (e.g. rich-text / date-time) would be skipped when writing into an empty field.
+ *
+ * @param host The controller host (the workspace context) used to instantiate the repository.
+ * @param existingEditorAlias The editor alias from the existing value entry, if any.
+ * @param dataTypeUnique The property's data type unique, used as the fallback lookup key.
+ * @returns The editor schema alias, or `undefined` when it cannot be resolved.
+ */
+export async function resolveEditorSchemaAlias(
+    host: UmbControllerHost,
+    existingEditorAlias: string | undefined,
+    dataTypeUnique: string | undefined,
+): Promise<string | undefined> {
+    if (existingEditorAlias) {
+        return existingEditorAlias;
+    }
+
+    if (!dataTypeUnique) {
+        return undefined;
+    }
+
+    try {
+        const repository = new UmbDataTypeItemRepository(host);
+        const { data } = await repository.requestItems([dataTypeUnique]);
+        return data?.[0]?.propertyEditorSchemaAlias;
+    } catch {
+        // A lookup failure is non-fatal — fall back to no preparer (raw value passthrough).
+        return undefined;
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/PropertyValueOperations/RichTextSimplifiedPropertyValueTransformerTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/PropertyValueOperations/RichTextSimplifiedPropertyValueTransformerTests.cs
@@ -90,4 +90,28 @@ public class RichTextSimplifiedPropertyValueTransformerTests
         var obj = result.ShouldBeOfType<JsonObject>();
         obj["markup"]!.GetValue<string>().ShouldBe(string.Empty);
     }
+
+    // Regression for issue #249: replays the exact data from a live execute request/response to prove
+    // the server transform reproduces the response value, and that an empty current-blocks envelope
+    // (layout: {}) is PRESERVED verbatim rather than replaced by the Empty("Umbraco.RichText") default.
+    [Fact]
+    public async Task TransformToWriteValueAsync_PreservesCurrentEmptyBlocksEnvelope_Issue249()
+    {
+        // errorMessage's current value, verbatim from the live request's serialized entity context.
+        var currentValue = JsonNode.Parse(
+            "{\"markup\":\"<h2>Error</h2>\\n<p>Sorry there was a problem with submitting the form. Please try again.</p>\"," +
+            "\"blocks\":{\"layout\":{},\"contentData\":[],\"settingsData\":[],\"expose\":[]}}");
+        var llmValue = JsonValue.Create("There was an issue with submitting the form; please try again.");
+
+        var result = await _transformer.TransformToWriteValueAsync(llmValue, currentValue, Guid.NewGuid());
+
+        // Byte-for-byte match with the value the live server returned for this option.
+        var expected = JsonNode.Parse(
+            "{\"markup\":\"There was an issue with submitting the form; please try again.\"," +
+            "\"blocks\":{\"layout\":{},\"contentData\":[],\"settingsData\":[],\"expose\":[]}}")!.ToJsonString();
+        result!.ToJsonString().ShouldBe(expected);
+
+        // The preserved layout is empty ({}), NOT the no-current-value default which keys by editor alias.
+        result["blocks"]!["layout"]!.AsObject().Count.ShouldBe(0);
+    }
 }

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/PropertyValueOperations/RichTextSimplifiedPropertyValueTransformerTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/PropertyValueOperations/RichTextSimplifiedPropertyValueTransformerTests.cs
@@ -1,0 +1,93 @@
+using System.Text.Json.Nodes;
+using Umbraco.AI.Core.PropertyValueOperations.Transformers;
+
+namespace Umbraco.AI.Tests.Unit.PropertyValueOperations;
+
+public class RichTextSimplifiedPropertyValueTransformerTests
+{
+    private const string LayoutKey = "Umbraco.RichText";
+
+    private readonly RichTextSimplifiedPropertyValueTransformer _transformer = new();
+
+    [Fact]
+    public async Task GetSimplifiedSchemaAsync_ReturnsPlainStringSchema()
+    {
+        var schema = await _transformer.GetSimplifiedSchemaAsync(Guid.NewGuid());
+
+        schema.ShouldBeOfType<JsonObject>();
+        schema!["type"]!.GetValue<string>().ShouldBe("string");
+    }
+
+    [Fact]
+    public async Task TransformToWriteValueAsync_MarkupString_WrapsWithEmptyBlocks()
+    {
+        var result = await _transformer.TransformToWriteValueAsync(JsonValue.Create("<p>hi</p>"), currentValue: null, Guid.NewGuid());
+
+        var obj = result.ShouldBeOfType<JsonObject>();
+        obj["markup"]!.GetValue<string>().ShouldBe("<p>hi</p>");
+        var blocks = obj["blocks"]!.AsObject();
+        blocks["layout"]!.AsObject().ContainsKey(LayoutKey).ShouldBeTrue();
+        blocks["layout"]![LayoutKey]!.AsArray().Count.ShouldBe(0);
+        blocks["contentData"]!.AsArray().Count.ShouldBe(0);
+        blocks["settingsData"]!.AsArray().Count.ShouldBe(0);
+        blocks["expose"]!.AsArray().Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task TransformToWriteValueAsync_WithCurrentBlocks_PreservesBlocksAndReplacesMarkup()
+    {
+        var current = new JsonObject
+        {
+            ["markup"] = "<p>old</p>",
+            ["blocks"] = new JsonObject
+            {
+                ["layout"] = new JsonObject { [LayoutKey] = new JsonArray(new JsonObject { ["contentKey"] = "abc" }) },
+                ["contentData"] = new JsonArray(new JsonObject { ["key"] = "abc" }),
+                ["settingsData"] = new JsonArray(),
+                ["expose"] = new JsonArray(),
+            },
+        };
+
+        var result = await _transformer.TransformToWriteValueAsync(JsonValue.Create("<p>new</p>"), current, Guid.NewGuid());
+
+        var obj = result.ShouldBeOfType<JsonObject>();
+        obj["markup"]!.GetValue<string>().ShouldBe("<p>new</p>");
+        obj["blocks"]!["contentData"]!.AsArray().Count.ShouldBe(1);
+        obj["blocks"]!["layout"]![LayoutKey]!.AsArray().Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task TransformToWriteValueAsync_AlreadyWriteShaped_PassesThrough()
+    {
+        var writeShaped = new JsonObject
+        {
+            ["markup"] = "<p>x</p>",
+            ["blocks"] = new JsonObject { ["layout"] = new JsonObject { [LayoutKey] = new JsonArray() } },
+        };
+
+        var result = await _transformer.TransformToWriteValueAsync(writeShaped, currentValue: null, Guid.NewGuid());
+
+        var obj = result.ShouldBeOfType<JsonObject>();
+        obj["markup"]!.GetValue<string>().ShouldBe("<p>x</p>");
+    }
+
+    [Fact]
+    public async Task TransformToWriteValueAsync_NonObjectCurrentValue_DoesNotThrowAndUsesEmptyBlocks()
+    {
+        // A legacy plain-string current value must not throw on `currentValue["blocks"]`.
+        var result = await _transformer.TransformToWriteValueAsync(JsonValue.Create("<p>hi</p>"), JsonValue.Create("legacy string"), Guid.NewGuid());
+
+        var obj = result.ShouldBeOfType<JsonObject>();
+        obj["markup"]!.GetValue<string>().ShouldBe("<p>hi</p>");
+        obj["blocks"]!["contentData"]!.AsArray().Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task TransformToWriteValueAsync_NullValue_ProducesEmptyMarkup()
+    {
+        var result = await _transformer.TransformToWriteValueAsync(simplifiedValue: null, currentValue: null, Guid.NewGuid());
+
+        var obj = result.ShouldBeOfType<JsonObject>();
+        obj["markup"]!.GetValue<string>().ShouldBe(string.Empty);
+    }
+}


### PR DESCRIPTION
## Summary

v17 backport of #250. Fixes #249 — executing an AI Prompt against a **rich-text (`Umbraco.RichText` / TipTap)** property failed with an opaque HTTP 400 (`invalid_json_schema`) from strict providers like OpenAI. (Reported as "Block List/Grid", but the reporter's real case was RichText — whose write schema embeds the same block structure.)

The schema-driven wand constrains strict structured output to the target property's CMS **write** schema. RichText's `blocks` embeds an intentionally unconstrained `values[].value` node (`{}`, from CMS `BlockJsonSchemaHelper`), which has **no faithful equivalent** in OpenAI's strict subset → rejected before generation.

> **Note:** the original commit on this branch took a *fail-fast* approach; after design review it evolved into the general transformer below. The `AIPromptSchemaCompatibility` guard from that commit is retained as a fallback.

## Approach — simplified value transformers

New general server-side abstraction **`IAISimplifiedPropertyValueTransformer`** (Umbraco.AI.Core, discovered like `IAIPropertyValueHandler`): a per-editor **simplified, strict-representable LLM schema** plus a **total/idempotent transform** back to the editor's write value.

`RichTextSimplifiedPropertyValueTransformer` offers the LLM a plain markup **string** and wraps the result into `{ markup, blocks }`, **preserving existing inline blocks** from the current value.

**Consumer chooses the representation by capability** (no regression):
| Consumer | Schema presented |
|---|---|
| **Prompt** (one-shot, strict) | the **simplified** schema when a transformer is registered; else the write schema; else the string model |
| **Agent** (loose, iterative, `add_item` handlers) | **unchanged** — keeps the full write schema so block authoring is preserved |

## What `AIPromptService` now does

- Uses the simplified schema when a transformer exists, and runs the transform **server-side** so `ValueChange.Value` is the write shape, while `DisplayValue` stays the simplified (markup) value for the preview.
- Reads the current write-shape value from the **serialized entity/element already in the runtime context** to preserve existing blocks — **no new request field / client plumbing**.
- Runs the `IsStrictRepresentable` guard on whichever schema is used (incl. a simplified one); block editors (no transformer) still fail fast rather than 400.
- Runs **plain-text output mode** for `DisplayMode == TipTapTool` prompts (decided server-side), so the in-editor toolbar keeps receiving a string.
- Surfaces transform failures as a clean 400 and isolates per-option failures.
- Resolver: additive `ResolvePropertyValueSchemaAsync`; old `ResolveValueSchemaAsync` kept and marked `[Obsolete("… Will be removed in v19")]` (v17 line: current major + 2).

## Frontend

`applyValueChange` (document/block/media adapters) resolves the editor alias from the data-type item repository when a field is **empty**, so preparers still run into empty fields.

## Validation

- Builds green; unit tests pass (Umbraco.AI **936**, Umbraco.AI.Prompt **84**), incl. the RichText transformer suite (with a #249 regression replaying a live request/response byte-for-byte) and resolver tests.
- End-to-end validated on v18 (#250) against a real OpenAI key: RichText prompt → no 400, options generated, editor updated, `{ markup, blocks }` with existing blocks preserved.

## Not in scope (follow-ups)

- Agent adoption of the transform at the dispatcher `SetValue` leaf (additive).
- Moving DateTime normalisation server-side + preparer cleanup.
- "Proper" recursive block-content generation for the Prompt path (intractable strict schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)