### PR TITLE
fix(agent): Apply profile Temperature and MaxTokens to agent runtime (#256) [v17 backport]

### DIFF
--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Chat/AIAgentFactory.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Chat/AIAgentFactory.cs
@@ -164,7 +164,8 @@ internal sealed class AIAgentFactory : IAIAgentFactory
         }
 
         // Get profile - use default Chat profile if not specified
-        var chatClient = await CreateChatClientAsync(agent, cancellationToken);
+        var profile = await ResolveProfileAsync(agent, cancellationToken);
+        var chatClient = await _chatClientFactory.CreateClientAsync(profile, cancellationToken);
 
         var config = agent.GetStandardConfig();
 
@@ -175,13 +176,20 @@ internal sealed class AIAgentFactory : IAIAgentFactory
 
         // Build ChatOptions — always needed for instructions and tools,
         // plus output schema response format if configured.
+        // Inference settings (Temperature, MaxOutputTokens) are copied from the
+        // resolved profile so the agent runtime honors the same profile settings as
+        // the core chat path (AIChatService.MergeOptions); otherwise MaxOutputTokens
+        // reaches the provider as null and responses truncate at the SDK default.
         // When approval is required, disable multi-call turns so each destructive
         // tool call is presented individually for approval (MEAI limitation).
+        var chatSettings = profile.Settings as AIChatProfileSettings;
         var chatOptions = new ChatOptions
         {
             Instructions = config?.Instructions,
             Tools = tools,
             AllowMultipleToolCalls = requiresApproval ? false : null,
+            Temperature = chatSettings?.Temperature,
+            MaxOutputTokens = chatSettings?.MaxTokens,
         };
 
         if (config?.OutputSchema is JsonElement schema)
@@ -217,22 +225,17 @@ internal sealed class AIAgentFactory : IAIAgentFactory
         return mafWorkflow.AsAIAgent(config.WorkflowId);
     }
 
-    private async Task<IChatClient> CreateChatClientAsync(
+    private async Task<AIProfile> ResolveProfileAsync(
         UmbracoAIAgent agent,
         CancellationToken cancellationToken)
     {
-        AIProfile profile;
         if (agent.ProfileId.HasValue)
         {
-            profile = await _profileService.GetProfileAsync(agent.ProfileId.Value, cancellationToken)
+            return await _profileService.GetProfileAsync(agent.ProfileId.Value, cancellationToken)
                 ?? throw new InvalidOperationException($"Profile with ID '{agent.ProfileId}' not found.");
         }
-        else
-        {
-            profile = await _profileService.GetDefaultProfileAsync(AICapability.Chat, cancellationToken);
-        }
 
-        return await _chatClientFactory.CreateClientAsync(profile, cancellationToken);
+        return await _profileService.GetDefaultProfileAsync(AICapability.Chat, cancellationToken);
     }
 
     /// <summary>

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/Chat/AIAgentFactoryApprovalTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/Chat/AIAgentFactoryApprovalTests.cs
@@ -148,7 +148,39 @@ public class AIAgentFactoryApprovalTests
         chatOptions.AllowMultipleToolCalls.ShouldBeNull();
     }
 
-    private static AIAgentFactory CreateFactory(IEnumerable<IAITool> tools)
+    [Fact]
+    public async Task CreateAgentAsync_CopiesTemperatureAndMaxTokensFromProfileSettings()
+    {
+        IAITool[] tools = [new TestTool { Id = "get-thing", Name = "get-thing", IsDestructive = false }];
+
+        var factory = CreateFactory(
+            tools,
+            new AIChatProfileSettings { Temperature = 0.5f, MaxTokens = 64000 });
+        var agent = CreateAgent(["get-thing"]);
+
+        var result = await factory.CreateAgentAsync(agent);
+
+        var chatOptions = ExtractChatOptions(result);
+        chatOptions!.Temperature.ShouldBe(0.5f);
+        chatOptions.MaxOutputTokens.ShouldBe(64000);
+    }
+
+    [Fact]
+    public async Task CreateAgentAsync_WithNoChatSettings_LeavesInferenceOptionsNull()
+    {
+        IAITool[] tools = [new TestTool { Id = "get-thing", Name = "get-thing", IsDestructive = false }];
+
+        var factory = CreateFactory(tools);
+        var agent = CreateAgent(["get-thing"]);
+
+        var result = await factory.CreateAgentAsync(agent);
+
+        var chatOptions = ExtractChatOptions(result);
+        chatOptions!.Temperature.ShouldBeNull();
+        chatOptions.MaxOutputTokens.ShouldBeNull();
+    }
+
+    private static AIAgentFactory CreateFactory(IEnumerable<IAITool> tools, IAIProfileSettings? profileSettings = null)
     {
         var toolCollection = new AIToolCollection(() => tools);
         var scopeCollection = new AIToolScopeCollection(() => []);
@@ -175,6 +207,7 @@ public class AIAgentFactoryApprovalTests
             Alias = "test",
             Name = "Test",
             ConnectionId = Guid.Empty,
+            Settings = profileSettings,
         };
 
         var profileServiceMock = new Mock<IAIProfileService>();


### PR DESCRIPTION
Fixes #256 on the v17 line. Backport of #257 (v18).

## Problem

When running an agent, the profile's chat settings (`MaxTokens`, `Temperature`) were not applied to the request. `AIAgentFactory` built its own `ChatOptions` with only `Instructions`, `Tools` and `AllowMultipleToolCalls`, so `MaxOutputTokens` reached the provider as `null`. On the Anthropic path this capped agent responses at the SDK default output limit (~1024 tokens, finish reason `Length`) regardless of the configured profile value. Reported against 17.1.0.

## Fix

- `AIAgentFactory.CreateChatClientAsync` → refactored to `ResolveProfileAsync`, returning the resolved `AIProfile` so it's resolved once and reused.
- `CreateStandardAgentAsync` now reads `profile.Settings as AIChatProfileSettings` and copies `Temperature` and `MaxTokens` into `ChatOptions.Temperature` / `ChatOptions.MaxOutputTokens`, mirroring `AIChatService.MergeOptions`.

## Tests

Added two unit tests to `AIAgentFactoryApprovalTests` (identical to the v18 change):
- `CreateAgentAsync_CopiesTemperatureAndMaxTokensFromProfileSettings`
- `CreateAgentAsync_WithNoChatSettings_LeavesInferenceOptionsNull`

All tests in the file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)