### PR TITLE
fix(prompt): Serialize correct culture in split-view property actions

### DIFF
--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/prompt/property-actions/prompt-insert.property-action.ts
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/prompt/property-actions/prompt-insert.property-action.ts
@@ -241,23 +241,31 @@ export class UaiPromptInsertPropertyAction extends UmbPropertyActionBase<UaiProm
 
         const contextItems: UaiPromptContextItem[] = [];
 
+        // Derive the active variant from the property context so split-view serializes
+        // the correct pane's values. The property context's variantId reflects the pane
+        // the action was triggered from; without this, getActiveVariants()[0] always wins.
+        const variantId = this.#propertyContext?.getVariantId?.();
+        const activeVariant = variantId
+            ? { culture: variantId.culture ?? null, segment: variantId.segment ?? null }
+            : undefined;
+
         try {
             if (this.#isBlockWorkspace) {
-                // Block: serialize block as element context
+                // Block: serialize block as element context (block derives its own variant via getVariantId)
                 const serializedElement = await adapter.serializeForLlm(this.#workspaceContext);
                 contextItems.push(createElementContextItem(serializedElement));
 
-                // Serialize parent document as entity context
+                // Serialize parent document as entity context, passing the active variant override
                 if (this.#parentDocumentContext) {
                     const docAdapter = await resolveEntityAdapterByType("document");
                     if (docAdapter?.canHandle(this.#parentDocumentContext)) {
-                        const serializedEntity = await docAdapter.serializeForLlm(this.#parentDocumentContext);
+                        const serializedEntity = await docAdapter.serializeForLlm(this.#parentDocumentContext, activeVariant);
                         contextItems.push(createEntityContextItem(serializedEntity));
                     }
                 }
             } else {
-                // Document/media: serialize as entity context (as before)
-                const serializedEntity = await adapter.serializeForLlm(this.#workspaceContext);
+                // Document/media: serialize as entity context, passing the active variant override
+                const serializedEntity = await adapter.serializeForLlm(this.#workspaceContext, activeVariant);
                 contextItems.push(createEntityContextItem(serializedEntity));
             }
         } catch {

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/prompt/tiptap/prompts-tiptap-toolbar.element.ts
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/prompt/tiptap/prompts-tiptap-toolbar.element.ts
@@ -63,6 +63,7 @@ export class UaiPromptsTiptapToolbarElement extends UmbLitElement {
 
     #propertyAlias: string | null = null;
     #propertyEditorUiAlias: string | null = null;
+    #propertyContext?: typeof UMB_PROPERTY_CONTEXT.TYPE;
     #contentTypeAliases: string[] = [];
     #workspaceContext?: WorkspaceContextLike;
     #parentDocumentContext?: WorkspaceContextLike;
@@ -74,6 +75,7 @@ export class UaiPromptsTiptapToolbarElement extends UmbLitElement {
 
         this.consumeContext(UMB_PROPERTY_CONTEXT, (context) => {
             if (!context) return;
+            this.#propertyContext = context;
             this.#propertyAlias = context.getAlias() ?? null;
             this.observe(context.editorManifest, (manifest) => {
                 this.#propertyEditorUiAlias = manifest?.alias ?? null;
@@ -324,26 +326,34 @@ export class UaiPromptsTiptapToolbarElement extends UmbLitElement {
 
         const contextItems: UaiPromptContextItem[] = [];
 
+        // Derive the active variant from the property context so split-view serializes
+        // the correct pane's values. The property context's variantId reflects the pane
+        // the toolbar lives in; without this, getActiveVariants()[0] always wins.
+        const variantId = this.#propertyContext?.getVariantId?.();
+        const activeVariant = variantId
+            ? { culture: variantId.culture ?? null, segment: variantId.segment ?? null }
+            : undefined;
+
         try {
             const adapter = await resolveEntityAdapterByType(entityType);
             if (!adapter?.canHandle(this.#workspaceContext)) return undefined;
 
             if (this.#isBlockWorkspace) {
-                // Block: serialize block as element context
+                // Block: serialize block as element context (block derives its own variant via getVariantId)
                 const serializedElement = await adapter.serializeForLlm(this.#workspaceContext);
                 contextItems.push(createElementContextItem(serializedElement));
 
-                // Serialize parent document as entity context
+                // Serialize parent document as entity context, passing the active variant override
                 if (this.#parentDocumentContext) {
                     const docAdapter = await resolveEntityAdapterByType('document');
                     if (docAdapter?.canHandle(this.#parentDocumentContext)) {
-                        const serializedEntity = await docAdapter.serializeForLlm(this.#parentDocumentContext);
+                        const serializedEntity = await docAdapter.serializeForLlm(this.#parentDocumentContext, activeVariant);
                         contextItems.push(createEntityContextItem(serializedEntity));
                     }
                 }
             } else {
-                // Document/media: serialize as entity context
-                const serializedEntity = await adapter.serializeForLlm(this.#workspaceContext);
+                // Document/media: serialize as entity context, passing the active variant override
+                const serializedEntity = await adapter.serializeForLlm(this.#workspaceContext, activeVariant);
                 contextItems.push(createEntityContextItem(serializedEntity));
             }
         } catch {

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/adapters/document.adapter.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/adapters/document.adapter.ts
@@ -87,11 +87,8 @@ interface DocumentWorkspaceContextLike {
 /**
  * Resolve the active variant from the workspace's split-view manager.
  * Returns null when none can be determined (invariant document, missing API,
- * mocked context). When multiple variants are focused (split view), the first
- * is used since the AI prompt is triggered against a single editing context.
- *
- * TODO: revisit when invoking from the second pane of a split view —
- * `getActiveVariants()[0]` always picks the leftmost pane today.
+ * mocked context). Falls back to the first active variant when the caller
+ * does not supply an override (single-pane editing, invariant content).
  */
 function getActiveVariant(ctx: DocumentWorkspaceContextLike): ActiveVariantInfo | null {
     const active = ctx.splitView?.getActiveVariants?.();
@@ -220,13 +217,16 @@ export class UaiDocumentAdapter implements UaiEntityAdapterApi {
      * for properties that don't vary, so prompt template variables like
      * `{{header}}` resolve to the active culture's value.
      */
-    async serializeForLlm(workspaceContext: unknown): Promise<UaiSerializedEntity> {
+    async serializeForLlm(
+        workspaceContext: unknown,
+        activeVariant?: { culture: string | null; segment: string | null },
+    ): Promise<UaiSerializedEntity> {
         const ctx = workspaceContext as DocumentWorkspaceContextLike;
 
         const unique = ctx.getUnique();
         const contentType = ctx.getContentTypeUnique();
         const values = ctx.getValues() ?? [];
-        const active = getActiveVariant(ctx);
+        const active = activeVariant ?? getActiveVariant(ctx);
 
         // Pick the active variant's name when available so the LLM sees the
         // name from the variant the editor is on, matching the property values.

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/types.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/entity-adapter/types.ts
@@ -165,8 +165,13 @@ export interface UaiEntityAdapterApi extends UmbApi {
 
     /**
      * Serialize the entity for LLM context.
+     * @param activeVariant When provided, overrides variant detection in the adapter so values are
+     * read from the correct culture/segment (e.g. the right pane in split-view).
      */
-    serializeForLlm(workspaceContext: unknown): Promise<UaiSerializedEntity>;
+    serializeForLlm(
+        workspaceContext: unknown,
+        activeVariant?: { culture: string | null; segment: string | null },
+    ): Promise<UaiSerializedEntity>;
 
     /**
      * Apply a value change to the workspace (staged, not persisted).


### PR DESCRIPTION
## What

Recovers the split-view culture serialization fix that was lost during the v17 `2026.06.1` hotfix. When an AI Prompt Property Action or TipTap toolbar prompt is invoked from the **right pane** of a split-view editor, the document adapter was always reading `{{currentValue}}` and other property values from the **left** pane, because `splitView.getActiveVariants()[0]` always resolves the leftmost variant.

The property context already knows which pane the action came from via `getVariantId()`. That is now passed as an `activeVariant` override to `serializeForLlm`, so the document adapter picks values for the correct culture instead of hardcoding index 0.

## Why this is a "recovery" PR

The fix originally landed as commit `3d319662` on the abandoned branch `v17/hotfix/2026.06.1` (via #207). That hotfix branch was **never merged back** into `v17/main` or `v17/dev` — `17.0.1` was ultimately tagged from a different commit that did not include this change. As a result the bug is still live on **both** active lines: `v18/dev` and `v17/dev` still carry the old `serializeForLlm(workspaceContext)` signature and the "leftmost pane" TODO this fix removes.

This PR cherry-picks the original commit (`git cherry-pick -x`) onto `v18/dev`. A sibling backport to `v17/dev` follows.

## Changes

- `UaiEntityAdapterApi.serializeForLlm` gains an optional `activeVariant` parameter (block/media adapters unaffected — optional second param)
- `UaiDocumentAdapter.serializeForLlm` uses the override when provided, falling back to `getActiveVariants()[0]` for non-split-view cases
- `UaiPromptInsertPropertyAction` and `UaiPromptsTiptapToolbarElement` derive the active variant from the property context and forward it

## Verification

- `npm run build:core` + `npm run build:prompt` pass (typecheck clean with the new signature)
- Manual split-view culture check still recommended before release

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)