### PR TITLE
fix(anthropic,openai,amazon): Drop sampling parameters on models that reject them [v17 backport]

### DIFF
--- a/Umbraco.AI.Amazon/Umbraco.AI.Amazon.slnx
+++ b/Umbraco.AI.Amazon/Umbraco.AI.Amazon.slnx
@@ -1,3 +1,6 @@
 <Solution>
   <Project Path="src/Umbraco.AI.Amazon/Umbraco.AI.Amazon.csproj" />
+  <Folder Name="/Tests/">
+    <Project Path="tests/Umbraco.AI.Amazon.Tests.Unit/Umbraco.AI.Amazon.Tests.Unit.csproj" />
+  </Folder>
 </Solution>

--- a/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/AmazonChatCapability.cs
+++ b/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/AmazonChatCapability.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 using Amazon.BedrockRuntime;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
 using Umbraco.AI.Core.Models;
 using Umbraco.AI.Core.Providers;
 using Umbraco.AI.Extensions;
@@ -10,7 +11,14 @@ namespace Umbraco.AI.Amazon;
 /// <summary>
 /// AI chat capability for Amazon Bedrock provider.
 /// </summary>
-public class AmazonChatCapability(AmazonProvider provider) : AIChatCapabilityBase<AmazonProviderSettings>(provider)
+/// <remarks>
+/// The <paramref name="logger"/> is optional so the capability can still be constructed directly (in tests,
+/// or by a caller that predates it) without a DI container supplying one.
+/// </remarks>
+public class AmazonChatCapability(
+    AmazonProvider provider,
+    ILogger<AmazonChatCapability>? logger = null)
+    : AIChatCapabilityBase<AmazonProviderSettings>(provider)
 {
     /// <summary>
     /// Optional region prefix pattern for inference profile IDs (e.g., "eu.", "us.", "apac.").
@@ -64,7 +72,10 @@ public class AmazonChatCapability(AmazonProvider provider) : AIChatCapabilityBas
         }
 
         var client = AmazonProvider.CreateBedrockRuntimeClient(settings);
-        return client.AsIChatClient(modelId);
+
+        // Wrapped innermost, so the sampling parameters are filtered against the target model no matter
+        // which caller assembled the ChatOptions. See AmazonSamplingParameterChatClient.
+        return new AmazonSamplingParameterChatClient(client.AsIChatClient(modelId), modelId, logger);
     }
 
     private static bool IsChatModel(string modelId)

--- a/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/AmazonChatCapability.cs
+++ b/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/AmazonChatCapability.cs
@@ -11,15 +11,24 @@ namespace Umbraco.AI.Amazon;
 /// <summary>
 /// AI chat capability for Amazon Bedrock provider.
 /// </summary>
-/// <remarks>
-/// The <paramref name="logger"/> is optional so the capability can still be constructed directly (in tests,
-/// or by a caller that predates it) without a DI container supplying one.
-/// </remarks>
 public class AmazonChatCapability(
     AmazonProvider provider,
-    ILogger<AmazonChatCapability>? logger = null)
+    ILogger<AmazonChatCapability>? logger)
     : AIChatCapabilityBase<AmazonProviderSettings>(provider)
 {
+    /// <summary>
+    /// Initializes a new instance without a logger.
+    /// </summary>
+    /// <remarks>
+    /// Retained so adding the logger parameter stays binary compatible. An optional parameter would not
+    /// achieve that — the compiler emits a single constructor and bakes the default in at each call site,
+    /// so assemblies compiled against the previous signature would fail to bind.
+    /// </remarks>
+    public AmazonChatCapability(AmazonProvider provider)
+        : this(provider, null)
+    {
+    }
+
     /// <summary>
     /// Optional region prefix pattern for inference profile IDs (e.g., "eu.", "us.", "apac.").
     /// </summary>

--- a/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/AmazonModelUtilities.cs
+++ b/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/AmazonModelUtilities.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+
 namespace Umbraco.AI.Extensions;
 
 /// <summary>
@@ -5,6 +7,81 @@ namespace Umbraco.AI.Extensions;
 /// </summary>
 internal static class AmazonModelUtilities
 {
+    /// <summary>
+    /// Strips the optional region prefix (<c>eu.</c>, <c>us.</c>, <c>apac.</c>) that inference profile IDs
+    /// carry, and the trailing Bedrock version suffix (<c>-v1:0</c>).
+    /// </summary>
+    private static readonly Regex BedrockIdDecorations =
+        new(@"^(eu|us|apac)\.|-v\d+:\d+$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Vendor-qualified model families that accept the sampling parameters (<c>temperature</c>,
+    /// <c>top_p</c>, <c>top_k</c>), matched against the region- and version-stripped model ID.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Bedrock fronts other vendors' models, so support is inherited from whoever built the model rather
+    /// than being an Amazon property: a Bedrock-hosted <c>anthropic.claude-opus-4-8</c> rejects the
+    /// sampling parameters for exactly the same reason the first-party Anthropic model does. The vendor
+    /// and family are both present in the ID, so they can be matched directly.
+    /// </para>
+    /// <para>
+    /// Because provider packages cannot reference each other, the Claude rules below are a deliberate
+    /// duplicate of the ones in <c>Umbraco.AI.Anthropic</c>. Keeping a local copy is preferable to a shared
+    /// table in core, which would couple core releases to vendor model launches. If the two copies drift,
+    /// the worst case is a dropped temperature on a Bedrock-hosted Claude that would have accepted it.
+    /// </para>
+    /// <para>
+    /// As with the other providers this is an <em>allow</em>-list, so anything unrecognised — a vendor we
+    /// don't enumerate, or a family newer than this list — fails safe by dropping the parameters.
+    /// </para>
+    /// </remarks>
+    private static readonly Regex[] SamplingParameterModelPatterns =
+    [
+        // Amazon's own models.
+        new(@"^amazon\.nova-", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
+        // Mistral and Meta Llama accept the sampling parameters across their Bedrock catalogue.
+        new(@"^mistral\.", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"^meta\.llama", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
+        // Claude — mirrors Umbraco.AI.Anthropic. Claude 3, 3.5 and 3.7.
+        new(@"^anthropic\.claude-3(-|$)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
+        // Claude 4 with no minor version (the trailing 8-digit group is a release date).
+        new(@"^anthropic\.claude-(opus|sonnet|haiku)-4(-\d{8})?$",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
+        // Claude 4.0 / 4.1 / 4.5 / 4.6. 4.7 and 4.8 are deliberately excluded.
+        new(@"^anthropic\.claude-(opus|sonnet|haiku)-4-[0156](-\d{8})?$",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled),
+    ];
+
+    /// <summary>
+    /// Determines whether a Bedrock model accepts the sampling parameters (<c>temperature</c>,
+    /// <c>top_p</c>, <c>top_k</c>).
+    /// </summary>
+    /// <param name="modelId">
+    /// The Bedrock model or inference profile ID, with or without a region prefix and version suffix
+    /// (e.g. <c>us.anthropic.claude-opus-4-8-v1:0</c>).
+    /// </param>
+    /// <returns>
+    /// <c>true</c> when the model is a known family that accepts them; otherwise <c>false</c>. Unknown and
+    /// unresolved models return <c>false</c> so the parameters are dropped rather than risking a rejected
+    /// request — see the remarks on <see cref="SamplingParameterModelPatterns"/>.
+    /// </returns>
+    public static bool SupportsSamplingParameters(string? modelId)
+    {
+        if (string.IsNullOrWhiteSpace(modelId))
+        {
+            return false;
+        }
+
+        var normalised = BedrockIdDecorations.Replace(modelId, string.Empty);
+
+        return SamplingParameterModelPatterns.Any(p => p.IsMatch(normalised));
+    }
+
     /// <summary>
     /// Formats a Bedrock model ID or inference profile ID into a human-readable display name.
     /// </summary>

--- a/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/AmazonModelUtilities.cs
+++ b/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/AmazonModelUtilities.cs
@@ -32,8 +32,9 @@ internal static class AmazonModelUtilities
     /// the worst case is a dropped temperature on a Bedrock-hosted Claude that would have accepted it.
     /// </para>
     /// <para>
-    /// As with the other providers this is an <em>allow</em>-list, so anything unrecognised — a vendor we
-    /// don't enumerate, or a family newer than this list — fails safe by dropping the parameters.
+    /// As with the other providers this is an allow-list rather than a deny-list, so anything
+    /// unrecognised — a vendor we don't enumerate, or a family newer than this list — fails safe by
+    /// dropping the parameters instead of risking a rejected request.
     /// </para>
     /// </remarks>
     private static readonly Regex[] SamplingParameterModelPatterns =
@@ -48,12 +49,9 @@ internal static class AmazonModelUtilities
         // Claude — mirrors Umbraco.AI.Anthropic. Claude 3, 3.5 and 3.7.
         new(@"^anthropic\.claude-3(-|$)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-        // Claude 4 with no minor version (the trailing 8-digit group is a release date).
-        new(@"^anthropic\.claude-(opus|sonnet|haiku)-4(-\d{8})?$",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled),
-
-        // Claude 4.0 / 4.1 / 4.5 / 4.6. 4.7 and 4.8 are deliberately excluded.
-        new(@"^anthropic\.claude-(opus|sonnet|haiku)-4-[0156](-\d{8})?$",
+        // Claude 4, and 4.0 / 4.1 / 4.5 / 4.6. The optional trailing 8-digit group is a release date,
+        // not a minor version. 4.7 and 4.8 are deliberately excluded from the minor versions.
+        new(@"^anthropic\.claude-(opus|sonnet|haiku)-4(-[0156])?(-\d{8})?$",
             RegexOptions.IgnoreCase | RegexOptions.Compiled),
     ];
 

--- a/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/AmazonSamplingParameterChatClient.cs
+++ b/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/AmazonSamplingParameterChatClient.cs
@@ -22,10 +22,6 @@ namespace Umbraco.AI.Amazon;
 /// agent runtime builds its <see cref="ChatOptions"/> without a <c>ModelId</c>, so the bound value is the
 /// only way to identify the model on that path.
 /// </para>
-/// <para>
-/// The caller's <see cref="ChatOptions"/> is never mutated; a clone is taken only when something actually
-/// needs removing, so the common case allocates nothing.
-/// </para>
 /// </remarks>
 internal sealed class AmazonSamplingParameterChatClient(
     IChatClient innerClient,
@@ -49,9 +45,10 @@ internal sealed class AmazonSamplingParameterChatClient(
 
     /// <summary>
     /// Returns the options to send, with the sampling parameters removed when the resolved model
-    /// does not accept them. Returns the original instance untouched when there is nothing to remove.
+    /// does not accept them. Returns the original instance untouched when there is nothing to remove,
+    /// so the caller's <see cref="ChatOptions"/> is never mutated.
     /// </summary>
-    internal ChatOptions? FilterOptions(ChatOptions? options)
+    private ChatOptions? FilterOptions(ChatOptions? options)
     {
         if (options is null)
         {

--- a/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/AmazonSamplingParameterChatClient.cs
+++ b/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/AmazonSamplingParameterChatClient.cs
@@ -1,0 +1,84 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Umbraco.AI.Extensions;
+
+namespace Umbraco.AI.Amazon;
+
+/// <summary>
+/// A chat client decorator that removes the sampling parameters (<c>Temperature</c>, <c>TopP</c>,
+/// <c>TopK</c>) from the request when the target Bedrock model does not accept them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Bedrock fronts other vendors' models, so it inherits their restrictions: a Bedrock-hosted
+/// <c>anthropic.claude-opus-4-8</c> rejects the sampling parameters exactly as the first-party Anthropic
+/// model does. Filtering here — inside the provider, beneath the core middleware pipeline — covers every
+/// caller at once: the chat service (<c>AIChatService.MergeOptions</c>), the agent runtime
+/// (<c>AIAgentFactory</c>), and anything calling <c>IChatClient</c> directly.
+/// </para>
+/// <para>
+/// The model is resolved from <see cref="ChatOptions.ModelId"/> when the caller set one, falling back to
+/// the model the client was bound to at creation. The fallback is load-bearing rather than defensive: the
+/// agent runtime builds its <see cref="ChatOptions"/> without a <c>ModelId</c>, so the bound value is the
+/// only way to identify the model on that path.
+/// </para>
+/// <para>
+/// The caller's <see cref="ChatOptions"/> is never mutated; a clone is taken only when something actually
+/// needs removing, so the common case allocates nothing.
+/// </para>
+/// </remarks>
+internal sealed class AmazonSamplingParameterChatClient(
+    IChatClient innerClient,
+    string? boundModelId,
+    ILogger? logger)
+    : DelegatingChatClient(innerClient)
+{
+    /// <inheritdoc />
+    public override Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => base.GetResponseAsync(messages, FilterOptions(options), cancellationToken);
+
+    /// <inheritdoc />
+    public override IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => base.GetStreamingResponseAsync(messages, FilterOptions(options), cancellationToken);
+
+    /// <summary>
+    /// Returns the options to send, with the sampling parameters removed when the resolved model
+    /// does not accept them. Returns the original instance untouched when there is nothing to remove.
+    /// </summary>
+    internal ChatOptions? FilterOptions(ChatOptions? options)
+    {
+        if (options is null)
+        {
+            return null;
+        }
+
+        if (options.Temperature is null && options.TopP is null && options.TopK is null)
+        {
+            return options;
+        }
+
+        var modelId = options.ModelId ?? boundModelId;
+        if (AmazonModelUtilities.SupportsSamplingParameters(modelId))
+        {
+            return options;
+        }
+
+        var filtered = options.Clone();
+        filtered.Temperature = null;
+        filtered.TopP = null;
+        filtered.TopK = null;
+
+        logger?.LogDebug(
+            "Bedrock model '{ModelId}' does not accept the sampling parameters; " +
+            "Temperature/TopP/TopK were removed from the request.",
+            modelId ?? "(unresolved)");
+
+        return filtered;
+    }
+}

--- a/Umbraco.AI.Amazon/tests/Umbraco.AI.Amazon.Tests.Unit/AmazonSamplingParameterChatClientTests.cs
+++ b/Umbraco.AI.Amazon/tests/Umbraco.AI.Amazon.Tests.Unit/AmazonSamplingParameterChatClientTests.cs
@@ -59,17 +59,10 @@ public class AmazonSamplingParameterChatClientTests
         inner.ReceivedOptions.Temperature.ShouldBeNull();
         inner.ReceivedOptions.TopP.ShouldBeNull();
         inner.ReceivedOptions.TopK.ShouldBeNull();
-    }
 
-    [Fact]
-    public async Task GetResponseAsync_ModelRejectsSampling_PreservesMaxOutputTokens()
-    {
-        var (client, inner) = CreateClient("us.anthropic.claude-opus-4-8-v1:0");
-        var options = new ChatOptions { Temperature = 0.3f, MaxOutputTokens = 64000 };
-
-        await client.GetResponseAsync(Messages, options);
-
-        inner.ReceivedOptions!.MaxOutputTokens.ShouldBe(64000);
+        // MaxOutputTokens is accepted by every model and is the setting #256 was actually about —
+        // filtering must not take it with the sampling parameters.
+        inner.ReceivedOptions.MaxOutputTokens.ShouldBe(4096);
     }
 
     [Fact]
@@ -85,14 +78,26 @@ public class AmazonSamplingParameterChatClientTests
     }
 
     [Fact]
-    public async Task GetResponseAsync_BoundModelUsedWhenOptionsHaveNoModelId()
+    public async Task GetResponseAsync_OptionsModelIdOverridesBoundModel()
     {
-        var (client, inner) = CreateClient("us.anthropic.claude-opus-4-8-v1:0");
-        var options = new ChatOptions { Temperature = 0.3f };
+        // A caller-supplied ModelId wins over the model the client was bound to.
+        var (client, inner) = CreateClient("amazon.nova-pro-v1:0");
+        var options = new ChatOptions { ModelId = "anthropic.claude-opus-4-8-v1:0", Temperature = 0.3f };
 
         await client.GetResponseAsync(Messages, options);
 
         inner.ReceivedOptions!.Temperature.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_NullOptions_StaysNull()
+    {
+        var (client, inner) = CreateClient("anthropic.claude-opus-4-8-v1:0");
+
+        await client.GetResponseAsync(Messages);
+
+        inner.WasCalled.ShouldBeTrue();
+        inner.ReceivedOptions.ShouldBeNull();
     }
 
     [Fact]

--- a/Umbraco.AI.Amazon/tests/Umbraco.AI.Amazon.Tests.Unit/AmazonSamplingParameterChatClientTests.cs
+++ b/Umbraco.AI.Amazon/tests/Umbraco.AI.Amazon.Tests.Unit/AmazonSamplingParameterChatClientTests.cs
@@ -1,0 +1,135 @@
+using Microsoft.Extensions.AI;
+using Umbraco.AI.Amazon.Tests.Unit.Fakes;
+
+namespace Umbraco.AI.Amazon.Tests.Unit;
+
+/// <summary>
+/// Covers the sampling-parameter filtering for Bedrock, which inherits its restrictions from whichever
+/// vendor built the model it is fronting (issue #256 follow-up).
+/// </summary>
+public class AmazonSamplingParameterChatClientTests
+{
+    private static (AmazonSamplingParameterChatClient Client, RecordingChatClient Inner) CreateClient(
+        string? boundModelId)
+    {
+        var inner = new RecordingChatClient();
+        return (new AmazonSamplingParameterChatClient(inner, boundModelId, logger: null), inner);
+    }
+
+    private static readonly List<ChatMessage> Messages = [new(ChatRole.User, "hi")];
+
+    [Theory]
+    // Amazon's own models, plus Mistral and Meta, all accept the sampling parameters.
+    [InlineData("amazon.nova-pro-v1:0")]
+    [InlineData("us.amazon.nova-lite-v1:0")]
+    [InlineData("mistral.mistral-large-2407-v1:0")]
+    [InlineData("meta.llama3-1-70b-instruct-v1:0")]
+    // Bedrock-hosted Claude families that still accept them.
+    [InlineData("anthropic.claude-3-5-sonnet-20240620-v1:0")]
+    [InlineData("anthropic.claude-3-haiku-20240307-v1:0")]
+    [InlineData("anthropic.claude-sonnet-4-20250514-v1:0")]
+    [InlineData("us.anthropic.claude-opus-4-5-20251101-v1:0")]
+    [InlineData("eu.anthropic.claude-sonnet-4-6-v1:0")]
+    public async Task GetResponseAsync_ModelSupportsSampling_ForwardsTemperature(string modelId)
+    {
+        var (client, inner) = CreateClient(modelId);
+        var options = new ChatOptions { Temperature = 0.3f, MaxOutputTokens = 4096 };
+
+        await client.GetResponseAsync(Messages, options);
+
+        inner.ReceivedOptions.ShouldNotBeNull();
+        inner.ReceivedOptions.Temperature.ShouldBe(0.3f);
+        inner.ReceivedOptions.MaxOutputTokens.ShouldBe(4096);
+    }
+
+    [Theory]
+    // Bedrock-hosted Claude inherits Anthropic's removal of the sampling parameters from 4.7 onwards.
+    [InlineData("anthropic.claude-opus-4-7-v1:0")]
+    [InlineData("anthropic.claude-opus-4-8-v1:0")]
+    [InlineData("us.anthropic.claude-opus-4-8-v1:0")]
+    [InlineData("apac.anthropic.claude-sonnet-5-v1:0")]
+    public async Task GetResponseAsync_ModelRejectsSampling_DropsSamplingParameters(string modelId)
+    {
+        var (client, inner) = CreateClient(modelId);
+        var options = new ChatOptions { Temperature = 0.3f, TopP = 0.9f, TopK = 40, MaxOutputTokens = 4096 };
+
+        await client.GetResponseAsync(Messages, options);
+
+        inner.ReceivedOptions.ShouldNotBeNull();
+        inner.ReceivedOptions.Temperature.ShouldBeNull();
+        inner.ReceivedOptions.TopP.ShouldBeNull();
+        inner.ReceivedOptions.TopK.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_ModelRejectsSampling_PreservesMaxOutputTokens()
+    {
+        var (client, inner) = CreateClient("us.anthropic.claude-opus-4-8-v1:0");
+        var options = new ChatOptions { Temperature = 0.3f, MaxOutputTokens = 64000 };
+
+        await client.GetResponseAsync(Messages, options);
+
+        inner.ReceivedOptions!.MaxOutputTokens.ShouldBe(64000);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_UnknownVendor_DropsSamplingParameters()
+    {
+        // A vendor we don't enumerate fails safe, rather than assuming support.
+        var (client, inner) = CreateClient("cohere.command-r-plus-v1:0");
+        var options = new ChatOptions { Temperature = 0.3f };
+
+        await client.GetResponseAsync(Messages, options);
+
+        inner.ReceivedOptions!.Temperature.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_BoundModelUsedWhenOptionsHaveNoModelId()
+    {
+        var (client, inner) = CreateClient("us.anthropic.claude-opus-4-8-v1:0");
+        var options = new ChatOptions { Temperature = 0.3f };
+
+        await client.GetResponseAsync(Messages, options);
+
+        inner.ReceivedOptions!.Temperature.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_DoesNotMutateCallerOptions()
+    {
+        var (client, _) = CreateClient("anthropic.claude-opus-4-8-v1:0");
+        var options = new ChatOptions { Temperature = 0.3f, TopP = 0.9f, TopK = 40 };
+
+        await client.GetResponseAsync(Messages, options);
+
+        options.Temperature.ShouldBe(0.3f);
+        options.TopP.ShouldBe(0.9f);
+        options.TopK.ShouldBe(40);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_NoSamplingParametersSet_PassesOriginalInstanceThrough()
+    {
+        var (client, inner) = CreateClient("anthropic.claude-opus-4-8-v1:0");
+        var options = new ChatOptions { MaxOutputTokens = 1024 };
+
+        await client.GetResponseAsync(Messages, options);
+
+        inner.ReceivedOptions.ShouldBeSameAs(options);
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_ModelRejectsSampling_DropsSamplingParameters()
+    {
+        var (client, inner) = CreateClient("anthropic.claude-opus-4-8-v1:0");
+        var options = new ChatOptions { Temperature = 0.3f };
+
+        await foreach (var _ in client.GetStreamingResponseAsync(Messages, options))
+        {
+            // drain
+        }
+
+        inner.ReceivedOptions!.Temperature.ShouldBeNull();
+    }
+}

--- a/Umbraco.AI.Amazon/tests/Umbraco.AI.Amazon.Tests.Unit/Fakes/RecordingChatClient.cs
+++ b/Umbraco.AI.Amazon/tests/Umbraco.AI.Amazon.Tests.Unit/Fakes/RecordingChatClient.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.AI;
+
+namespace Umbraco.AI.Amazon.Tests.Unit.Fakes;
+
+/// <summary>
+/// A minimal <see cref="IChatClient"/> that records the <see cref="ChatOptions"/> it was called with,
+/// so tests can assert on what a decorator forwarded to the underlying provider client.
+/// </summary>
+internal sealed class RecordingChatClient : IChatClient
+{
+    public ChatOptions? ReceivedOptions { get; private set; }
+
+    public bool WasCalled { get; private set; }
+
+    public Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ReceivedOptions = options;
+        WasCalled = true;
+        return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "ok")));
+    }
+
+    public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ReceivedOptions = options;
+        WasCalled = true;
+        yield return new ChatResponseUpdate(ChatRole.Assistant, "ok");
+        await Task.CompletedTask;
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+    public void Dispose()
+    {
+    }
+}

--- a/Umbraco.AI.Amazon/tests/Umbraco.AI.Amazon.Tests.Unit/Umbraco.AI.Amazon.Tests.Unit.csproj
+++ b/Umbraco.AI.Amazon/tests/Umbraco.AI.Amazon.Tests.Unit/Umbraco.AI.Amazon.Tests.Unit.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsTestProject>true</IsTestProject>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Umbraco.AI.Amazon\Umbraco.AI.Amazon.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="Shouldly" />
+  </ItemGroup>
+
+</Project>

--- a/Umbraco.AI.Amazon/tests/Umbraco.AI.Amazon.Tests.Unit/packages.lock.json
+++ b/Umbraco.AI.Amazon/tests/Umbraco.AI.Amazon.Tests.Unit/packages.lock.json
@@ -119,6 +119,11 @@
           "Asp.Versioning.Mvc": "8.1.1"
         }
       },
+      "AWSSDK.Core": {
+        "type": "Transitive",
+        "resolved": "4.0.9.4",
+        "contentHash": "bpxzv4e0WjOVmKiYkjkNWeKvwyzoIVFS+u5zYnsryM2qTyhkfeLGQ4LPqDo+m/7OIJlGWr6V9zkc3V9bb0QmYg=="
+      },
       "BouncyCastle.Cryptography": {
         "type": "Transitive",
         "resolved": "2.6.2",
@@ -1642,10 +1647,12 @@
           "xunit.extensibility.core": "[2.9.3]"
         }
       },
-      "umbraco.ai.anthropic": {
+      "umbraco.ai.amazon": {
         "type": "Project",
         "dependencies": {
-          "Anthropic": "[12.29.1, 12.999.999)",
+          "AWSSDK.Bedrock": "[4.0.30.4, 4.999.999)",
+          "AWSSDK.BedrockRuntime": "[4.0.21.1, 4.999.999)",
+          "AWSSDK.Extensions.Bedrock.MEAI": "[4.0.8.12, 4.999.999)",
           "Umbraco.AI.Core": "[1.0.0, )"
         }
       },
@@ -1665,12 +1672,32 @@
           "Umbraco.Cms.Web.Common": "[17.4.0, 17.999.999)"
         }
       },
-      "Anthropic": {
+      "AWSSDK.Bedrock": {
         "type": "CentralTransitive",
-        "requested": "[12.29.1, 12.999.999)",
-        "resolved": "12.29.1",
-        "contentHash": "EVq7ygOtMejWNXW+Dz+vv/ie50JgZB4jFc4gT2TTpBZXtp64zWRR7DqdGhbEaYThyMuaevN4ZRGUWBrSrb0+rg==",
+        "requested": "[4.0.30.4, 4.999.999)",
+        "resolved": "4.0.30.4",
+        "contentHash": "2BRrOrk5H4tLdkTnmqhGuuwwfthXW1ndN7CSHkf7fhk3EEVZ12Kl32yB/lNbnFVSsjCArnMRvQEB+ATv9op0Vw==",
         "dependencies": {
+          "AWSSDK.Core": "[4.0.9.4, 5.0.0)"
+        }
+      },
+      "AWSSDK.BedrockRuntime": {
+        "type": "CentralTransitive",
+        "requested": "[4.0.21.1, 4.999.999)",
+        "resolved": "4.0.21.1",
+        "contentHash": "ec1uHKBW3JusA4HzBqk9OlDDMlnq0bDUj/JWSrTFV8goQHD4ysx95bIYPwhJmJ1T+Q6IgpWDVsuViRNoR+3KkQ==",
+        "dependencies": {
+          "AWSSDK.Core": "[4.0.9.4, 5.0.0)"
+        }
+      },
+      "AWSSDK.Extensions.Bedrock.MEAI": {
+        "type": "CentralTransitive",
+        "requested": "[4.0.8.12, 4.999.999)",
+        "resolved": "4.0.8.12",
+        "contentHash": "Qfsmm+jJJH80eb7uUyFOOruRWmnplggpRZuDrxkukV5YQPyJ9fD9PC1VNX25WaTTDyvvpIMSdMsYwh3f05yDFA==",
+        "dependencies": {
+          "AWSSDK.BedrockRuntime": "4.0.21.1",
+          "AWSSDK.Core": "4.0.9.4",
           "Microsoft.Extensions.AI.Abstractions": "10.5.1"
         }
       },

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
@@ -10,15 +10,24 @@ namespace Umbraco.AI.Anthropic;
 /// <summary>
 /// AI chat capability for Anthropic provider.
 /// </summary>
-/// <remarks>
-/// The <paramref name="logger"/> is optional so the capability can still be constructed directly (in tests,
-/// or by a caller that predates it) without a DI container supplying one.
-/// </remarks>
 public class AnthropicChatCapability(
     AnthropicProvider provider,
-    ILogger<AnthropicChatCapability>? logger = null)
+    ILogger<AnthropicChatCapability>? logger)
     : AIChatCapabilityBase<AnthropicProviderSettings>(provider)
 {
+    /// <summary>
+    /// Initializes a new instance without a logger.
+    /// </summary>
+    /// <remarks>
+    /// Retained so adding the logger parameter stays binary compatible. An optional parameter would not
+    /// achieve that — the compiler emits a single constructor and bakes the default in at each call site,
+    /// so assemblies compiled against the previous signature would fail to bind.
+    /// </remarks>
+    public AnthropicChatCapability(AnthropicProvider provider)
+        : this(provider, null)
+    {
+    }
+
     private const string DefaultChatModel = "claude-sonnet-4-20250514";
     
     private new AnthropicProvider Provider => (AnthropicProvider)base.Provider;

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
 using Umbraco.AI.Core.Models;
 using Umbraco.AI.Core.Providers;
 using Umbraco.AI.Extensions;
@@ -9,7 +10,14 @@ namespace Umbraco.AI.Anthropic;
 /// <summary>
 /// AI chat capability for Anthropic provider.
 /// </summary>
-public class AnthropicChatCapability(AnthropicProvider provider) : AIChatCapabilityBase<AnthropicProviderSettings>(provider)
+/// <remarks>
+/// The <paramref name="logger"/> is optional so the capability can still be constructed directly (in tests,
+/// or by a caller that predates it) without a DI container supplying one.
+/// </remarks>
+public class AnthropicChatCapability(
+    AnthropicProvider provider,
+    ILogger<AnthropicChatCapability>? logger = null)
+    : AIChatCapabilityBase<AnthropicProviderSettings>(provider)
 {
     private const string DefaultChatModel = "claude-sonnet-4-20250514";
     
@@ -40,8 +48,14 @@ public class AnthropicChatCapability(AnthropicProvider provider) : AIChatCapabil
 
     /// <inheritdoc />
     protected override IChatClient CreateClient(AnthropicProviderSettings settings, string? modelId)
-        => AnthropicProvider.CreateAnthropicClient(settings)
+    {
+        var inner = AnthropicProvider.CreateAnthropicClient(settings)
             .Beta.AsIChatClient(modelId);
+
+        // Wrapped innermost, so the sampling parameters are filtered against the target model no matter
+        // which caller assembled the ChatOptions. See AnthropicSamplingParameterChatClient.
+        return new AnthropicSamplingParameterChatClient(inner, modelId, logger);
+    }
 
     private static bool IsChatModel(string modelId)
         => IncludePatterns.Any(p => p.IsMatch(modelId));

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicModelUtilities.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicModelUtilities.cs
@@ -30,13 +30,12 @@ internal static class AnthropicModelUtilities
         // Claude 3, 3.5 and 3.7 — e.g. claude-3-opus-20240229, claude-3-5-sonnet-20241022.
         new(@"^claude-3(-|$)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-        // Claude 4 with no minor version — e.g. claude-sonnet-4-20250514, claude-opus-4-20250514.
-        // The trailing 8-digit group is a release date, not a minor version.
-        new(@"^claude-(opus|sonnet|haiku)-4(-\d{8})?$", RegexOptions.IgnoreCase | RegexOptions.Compiled),
-
-        // Claude 4.0 / 4.1 / 4.5 / 4.6 — e.g. claude-opus-4-1-20250805, claude-sonnet-4-6.
-        // 4.7 and 4.8 are deliberately excluded: they reject the sampling parameters.
-        new(@"^claude-(opus|sonnet|haiku)-4-[0156](-\d{8})?$", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        // Claude 4, and 4.0 / 4.1 / 4.5 / 4.6 — e.g. claude-sonnet-4-20250514,
+        // claude-opus-4-1-20250805, claude-sonnet-4-6. The optional trailing 8-digit group is a
+        // release date, not a minor version. 4.7 and 4.8 are deliberately excluded from the minor
+        // versions: they reject the sampling parameters.
+        new(@"^claude-(opus|sonnet|haiku)-4(-[0156])?(-\d{8})?$",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled),
     ];
 
     /// <summary>

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicModelUtilities.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicModelUtilities.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+
 namespace Umbraco.AI.Extensions;
 
 /// <summary>
@@ -5,6 +7,52 @@ namespace Umbraco.AI.Extensions;
 /// </summary>
 internal static class AnthropicModelUtilities
 {
+    /// <summary>
+    /// Model families that accept the sampling parameters (<c>temperature</c>, <c>top_p</c>, <c>top_k</c>).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Anthropic removed the sampling parameters from Claude Opus 4.7 onwards — sending any of them to a
+    /// newer model is rejected with <c>400 invalid_request_error: `temperature` is deprecated for this
+    /// model.</c> This is an <em>allow</em>-list of the older families that still accept them rather than a
+    /// deny-list of the newer ones, because the set of already-released models is closed and will never
+    /// change, whereas a deny-list would need updating on every Anthropic release just to stay correct.
+    /// </para>
+    /// <para>
+    /// The failure modes are asymmetric, and that is the whole point: a stale allow-list silently drops a
+    /// value on a brand-new model that would have honoured it (degraded, but the request succeeds), while a
+    /// stale deny-list sends a parameter to a model that rejects it (the request fails outright). This list
+    /// therefore fails safe, and only needs to be accurate about models that already exist.
+    /// </para>
+    /// </remarks>
+    private static readonly Regex[] SamplingParameterModelPatterns =
+    [
+        // Claude 3, 3.5 and 3.7 — e.g. claude-3-opus-20240229, claude-3-5-sonnet-20241022.
+        new(@"^claude-3(-|$)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
+        // Claude 4 with no minor version — e.g. claude-sonnet-4-20250514, claude-opus-4-20250514.
+        // The trailing 8-digit group is a release date, not a minor version.
+        new(@"^claude-(opus|sonnet|haiku)-4(-\d{8})?$", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
+        // Claude 4.0 / 4.1 / 4.5 / 4.6 — e.g. claude-opus-4-1-20250805, claude-sonnet-4-6.
+        // 4.7 and 4.8 are deliberately excluded: they reject the sampling parameters.
+        new(@"^claude-(opus|sonnet|haiku)-4-[0156](-\d{8})?$", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+    ];
+
+    /// <summary>
+    /// Determines whether a Claude model accepts the sampling parameters (<c>temperature</c>,
+    /// <c>top_p</c>, <c>top_k</c>).
+    /// </summary>
+    /// <param name="modelId">The model ID, or <c>null</c> if no model has been resolved.</param>
+    /// <returns>
+    /// <c>true</c> when the model is a known family that accepts them; otherwise <c>false</c>. Unknown and
+    /// unresolved models return <c>false</c> so the parameters are dropped rather than risking a rejected
+    /// request — see the remarks on <see cref="SamplingParameterModelPatterns"/>.
+    /// </returns>
+    public static bool SupportsSamplingParameters(string? modelId)
+        => !string.IsNullOrWhiteSpace(modelId)
+           && SamplingParameterModelPatterns.Any(p => p.IsMatch(modelId));
+
     /// <summary>
     /// Formats a Claude model ID into a human-readable display name.
     /// </summary>

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicSamplingParameterChatClient.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicSamplingParameterChatClient.cs
@@ -23,10 +23,6 @@ namespace Umbraco.AI.Anthropic;
 /// agent runtime builds its <see cref="ChatOptions"/> without a <c>ModelId</c>, so the bound value is the
 /// only way to identify the model on that path — which is the path the original report came in on.
 /// </para>
-/// <para>
-/// The caller's <see cref="ChatOptions"/> is never mutated; a clone is taken only when something actually
-/// needs removing, so the common case allocates nothing.
-/// </para>
 /// </remarks>
 internal sealed class AnthropicSamplingParameterChatClient(
     IChatClient innerClient,
@@ -50,9 +46,10 @@ internal sealed class AnthropicSamplingParameterChatClient(
 
     /// <summary>
     /// Returns the options to send, with the sampling parameters removed when the resolved model
-    /// does not accept them. Returns the original instance untouched when there is nothing to remove.
+    /// does not accept them. Returns the original instance untouched when there is nothing to remove,
+    /// so the caller's <see cref="ChatOptions"/> is never mutated.
     /// </summary>
-    internal ChatOptions? FilterOptions(ChatOptions? options)
+    private ChatOptions? FilterOptions(ChatOptions? options)
     {
         if (options is null)
         {

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicSamplingParameterChatClient.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicSamplingParameterChatClient.cs
@@ -1,0 +1,85 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Umbraco.AI.Extensions;
+
+namespace Umbraco.AI.Anthropic;
+
+/// <summary>
+/// A chat client decorator that removes the sampling parameters (<c>Temperature</c>, <c>TopP</c>,
+/// <c>TopK</c>) from the request when the target Claude model does not accept them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Anthropic removed the sampling parameters from Claude Opus 4.7 onwards, so forwarding a profile's
+/// configured temperature to a newer model fails the whole request with
+/// <c>400 invalid_request_error: `temperature` is deprecated for this model.</c> Filtering here — inside
+/// the provider, beneath the core middleware pipeline — covers every caller at once: the chat service
+/// (<c>AIChatService.MergeOptions</c>), the agent runtime (<c>AIAgentFactory</c>), and anything calling
+/// <c>IChatClient</c> directly.
+/// </para>
+/// <para>
+/// The model is resolved from <see cref="ChatOptions.ModelId"/> when the caller set one, falling back to
+/// the model the client was bound to at creation. The fallback is load-bearing rather than defensive: the
+/// agent runtime builds its <see cref="ChatOptions"/> without a <c>ModelId</c>, so the bound value is the
+/// only way to identify the model on that path — which is the path the original report came in on.
+/// </para>
+/// <para>
+/// The caller's <see cref="ChatOptions"/> is never mutated; a clone is taken only when something actually
+/// needs removing, so the common case allocates nothing.
+/// </para>
+/// </remarks>
+internal sealed class AnthropicSamplingParameterChatClient(
+    IChatClient innerClient,
+    string? boundModelId,
+    ILogger? logger)
+    : DelegatingChatClient(innerClient)
+{
+    /// <inheritdoc />
+    public override Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => base.GetResponseAsync(messages, FilterOptions(options), cancellationToken);
+
+    /// <inheritdoc />
+    public override IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => base.GetStreamingResponseAsync(messages, FilterOptions(options), cancellationToken);
+
+    /// <summary>
+    /// Returns the options to send, with the sampling parameters removed when the resolved model
+    /// does not accept them. Returns the original instance untouched when there is nothing to remove.
+    /// </summary>
+    internal ChatOptions? FilterOptions(ChatOptions? options)
+    {
+        if (options is null)
+        {
+            return null;
+        }
+
+        if (options.Temperature is null && options.TopP is null && options.TopK is null)
+        {
+            return options;
+        }
+
+        var modelId = options.ModelId ?? boundModelId;
+        if (AnthropicModelUtilities.SupportsSamplingParameters(modelId))
+        {
+            return options;
+        }
+
+        var filtered = options.Clone();
+        filtered.Temperature = null;
+        filtered.TopP = null;
+        filtered.TopK = null;
+
+        logger?.LogDebug(
+            "Anthropic model '{ModelId}' does not accept the sampling parameters; " +
+            "Temperature/TopP/TopK were removed from the request.",
+            modelId ?? "(unresolved)");
+
+        return filtered;
+    }
+}

--- a/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicSamplingParameterChatClientTests.cs
+++ b/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicSamplingParameterChatClientTests.cs
@@ -47,8 +47,6 @@ public class AnthropicSamplingParameterChatClientTests
     [InlineData("claude-opus-4-8")]
     [InlineData("claude-opus-5")]
     [InlineData("claude-sonnet-5")]
-    [InlineData("claude-fable-5")]
-    [InlineData("claude-mythos-5")]
     public async Task GetResponseAsync_ModelRejectsSampling_DropsSamplingParameters(string modelId)
     {
         var (client, inner) = CreateClient(modelId);
@@ -60,19 +58,10 @@ public class AnthropicSamplingParameterChatClientTests
         inner.ReceivedOptions.Temperature.ShouldBeNull();
         inner.ReceivedOptions.TopP.ShouldBeNull();
         inner.ReceivedOptions.TopK.ShouldBeNull();
-    }
 
-    [Fact]
-    public async Task GetResponseAsync_ModelRejectsSampling_PreservesMaxOutputTokens()
-    {
-        // MaxOutputTokens is accepted by every model and is the setting issue #256 was actually about —
+        // MaxOutputTokens is accepted by every model and is the setting #256 was actually about —
         // filtering must not take it with the sampling parameters.
-        var (client, inner) = CreateClient("claude-opus-4-8");
-        var options = new ChatOptions { Temperature = 0.3f, MaxOutputTokens = 64000 };
-
-        await client.GetResponseAsync(Messages, options);
-
-        inner.ReceivedOptions!.MaxOutputTokens.ShouldBe(64000);
+        inner.ReceivedOptions.MaxOutputTokens.ShouldBe(64000);
     }
 
     [Fact]

--- a/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicSamplingParameterChatClientTests.cs
+++ b/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicSamplingParameterChatClientTests.cs
@@ -1,0 +1,176 @@
+using Microsoft.Extensions.AI;
+using Umbraco.AI.Anthropic.Tests.Unit.Fakes;
+
+namespace Umbraco.AI.Anthropic.Tests.Unit;
+
+/// <summary>
+/// Covers the sampling-parameter filtering that keeps a profile's configured temperature from being sent
+/// to Claude models that reject it (issue #256 follow-up).
+/// </summary>
+public class AnthropicSamplingParameterChatClientTests
+{
+    private static (AnthropicSamplingParameterChatClient Client, RecordingChatClient Inner) CreateClient(
+        string? boundModelId)
+    {
+        var inner = new RecordingChatClient();
+        return (new AnthropicSamplingParameterChatClient(inner, boundModelId, logger: null), inner);
+    }
+
+    private static readonly List<ChatMessage> Messages = [new(ChatRole.User, "hi")];
+
+    [Theory]
+    // Models that still accept the sampling parameters.
+    [InlineData("claude-3-opus-20240229")]
+    [InlineData("claude-3-5-sonnet-20241022")]
+    [InlineData("claude-3-7-sonnet-20250219")]
+    [InlineData("claude-sonnet-4-20250514")]
+    [InlineData("claude-opus-4-1-20250805")]
+    [InlineData("claude-opus-4-5-20251101")]
+    [InlineData("claude-haiku-4-5-20251001")]
+    [InlineData("claude-sonnet-4-6")]
+    [InlineData("claude-opus-4-6")]
+    public async Task GetResponseAsync_ModelSupportsSampling_ForwardsTemperature(string modelId)
+    {
+        var (client, inner) = CreateClient(modelId);
+        var options = new ChatOptions { Temperature = 0.3f, MaxOutputTokens = 64000 };
+
+        await client.GetResponseAsync(Messages, options);
+
+        inner.ReceivedOptions.ShouldNotBeNull();
+        inner.ReceivedOptions.Temperature.ShouldBe(0.3f);
+        inner.ReceivedOptions.MaxOutputTokens.ShouldBe(64000);
+    }
+
+    [Theory]
+    // Anthropic removed the sampling parameters from Opus 4.7 onwards.
+    [InlineData("claude-opus-4-7")]
+    [InlineData("claude-opus-4-8")]
+    [InlineData("claude-opus-5")]
+    [InlineData("claude-sonnet-5")]
+    [InlineData("claude-fable-5")]
+    [InlineData("claude-mythos-5")]
+    public async Task GetResponseAsync_ModelRejectsSampling_DropsSamplingParameters(string modelId)
+    {
+        var (client, inner) = CreateClient(modelId);
+        var options = new ChatOptions { Temperature = 0.3f, TopP = 0.9f, TopK = 40, MaxOutputTokens = 64000 };
+
+        await client.GetResponseAsync(Messages, options);
+
+        inner.ReceivedOptions.ShouldNotBeNull();
+        inner.ReceivedOptions.Temperature.ShouldBeNull();
+        inner.ReceivedOptions.TopP.ShouldBeNull();
+        inner.ReceivedOptions.TopK.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_ModelRejectsSampling_PreservesMaxOutputTokens()
+    {
+        // MaxOutputTokens is accepted by every model and is the setting issue #256 was actually about —
+        // filtering must not take it with the sampling parameters.
+        var (client, inner) = CreateClient("claude-opus-4-8");
+        var options = new ChatOptions { Temperature = 0.3f, MaxOutputTokens = 64000 };
+
+        await client.GetResponseAsync(Messages, options);
+
+        inner.ReceivedOptions!.MaxOutputTokens.ShouldBe(64000);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_UnknownModel_DropsSamplingParameters()
+    {
+        // Unknown models fail safe: dropping a value that would have worked is a degraded request,
+        // whereas sending one that is rejected is a failed request.
+        var (client, inner) = CreateClient("claude-something-not-yet-released");
+        var options = new ChatOptions { Temperature = 0.3f };
+
+        await client.GetResponseAsync(Messages, options);
+
+        inner.ReceivedOptions!.Temperature.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_NoModelResolved_DropsSamplingParameters()
+    {
+        var (client, inner) = CreateClient(boundModelId: null);
+        var options = new ChatOptions { Temperature = 0.3f };
+
+        await client.GetResponseAsync(Messages, options);
+
+        inner.ReceivedOptions!.Temperature.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_OptionsModelIdOverridesBoundModel()
+    {
+        // A caller-supplied ModelId wins over the model the client was bound to.
+        var (client, inner) = CreateClient("claude-sonnet-4-6");
+        var options = new ChatOptions { ModelId = "claude-opus-4-8", Temperature = 0.3f };
+
+        await client.GetResponseAsync(Messages, options);
+
+        inner.ReceivedOptions!.Temperature.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_BoundModelUsedWhenOptionsHaveNoModelId()
+    {
+        // The agent runtime builds ChatOptions without a ModelId, so the bound model is the only way to
+        // identify the target — this is the path issue #256's follow-up was reported on.
+        var (client, inner) = CreateClient("claude-opus-4-8");
+        var options = new ChatOptions { Temperature = 0.3f };
+
+        await client.GetResponseAsync(Messages, options);
+
+        inner.ReceivedOptions!.Temperature.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_DoesNotMutateCallerOptions()
+    {
+        var (client, _) = CreateClient("claude-opus-4-8");
+        var options = new ChatOptions { Temperature = 0.3f, TopP = 0.9f, TopK = 40 };
+
+        await client.GetResponseAsync(Messages, options);
+
+        options.Temperature.ShouldBe(0.3f);
+        options.TopP.ShouldBe(0.9f);
+        options.TopK.ShouldBe(40);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_NoSamplingParametersSet_PassesOriginalInstanceThrough()
+    {
+        // Nothing to remove, so no clone should be taken.
+        var (client, inner) = CreateClient("claude-opus-4-8");
+        var options = new ChatOptions { MaxOutputTokens = 1024 };
+
+        await client.GetResponseAsync(Messages, options);
+
+        inner.ReceivedOptions.ShouldBeSameAs(options);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_NullOptions_StaysNull()
+    {
+        var (client, inner) = CreateClient("claude-opus-4-8");
+
+        await client.GetResponseAsync(Messages);
+
+        inner.WasCalled.ShouldBeTrue();
+        inner.ReceivedOptions.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_ModelRejectsSampling_DropsSamplingParameters()
+    {
+        var (client, inner) = CreateClient("claude-opus-4-8");
+        var options = new ChatOptions { Temperature = 0.3f };
+
+        await foreach (var _ in client.GetStreamingResponseAsync(Messages, options))
+        {
+            // drain
+        }
+
+        inner.ReceivedOptions!.Temperature.ShouldBeNull();
+    }
+}

--- a/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/Fakes/RecordingChatClient.cs
+++ b/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/Fakes/RecordingChatClient.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.AI;
+
+namespace Umbraco.AI.Anthropic.Tests.Unit.Fakes;
+
+/// <summary>
+/// A minimal <see cref="IChatClient"/> that records the <see cref="ChatOptions"/> it was called with,
+/// so tests can assert on what a decorator forwarded to the underlying provider client.
+/// </summary>
+internal sealed class RecordingChatClient : IChatClient
+{
+    public ChatOptions? ReceivedOptions { get; private set; }
+
+    public bool WasCalled { get; private set; }
+
+    public Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ReceivedOptions = options;
+        WasCalled = true;
+        return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "ok")));
+    }
+
+    public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ReceivedOptions = options;
+        WasCalled = true;
+        yield return new ChatResponseUpdate(ChatRole.Assistant, "ok");
+        await Task.CompletedTask;
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+    public void Dispose()
+    {
+    }
+}

--- a/Umbraco.AI.OpenAI/Umbraco.AI.OpenAI.slnx
+++ b/Umbraco.AI.OpenAI/Umbraco.AI.OpenAI.slnx
@@ -1,3 +1,6 @@
 <Solution>
   <Project Path="src/Umbraco.AI.OpenAI/Umbraco.AI.OpenAI.csproj" />
+  <Folder Name="/Tests/">
+    <Project Path="tests/Umbraco.AI.OpenAI.Tests.Unit/Umbraco.AI.OpenAI.Tests.Unit.csproj" />
+  </Folder>
 </Solution>

--- a/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIChatCapability.cs
+++ b/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIChatCapability.cs
@@ -11,15 +11,24 @@ namespace Umbraco.AI.OpenAI;
 /// <summary>
 /// AI chat capability for OpenAI provider.
 /// </summary>
-/// <remarks>
-/// The <paramref name="logger"/> is optional so the capability can still be constructed directly (in tests,
-/// or by a caller that predates it) without a DI container supplying one.
-/// </remarks>
 public class OpenAIChatCapability(
     OpenAIProvider provider,
-    ILogger<OpenAIChatCapability>? logger = null)
+    ILogger<OpenAIChatCapability>? logger)
     : AIChatCapabilityBase<OpenAIProviderSettings>(provider)
 {
+    /// <summary>
+    /// Initializes a new instance without a logger.
+    /// </summary>
+    /// <remarks>
+    /// Retained so adding the logger parameter stays binary compatible. An optional parameter would not
+    /// achieve that — the compiler emits a single constructor and bakes the default in at each call site,
+    /// so assemblies compiled against the previous signature would fail to bind.
+    /// </remarks>
+    public OpenAIChatCapability(OpenAIProvider provider)
+        : this(provider, null)
+    {
+    }
+
     private const string DefaultChatModel = "gpt-4o";
 
     private new OpenAIProvider Provider => (OpenAIProvider)base.Provider;

--- a/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIChatCapability.cs
+++ b/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIChatCapability.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
 using Umbraco.AI.Core.Models;
 using Umbraco.AI.Core.Providers;
 using Umbraco.AI.Extensions;
@@ -10,7 +11,14 @@ namespace Umbraco.AI.OpenAI;
 /// <summary>
 /// AI chat capability for OpenAI provider.
 /// </summary>
-public class OpenAIChatCapability(OpenAIProvider provider) : AIChatCapabilityBase<OpenAIProviderSettings>(provider)
+/// <remarks>
+/// The <paramref name="logger"/> is optional so the capability can still be constructed directly (in tests,
+/// or by a caller that predates it) without a DI container supplying one.
+/// </remarks>
+public class OpenAIChatCapability(
+    OpenAIProvider provider,
+    ILogger<OpenAIChatCapability>? logger = null)
+    : AIChatCapabilityBase<OpenAIProviderSettings>(provider)
 {
     private const string DefaultChatModel = "gpt-4o";
 
@@ -55,9 +63,17 @@ public class OpenAIChatCapability(OpenAIProvider provider) : AIChatCapabilityBas
     /// <inheritdoc />
     [Experimental("OPENAI001")]
     protected override IChatClient CreateClient(OpenAIProviderSettings settings, string? modelId)
-        => OpenAIProvider.CreateOpenAIClient(settings)
+    {
+        var resolvedModelId = modelId ?? DefaultChatModel;
+
+        var inner = OpenAIProvider.CreateOpenAIClient(settings)
             .GetResponsesClient()
-            .AsIChatClient(modelId ?? DefaultChatModel);
+            .AsIChatClient(resolvedModelId);
+
+        // Wrapped innermost, so the sampling parameters are filtered against the target model no matter
+        // which caller assembled the ChatOptions. See OpenAISamplingParameterChatClient.
+        return new OpenAISamplingParameterChatClient(inner, resolvedModelId, logger);
+    }
 
     private static bool IsChatModel(string modelId)
         => IncludePatterns.Any(p => p.IsMatch(modelId))

--- a/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIModelUtilities.cs
+++ b/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIModelUtilities.cs
@@ -11,18 +11,11 @@ internal static class OpenAIModelUtilities
     /// Model families that accept the sampling parameters (<c>temperature</c>, <c>top_p</c>).
     /// </summary>
     /// <remarks>
-    /// <para>
     /// OpenAI's reasoning models (the <c>o</c>-series and the GPT-5 family) restrict the sampling
-    /// parameters — a non-default <c>temperature</c> is rejected rather than ignored. This is an
-    /// <em>allow</em>-list of the families that accept them rather than a deny-list of the ones that
-    /// don't, because the set of already-released models is closed and will never change, whereas a
-    /// deny-list would need updating on every OpenAI release just to stay correct.
-    /// </para>
-    /// <para>
-    /// The failure modes are asymmetric, and that is the whole point: a stale allow-list silently drops a
-    /// value on a brand-new model that would have honoured it (degraded, but the request succeeds), while
-    /// a stale deny-list sends a parameter to a model that rejects it (the request fails outright).
-    /// </para>
+    /// parameters — a non-default <c>temperature</c> is rejected rather than ignored. Deliberately an
+    /// allow-list rather than a deny-list, so that it fails safe: a stale allow-list degrades a request
+    /// by dropping a value the model would have honoured, whereas a stale deny-list fails one outright.
+    /// It also only has to be accurate about models that already exist, which is a closed set.
     /// </remarks>
     private static readonly Regex[] SamplingParameterModelPatterns =
     [

--- a/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIModelUtilities.cs
+++ b/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIModelUtilities.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+
 namespace Umbraco.AI.Extensions;
 
 /// <summary>
@@ -5,6 +7,47 @@ namespace Umbraco.AI.Extensions;
 /// </summary>
 internal static class OpenAIModelUtilities
 {
+    /// <summary>
+    /// Model families that accept the sampling parameters (<c>temperature</c>, <c>top_p</c>).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// OpenAI's reasoning models (the <c>o</c>-series and the GPT-5 family) restrict the sampling
+    /// parameters — a non-default <c>temperature</c> is rejected rather than ignored. This is an
+    /// <em>allow</em>-list of the families that accept them rather than a deny-list of the ones that
+    /// don't, because the set of already-released models is closed and will never change, whereas a
+    /// deny-list would need updating on every OpenAI release just to stay correct.
+    /// </para>
+    /// <para>
+    /// The failure modes are asymmetric, and that is the whole point: a stale allow-list silently drops a
+    /// value on a brand-new model that would have honoured it (degraded, but the request succeeds), while
+    /// a stale deny-list sends a parameter to a model that rejects it (the request fails outright).
+    /// </para>
+    /// </remarks>
+    private static readonly Regex[] SamplingParameterModelPatterns =
+    [
+        // GPT-3.5, GPT-4, GPT-4o, GPT-4.1 and their variants.
+        new(@"^gpt-3\.5", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"^gpt-4", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
+        // The ChatGPT-branded snapshots (e.g. chatgpt-4o-latest).
+        new(@"^chatgpt-", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+    ];
+
+    /// <summary>
+    /// Determines whether an OpenAI model accepts the sampling parameters (<c>temperature</c>,
+    /// <c>top_p</c>).
+    /// </summary>
+    /// <param name="modelId">The model ID, or <c>null</c> if no model has been resolved.</param>
+    /// <returns>
+    /// <c>true</c> when the model is a known family that accepts them; otherwise <c>false</c>. Unknown and
+    /// unresolved models — including the <c>o</c>-series and GPT-5 reasoning models — return <c>false</c>
+    /// so the parameters are dropped rather than risking a rejected request.
+    /// </returns>
+    public static bool SupportsSamplingParameters(string? modelId)
+        => !string.IsNullOrWhiteSpace(modelId)
+           && SamplingParameterModelPatterns.Any(p => p.IsMatch(modelId));
+
     /// <summary>
     /// Formats a model ID into a human-readable display name.
     /// </summary>

--- a/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAISamplingParameterChatClient.cs
+++ b/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAISamplingParameterChatClient.cs
@@ -1,0 +1,84 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Umbraco.AI.Extensions;
+
+namespace Umbraco.AI.OpenAI;
+
+/// <summary>
+/// A chat client decorator that removes the sampling parameters (<c>Temperature</c>, <c>TopP</c>,
+/// <c>TopK</c>) from the request when the target OpenAI model does not accept them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// OpenAI's reasoning models (the <c>o</c>-series and the GPT-5 family) restrict the sampling parameters,
+/// so forwarding a profile's configured temperature to one of them fails the request. Filtering here —
+/// inside the provider, beneath the core middleware pipeline — covers every caller at once: the chat
+/// service (<c>AIChatService.MergeOptions</c>), the agent runtime (<c>AIAgentFactory</c>), and anything
+/// calling <c>IChatClient</c> directly.
+/// </para>
+/// <para>
+/// The model is resolved from <see cref="ChatOptions.ModelId"/> when the caller set one, falling back to
+/// the model the client was bound to at creation. The fallback is load-bearing rather than defensive: the
+/// agent runtime builds its <see cref="ChatOptions"/> without a <c>ModelId</c>, so the bound value is the
+/// only way to identify the model on that path.
+/// </para>
+/// <para>
+/// The caller's <see cref="ChatOptions"/> is never mutated; a clone is taken only when something actually
+/// needs removing, so the common case allocates nothing.
+/// </para>
+/// </remarks>
+internal sealed class OpenAISamplingParameterChatClient(
+    IChatClient innerClient,
+    string? boundModelId,
+    ILogger? logger)
+    : DelegatingChatClient(innerClient)
+{
+    /// <inheritdoc />
+    public override Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => base.GetResponseAsync(messages, FilterOptions(options), cancellationToken);
+
+    /// <inheritdoc />
+    public override IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => base.GetStreamingResponseAsync(messages, FilterOptions(options), cancellationToken);
+
+    /// <summary>
+    /// Returns the options to send, with the sampling parameters removed when the resolved model
+    /// does not accept them. Returns the original instance untouched when there is nothing to remove.
+    /// </summary>
+    internal ChatOptions? FilterOptions(ChatOptions? options)
+    {
+        if (options is null)
+        {
+            return null;
+        }
+
+        if (options.Temperature is null && options.TopP is null && options.TopK is null)
+        {
+            return options;
+        }
+
+        var modelId = options.ModelId ?? boundModelId;
+        if (OpenAIModelUtilities.SupportsSamplingParameters(modelId))
+        {
+            return options;
+        }
+
+        var filtered = options.Clone();
+        filtered.Temperature = null;
+        filtered.TopP = null;
+        filtered.TopK = null;
+
+        logger?.LogDebug(
+            "OpenAI model '{ModelId}' does not accept the sampling parameters; " +
+            "Temperature/TopP/TopK were removed from the request.",
+            modelId ?? "(unresolved)");
+
+        return filtered;
+    }
+}

--- a/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAISamplingParameterChatClient.cs
+++ b/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAISamplingParameterChatClient.cs
@@ -22,10 +22,6 @@ namespace Umbraco.AI.OpenAI;
 /// agent runtime builds its <see cref="ChatOptions"/> without a <c>ModelId</c>, so the bound value is the
 /// only way to identify the model on that path.
 /// </para>
-/// <para>
-/// The caller's <see cref="ChatOptions"/> is never mutated; a clone is taken only when something actually
-/// needs removing, so the common case allocates nothing.
-/// </para>
 /// </remarks>
 internal sealed class OpenAISamplingParameterChatClient(
     IChatClient innerClient,
@@ -49,9 +45,10 @@ internal sealed class OpenAISamplingParameterChatClient(
 
     /// <summary>
     /// Returns the options to send, with the sampling parameters removed when the resolved model
-    /// does not accept them. Returns the original instance untouched when there is nothing to remove.
+    /// does not accept them. Returns the original instance untouched when there is nothing to remove,
+    /// so the caller's <see cref="ChatOptions"/> is never mutated.
     /// </summary>
-    internal ChatOptions? FilterOptions(ChatOptions? options)
+    private ChatOptions? FilterOptions(ChatOptions? options)
     {
         if (options is null)
         {

--- a/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/Fakes/RecordingChatClient.cs
+++ b/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/Fakes/RecordingChatClient.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.AI;
+
+namespace Umbraco.AI.OpenAI.Tests.Unit.Fakes;
+
+/// <summary>
+/// A minimal <see cref="IChatClient"/> that records the <see cref="ChatOptions"/> it was called with,
+/// so tests can assert on what a decorator forwarded to the underlying provider client.
+/// </summary>
+internal sealed class RecordingChatClient : IChatClient
+{
+    public ChatOptions? ReceivedOptions { get; private set; }
+
+    public bool WasCalled { get; private set; }
+
+    public Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ReceivedOptions = options;
+        WasCalled = true;
+        return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "ok")));
+    }
+
+    public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ReceivedOptions = options;
+        WasCalled = true;
+        yield return new ChatResponseUpdate(ChatRole.Assistant, "ok");
+        await Task.CompletedTask;
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+    public void Dispose()
+    {
+    }
+}

--- a/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/OpenAISamplingParameterChatClientTests.cs
+++ b/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/OpenAISamplingParameterChatClientTests.cs
@@ -1,0 +1,157 @@
+using Microsoft.Extensions.AI;
+using Umbraco.AI.OpenAI.Tests.Unit.Fakes;
+
+namespace Umbraco.AI.OpenAI.Tests.Unit;
+
+/// <summary>
+/// Covers the sampling-parameter filtering that keeps a profile's configured temperature from being sent
+/// to OpenAI reasoning models, which restrict it (issue #256 follow-up).
+/// </summary>
+public class OpenAISamplingParameterChatClientTests
+{
+    private static (OpenAISamplingParameterChatClient Client, RecordingChatClient Inner) CreateClient(
+        string? boundModelId)
+    {
+        var inner = new RecordingChatClient();
+        return (new OpenAISamplingParameterChatClient(inner, boundModelId, logger: null), inner);
+    }
+
+    private static readonly List<ChatMessage> Messages = [new(ChatRole.User, "hi")];
+
+    [Theory]
+    [InlineData("gpt-4o")]
+    [InlineData("gpt-4o-mini")]
+    [InlineData("gpt-4-turbo")]
+    [InlineData("gpt-4.1")]
+    [InlineData("gpt-3.5-turbo")]
+    [InlineData("chatgpt-4o-latest")]
+    public async Task GetResponseAsync_ModelSupportsSampling_ForwardsTemperature(string modelId)
+    {
+        var (client, inner) = CreateClient(modelId);
+        var options = new ChatOptions { Temperature = 0.3f, MaxOutputTokens = 4096 };
+
+        await client.GetResponseAsync(Messages, options);
+
+        inner.ReceivedOptions.ShouldNotBeNull();
+        inner.ReceivedOptions.Temperature.ShouldBe(0.3f);
+        inner.ReceivedOptions.MaxOutputTokens.ShouldBe(4096);
+    }
+
+    [Theory]
+    // Reasoning models restrict the sampling parameters.
+    [InlineData("o1")]
+    [InlineData("o1-mini")]
+    [InlineData("o3")]
+    [InlineData("o3-mini")]
+    [InlineData("gpt-5")]
+    [InlineData("gpt-5-mini")]
+    public async Task GetResponseAsync_ModelRejectsSampling_DropsSamplingParameters(string modelId)
+    {
+        var (client, inner) = CreateClient(modelId);
+        var options = new ChatOptions { Temperature = 0.3f, TopP = 0.9f, TopK = 40, MaxOutputTokens = 4096 };
+
+        await client.GetResponseAsync(Messages, options);
+
+        inner.ReceivedOptions.ShouldNotBeNull();
+        inner.ReceivedOptions.Temperature.ShouldBeNull();
+        inner.ReceivedOptions.TopP.ShouldBeNull();
+        inner.ReceivedOptions.TopK.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_ModelRejectsSampling_PreservesMaxOutputTokens()
+    {
+        var (client, inner) = CreateClient("o3");
+        var options = new ChatOptions { Temperature = 0.3f, MaxOutputTokens = 4096 };
+
+        await client.GetResponseAsync(Messages, options);
+
+        inner.ReceivedOptions!.MaxOutputTokens.ShouldBe(4096);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_UnknownModel_DropsSamplingParameters()
+    {
+        // Unknown models fail safe: dropping a value that would have worked is a degraded request,
+        // whereas sending one that is rejected is a failed request.
+        var (client, inner) = CreateClient("some-future-model");
+        var options = new ChatOptions { Temperature = 0.3f };
+
+        await client.GetResponseAsync(Messages, options);
+
+        inner.ReceivedOptions!.Temperature.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_BoundModelUsedWhenOptionsHaveNoModelId()
+    {
+        // The agent runtime builds ChatOptions without a ModelId, so the bound model is the only way to
+        // identify the target.
+        var (client, inner) = CreateClient("o3");
+        var options = new ChatOptions { Temperature = 0.3f };
+
+        await client.GetResponseAsync(Messages, options);
+
+        inner.ReceivedOptions!.Temperature.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_OptionsModelIdOverridesBoundModel()
+    {
+        var (client, inner) = CreateClient("gpt-4o");
+        var options = new ChatOptions { ModelId = "o3", Temperature = 0.3f };
+
+        await client.GetResponseAsync(Messages, options);
+
+        inner.ReceivedOptions!.Temperature.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_DoesNotMutateCallerOptions()
+    {
+        var (client, _) = CreateClient("o3");
+        var options = new ChatOptions { Temperature = 0.3f, TopP = 0.9f, TopK = 40 };
+
+        await client.GetResponseAsync(Messages, options);
+
+        options.Temperature.ShouldBe(0.3f);
+        options.TopP.ShouldBe(0.9f);
+        options.TopK.ShouldBe(40);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_NoSamplingParametersSet_PassesOriginalInstanceThrough()
+    {
+        var (client, inner) = CreateClient("o3");
+        var options = new ChatOptions { MaxOutputTokens = 1024 };
+
+        await client.GetResponseAsync(Messages, options);
+
+        inner.ReceivedOptions.ShouldBeSameAs(options);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_NullOptions_StaysNull()
+    {
+        var (client, inner) = CreateClient("o3");
+
+        await client.GetResponseAsync(Messages);
+
+        inner.WasCalled.ShouldBeTrue();
+        inner.ReceivedOptions.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_ModelRejectsSampling_DropsSamplingParameters()
+    {
+        var (client, inner) = CreateClient("o3");
+        var options = new ChatOptions { Temperature = 0.3f };
+
+        await foreach (var _ in client.GetStreamingResponseAsync(Messages, options))
+        {
+            // drain
+        }
+
+        inner.ReceivedOptions!.Temperature.ShouldBeNull();
+    }
+}

--- a/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/OpenAISamplingParameterChatClientTests.cs
+++ b/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/OpenAISamplingParameterChatClientTests.cs
@@ -56,17 +56,10 @@ public class OpenAISamplingParameterChatClientTests
         inner.ReceivedOptions.Temperature.ShouldBeNull();
         inner.ReceivedOptions.TopP.ShouldBeNull();
         inner.ReceivedOptions.TopK.ShouldBeNull();
-    }
 
-    [Fact]
-    public async Task GetResponseAsync_ModelRejectsSampling_PreservesMaxOutputTokens()
-    {
-        var (client, inner) = CreateClient("o3");
-        var options = new ChatOptions { Temperature = 0.3f, MaxOutputTokens = 4096 };
-
-        await client.GetResponseAsync(Messages, options);
-
-        inner.ReceivedOptions!.MaxOutputTokens.ShouldBe(4096);
+        // MaxOutputTokens is accepted by every model and is the setting #256 was actually about —
+        // filtering must not take it with the sampling parameters.
+        inner.ReceivedOptions.MaxOutputTokens.ShouldBe(4096);
     }
 
     [Fact]
@@ -75,19 +68,6 @@ public class OpenAISamplingParameterChatClientTests
         // Unknown models fail safe: dropping a value that would have worked is a degraded request,
         // whereas sending one that is rejected is a failed request.
         var (client, inner) = CreateClient("some-future-model");
-        var options = new ChatOptions { Temperature = 0.3f };
-
-        await client.GetResponseAsync(Messages, options);
-
-        inner.ReceivedOptions!.Temperature.ShouldBeNull();
-    }
-
-    [Fact]
-    public async Task GetResponseAsync_BoundModelUsedWhenOptionsHaveNoModelId()
-    {
-        // The agent runtime builds ChatOptions without a ModelId, so the bound model is the only way to
-        // identify the target.
-        var (client, inner) = CreateClient("o3");
         var options = new ChatOptions { Temperature = 0.3f };
 
         await client.GetResponseAsync(Messages, options);

--- a/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/Umbraco.AI.OpenAI.Tests.Unit.csproj
+++ b/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/Umbraco.AI.OpenAI.Tests.Unit.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsTestProject>true</IsTestProject>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Umbraco.AI.OpenAI\Umbraco.AI.OpenAI.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="Shouldly" />
+  </ItemGroup>
+
+</Project>

--- a/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/packages.lock.json
+++ b/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/packages.lock.json
@@ -979,6 +979,14 @@
         "resolved": "6.2.0",
         "contentHash": "DRx593fF5CJZ8pj94StWdZsE9/iXkJKp3L2xp6Y9EAliHf4+e1y4QvWL/jJmeZ7zb8NKpwyf6tq1CZDS2mQwAA=="
       },
+      "OpenAI": {
+        "type": "Transitive",
+        "resolved": "2.11.0",
+        "contentHash": "f0y5zOZVNhuc/gPQUHGkiljZlDUq2SddGOkGTPLHnjQC5mCiTCXq1BqxZ+xxxHU6bY0mEtFQJj1RlB2BpwD7Lw==",
+        "dependencies": {
+          "System.ClientModel": "1.10.0"
+        }
+      },
       "OpenIddict": {
         "type": "Transitive",
         "resolved": "7.4.0",
@@ -1440,8 +1448,8 @@
       },
       "System.Memory.Data": {
         "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "BVYuec3jV23EMRDeR7Dr1/qhx7369dZzJ9IWy2xylvb4YfXsrUxspWc4UWYid/tj4zZK58uGZqn2WQiaDMhmAg=="
+        "resolved": "10.0.3",
+        "contentHash": "MaGhRfGunmrj/nHjtsi9XkhlYJ/ERGWrbA+BiSKNtGnAjc9XlG5EhAvak6VRcX5LYzPF6pBO8nJ613dTgzabig=="
       },
       "System.Numerics.Tensors": {
         "type": "Transitive",
@@ -1642,13 +1650,6 @@
           "xunit.extensibility.core": "[2.9.3]"
         }
       },
-      "umbraco.ai.anthropic": {
-        "type": "Project",
-        "dependencies": {
-          "Anthropic": "[12.29.1, 12.999.999)",
-          "Umbraco.AI.Core": "[1.0.0, )"
-        }
-      },
       "umbraco.ai.core": {
         "type": "Project",
         "dependencies": {
@@ -1665,13 +1666,11 @@
           "Umbraco.Cms.Web.Common": "[17.4.0, 17.999.999)"
         }
       },
-      "Anthropic": {
-        "type": "CentralTransitive",
-        "requested": "[12.29.1, 12.999.999)",
-        "resolved": "12.29.1",
-        "contentHash": "EVq7ygOtMejWNXW+Dz+vv/ie50JgZB4jFc4gT2TTpBZXtp64zWRR7DqdGhbEaYThyMuaevN4ZRGUWBrSrb0+rg==",
+      "umbraco.ai.openai": {
+        "type": "Project",
         "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "10.5.1"
+          "Microsoft.Extensions.AI.OpenAI": "[10.7.0, 10.999.999)",
+          "Umbraco.AI.Core": "[1.0.0, )"
         }
       },
       "DocumentFormat.OpenXml": {
@@ -1694,6 +1693,16 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
           "System.Numerics.Tensors": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.AI.OpenAI": {
+        "type": "CentralTransitive",
+        "requested": "[10.7.0, 10.999.999)",
+        "resolved": "10.7.0",
+        "contentHash": "K/xC0SRJeQiHJNNx+ZIYq9liAB5Uy/wUGjHPljEtRW63TCyGWEBkNVU7/UwizTxQk0Tm9pclDEoNmKTw7xtKfg==",
+        "dependencies": {
+          "Microsoft.Extensions.AI.Abstractions": "10.7.0",
+          "OpenAI": "2.11.0"
         }
       },
       "Microsoft.Extensions.Caching.Memory": {
@@ -1737,11 +1746,13 @@
       "System.ClientModel": {
         "type": "CentralTransitive",
         "requested": "[1.5.0, 1.999.999)",
-        "resolved": "1.5.0",
-        "contentHash": "nyQUynSbLh8IVyETF2tN14IQwBYgif3gIBt2LAL3FSl0W5FIEJIog3sposTxdz23EqDN78LAQFpUxbaj1EsRJw==",
+        "resolved": "1.10.0",
+        "contentHash": "lBEWs54F5Y5pZ9hC+8z4S/X76957ex+DPk7WecRHlbIHtrPfbRMMlOgI3iDn4Jpb3bSxvBnKaaHoD59auFjlBA==",
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
-          "System.Memory.Data": "8.0.1"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "System.Memory.Data": "10.0.3"
         }
       },
       "Umbraco.Cms.Api.Management": {

--- a/Umbraco.AI.slnx
+++ b/Umbraco.AI.slnx
@@ -65,9 +65,11 @@
   <Folder Name="/Providers/" />
   <Folder Name="/Providers/Amazon/">
     <Project Path="Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/Umbraco.AI.Amazon.csproj" />
+    <Project Path="Umbraco.AI.Amazon/tests/Umbraco.AI.Amazon.Tests.Unit/Umbraco.AI.Amazon.Tests.Unit.csproj" />
   </Folder>
   <Folder Name="/Providers/Anthropic/">
     <Project Path="Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/Umbraco.AI.Anthropic.csproj" />
+    <Project Path="Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/Umbraco.AI.Anthropic.Tests.Unit.csproj" />
   </Folder>
   <Folder Name="/Providers/DeepSeek/">
     <Project Path="Umbraco.AI.DeepSeek/src/Umbraco.AI.DeepSeek/Umbraco.AI.DeepSeek.csproj" />
@@ -89,6 +91,7 @@
   </Folder>
   <Folder Name="/Providers/OpenAI/">
     <Project Path="Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/Umbraco.AI.OpenAI.csproj" />
+    <Project Path="Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/Umbraco.AI.OpenAI.Tests.Unit.csproj" />
   </Folder>
   <Folder Name="/Providers/TogetherAI/">
     <Project Path="Umbraco.AI.TogetherAI/src/Umbraco.AI.TogetherAI/Umbraco.AI.TogetherAI.csproj" />


### PR DESCRIPTION
Backport of #265 to the v17 line. Fixes #268 (reported by @Ron-Brouwer as a follow-up on #256). Remaining gaps are tracked in #266.

## Problem

```
Anthropic.Exceptions.AnthropicBadRequestException: Status Code: BadRequest
{"type":"error","error":{"type":"invalid_request_error",
"message":"`temperature` is deprecated for this model."}
```

Anthropic removed `temperature` / `top_p` / `top_k` from Claude Opus 4.7 onwards — sending any of them is a hard 400. OpenAI's reasoning models (o-series, GPT-5) restrict them the same way and are selectable in a profile today. Bedrock inherits the restriction from whichever vendor's model it is fronting.

Wider than the agent path: #258 added `Temperature` to `AIAgentFactory`, which is why it surfaced there, but `AIChatService.MergeOptions` has always sent it — so the core chat path had the same failure. Fixing it in the provider closes both.

## Fix

Each affected provider wraps its `IChatClient` in a decorator that removes the sampling parameters when the target model doesn't accept them. It sits innermost — inside `CreateClient`, beneath the core middleware pipeline — so it covers `AIChatService.MergeOptions`, the agent runtime, and direct `IChatClient` consumers alike. `MaxOutputTokens` is untouched.

Support is an **allow-list of the older families that accept the parameters**, not a deny-list of the newer ones: the set of released models is closed and never changes, whereas a deny-list needs updating on every vendor release just to stay correct. The failure modes are asymmetric — a stale allow-list silently drops a value that would have worked (degraded, request succeeds); a stale deny-list sends one to a model that rejects it (request fails). Unknown models therefore fail safe.

Model resolution comes from `ChatOptions.ModelId`, falling back to the model the client was bound to. The fallback is load-bearing: the agent runtime builds `ChatOptions` without a `ModelId`, and that's the reported path.

See #265 for the full rationale and the per-provider allow-list tables — the code is identical.

## v17-specific note

The cherry-pick was clean, but restoring surfaced a **pre-existing lock file drift on `v17/dev`**: `Umbraco.AI.Anthropic.Tests.Unit/packages.lock.json` still pinned `Umbraco.Code 2.4.0` while `Directory.Packages.props` requires `3.0.0-beta`. It went unnoticed because that test project wasn't in `Umbraco.AI.slnx`, so nothing in CI ever restored it. This PR adds it to the solution, which puts it back in the restore graph, so the regenerated lock file is included here.

`RestoreLockedMode` isn't set and CI doesn't pass `--locked-mode`, so this wasn't failing the build — restore was silently regenerating it. Worth knowing the drift existed.

## Tests

74 new tests across the three packages. Full solution green locally: `dotnet build` + `dotnet test Umbraco.AI.slnx --configuration Release` → 1320 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)