### PR TITLE
feat(core,openai,anthropic): Add provider-declared, model-aware capability settings

### DIFF
--- a/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/AmazonChatCapability.cs
+++ b/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/AmazonChatCapability.cs
@@ -1,10 +1,12 @@
 using System.Text.RegularExpressions;
 using Amazon.BedrockRuntime;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Umbraco.AI.Core.Models;
 using Umbraco.AI.Core.Providers;
 using Umbraco.AI.Extensions;
+using Umbraco.Cms.Core.DependencyInjection;
 
 namespace Umbraco.AI.Amazon;
 
@@ -23,9 +25,16 @@ public class AmazonChatCapability(
     /// Retained so adding the logger parameter stays binary compatible. An optional parameter would not
     /// achieve that — the compiler emits a single constructor and bakes the default in at each call site,
     /// so assemblies compiled against the previous signature would fail to bind.
+    /// <para>
+    /// The logger is resolved through the service locator, following the same approach as
+    /// <c>AIGuardrailEvaluatorBase</c>, so a consumer still on this signature gets real logging rather than
+    /// none. Null-conditional because the locator is unset before startup and in unit tests, and logging is
+    /// optional here — unlike the required services that pattern usually resolves.
+    /// </para>
     /// </remarks>
+    [Obsolete("Use the constructor that accepts a logger. Will be removed in v20.")]
     public AmazonChatCapability(AmazonProvider provider)
-        : this(provider, null)
+        : this(provider, StaticServiceProvider.Instance?.GetService<ILogger<AmazonChatCapability>>())
     {
     }
 

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
@@ -92,23 +92,12 @@ public class AnthropicChatCapability(
             };
 
     /// <inheritdoc />
-    protected override IChatClient CreateClient(AnthropicProviderSettings settings, string? modelId)
-    {
-        var inner = AnthropicProvider.CreateAnthropicClient(settings)
-            .Beta.AsIChatClient(modelId);
-
-        // Wrapped innermost, so the sampling parameters are filtered against the target model no matter
-        // which caller assembled the ChatOptions. See AnthropicSamplingParameterChatClient.
-        return new AnthropicSamplingParameterChatClient(inner, modelId, logger);
-    }
-
-    /// <inheritdoc />
     /// <remarks>
     /// <para>
-    /// Fetches the model list (cached) before handing back the client, so the per-request settings hook can
-    /// read the target model's reported capabilities synchronously. Both interface entry points route
-    /// through here rather than the synchronous <see cref="CreateClient"/>, so the prefetch cannot be
-    /// bypassed from outside the capability.
+    /// Fetches the model list (cached) before building the client, so the per-request settings hook can
+    /// read the target model's reported capabilities synchronously. This is the capability's only creation
+    /// method: the synchronous <c>CreateClient</c> hook is left unimplemented because every path that
+    /// reaches it would skip the prefetch, and both interface entry points route through here anyway.
     /// </para>
     /// <para>
     /// A failure is not fatal — capability data refines the decision but is not required to make a request,
@@ -134,7 +123,12 @@ public class AnthropicChatCapability(
                 + "is unavailable, so setting support will be inferred from the model ID instead.");
         }
 
-        return CreateClient(settings, modelId);
+        var inner = Provider.CreateSdkClient(settings)
+            .Beta.AsIChatClient(modelId);
+
+        // Wrapped innermost, so the sampling parameters are filtered against the target model no matter
+        // which caller assembled the ChatOptions. See AnthropicSamplingParameterChatClient.
+        return new AnthropicSamplingParameterChatClient(inner, modelId, logger);
     }
 
     /// <inheritdoc />

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
@@ -1,10 +1,12 @@
 using System.Text.RegularExpressions;
 using Anthropic.Models.Beta.Messages;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Umbraco.AI.Core.Models;
 using Umbraco.AI.Core.Providers;
 using Umbraco.AI.Extensions;
+using Umbraco.Cms.Core.DependencyInjection;
 
 namespace Umbraco.AI.Anthropic;
 
@@ -23,9 +25,16 @@ public class AnthropicChatCapability(
     /// Retained so adding the logger parameter stays binary compatible. An optional parameter would not
     /// achieve that — the compiler emits a single constructor and bakes the default in at each call site,
     /// so assemblies compiled against the previous signature would fail to bind.
+    /// <para>
+    /// The logger is resolved through the service locator, following the same approach as
+    /// <c>AIGuardrailEvaluatorBase</c>, so a consumer still on this signature gets real logging rather than
+    /// none. Null-conditional because the locator is unset before startup and in unit tests, and logging is
+    /// optional here — unlike the required services that pattern usually resolves.
+    /// </para>
     /// </remarks>
+    [Obsolete("Use the constructor that accepts a logger. Will be removed in v20.")]
     public AnthropicChatCapability(AnthropicProvider provider)
-        : this(provider, null)
+        : this(provider, StaticServiceProvider.Instance?.GetService<ILogger<AnthropicChatCapability>>())
     {
     }
 

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
@@ -59,7 +59,7 @@ public class AnthropicChatCapability(
     /// <inheritdoc />
     /// <remarks>
     /// The declaration of which settings each model accepts is written here rather than through
-    /// <see cref="IAICapability.GetSettingSupport"/>, because Anthropic's models endpoint reports it as
+    /// <see cref="IAICapability.GetSettingsSupport"/>, because Anthropic's models endpoint reports it as
     /// data: <c>capabilities.effort.supported</c> per model. Only models the API says nothing about fall
     /// back to inferring support from the ID.
     /// </remarks>
@@ -83,10 +83,10 @@ public class AnthropicChatCapability(
     /// Turns a model's reported capabilities into the settings declaration the profile editor reads,
     /// falling back to the ID-based predicate when the API reported nothing for the model.
     /// </summary>
-    private static AIModelSettingSupport BuildSettingSupport(AnthropicModelCapability model)
+    private static AIModelSettingsSupport BuildSettingSupport(AnthropicModelCapability model)
         => (model.SupportsEffort ?? AnthropicModelUtilities.SupportsEffort(model.Id))
-            ? AIModelSettingSupport.Default
-            : new AIModelSettingSupport
+            ? AIModelSettingsSupport.Default
+            : new AIModelSettingsSupport
             {
                 UnsupportedCapabilitySettings = [nameof(AnthropicChatCapabilitySettings.Effort)],
             };
@@ -140,7 +140,7 @@ public class AnthropicChatCapability(
     /// </para>
     /// <para>
     /// Skipped when the model does not accept effort at all, or does not accept the configured level —
-    /// the same predicates that drive <see cref="GetSettingSupport"/> — so a profile carrying a value the
+    /// the same predicates that drive <see cref="GetSettingsSupport"/> — so a profile carrying a value the
     /// model rejects cannot fail the request.
     /// </para>
     /// </remarks>

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
@@ -32,29 +32,34 @@ public class AnthropicChatCapability(AnthropicProvider provider)
     ];
 
     /// <inheritdoc />
+    /// <remarks>
+    /// The declaration of which settings each model accepts is written here rather than through
+    /// <see cref="IAICapability.GetSettingSupport"/>, because Anthropic's models endpoint reports it as
+    /// data: <c>capabilities.effort.supported</c> per model. Only models the API says nothing about fall
+    /// back to inferring support from the ID.
+    /// </remarks>
     protected override async Task<IReadOnlyList<AIModelDescriptor>> GetModelsAsync(
         AnthropicProviderSettings settings,
         CancellationToken cancellationToken = default)
     {
-        var allModels = await Provider.GetAvailableModelIdsAsync(settings, cancellationToken);
+        var allModels = await Provider.GetAvailableModelsAsync(settings, cancellationToken);
 
         return allModels
-            .Where(IsChatModel)
-            .Select(id => new AIModelDescriptor(
-                new AIModelRef(Provider.Id, id),
-                AnthropicModelUtilities.FormatDisplayName(id)))
+            .Where(m => IsChatModel(m.Id))
+            .OrderBy(m => m.Id)
+            .Select(m => new AIModelDescriptor(
+                new AIModelRef(Provider.Id, m.Id),
+                AnthropicModelUtilities.FormatDisplayName(m.Id),
+                BuildSettingSupport(m).ToMetadata()))
             .ToList();
     }
 
-    /// <inheritdoc />
-    /// <remarks>
-    /// Effort is not accepted by Claude 3.x, the base Claude 4 models, Opus 4.1, Sonnet 4.5 or Haiku 4.5,
-    /// so it is declared per model — otherwise the profile editor would offer it on a model that rejects
-    /// it. That legacy set is closed, so the predicate is a deny-list and an unrecognised model is treated
-    /// as supporting effort.
-    /// </remarks>
-    public override AIModelSettingSupport GetSettingSupport(string modelId)
-        => AnthropicModelUtilities.SupportsEffort(modelId)
+    /// <summary>
+    /// Turns a model's reported capabilities into the settings declaration the profile editor reads,
+    /// falling back to the ID-based predicate when the API reported nothing for the model.
+    /// </summary>
+    private static AIModelSettingSupport BuildSettingSupport(AnthropicModelCapability model)
+        => (model.SupportsEffort ?? AnthropicModelUtilities.SupportsEffort(model.Id))
             ? AIModelSettingSupport.Default
             : new AIModelSettingSupport
             {
@@ -65,6 +70,30 @@ public class AnthropicChatCapability(AnthropicProvider provider)
     protected override IChatClient CreateClient(AnthropicProviderSettings settings, string? modelId)
         => AnthropicProvider.CreateAnthropicClient(settings)
             .Beta.AsIChatClient(modelId);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Fetches the model list (cached) before handing back the client, so the per-request settings hook can
+    /// read the target model's reported capabilities synchronously. A failure here is swallowed: capability
+    /// data refines the decision but is not required to make a request, and losing the model list must not
+    /// stop chat from working.
+    /// </remarks>
+    protected override async Task<IChatClient> CreateClientAsync(
+        AnthropicProviderSettings settings,
+        string? modelId,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await Provider.GetAvailableModelsAsync(settings, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Fall back to inferring support from the model ID.
+        }
+
+        return CreateClient(settings, modelId);
+    }
 
     /// <inheritdoc />
     /// <remarks>
@@ -97,7 +126,11 @@ public class AnthropicChatCapability(AnthropicProvider provider)
         var model = modelId ?? DefaultChatModel;
         var level = capabilitySettings.Effort.Trim().ToLowerInvariant();
 
-        if (!AnthropicModelUtilities.SupportsEffortLevel(model, level))
+        // Prefer what the API reported for this model; fall back to the ID predicate when it is unknown.
+        var supportsEffort = Provider.TryGetModelCapability(model)?.SupportsEffort
+                             ?? AnthropicModelUtilities.SupportsEffort(model);
+
+        if (!supportsEffort || !AnthropicModelUtilities.IsKnownEffortLevel(level))
         {
             return;
         }

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
@@ -75,7 +75,7 @@ public class AnthropicChatCapability(
             .Select(m => new AIModelDescriptor(
                 new AIModelRef(Provider.Id, m.Id),
                 AnthropicModelUtilities.FormatDisplayName(m.Id),
-                BuildSettingSupport(m).ToMetadata()))
+                BuildSettingsSupport(m).ToMetadata()))
             .ToList();
     }
 
@@ -83,7 +83,7 @@ public class AnthropicChatCapability(
     /// Turns a model's reported capabilities into the settings declaration the profile editor reads,
     /// falling back to the ID-based predicate when the API reported nothing for the model.
     /// </summary>
-    private static AIModelSettingsSupport BuildSettingSupport(AnthropicModelCapability model)
+    private static AIModelSettingsSupport BuildSettingsSupport(AnthropicModelCapability model)
         => (model.SupportsEffort ?? AnthropicModelUtilities.SupportsEffort(model.Id))
             ? AIModelSettingsSupport.Default
             : new AIModelSettingsSupport

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
@@ -107,8 +107,8 @@ public class AnthropicChatCapability(AnthropicProvider provider)
             "low" => Effort.Low,
             "medium" => Effort.Medium,
             "high" => Effort.High,
-            "xhigh" => Effort.Xhigh,
-            "max" => Effort.Max,
+            // xhigh and max are not offered: which models accept them cannot be tracked with a list, so a
+            // stored value for either is skipped rather than sent.
             _ => (Effort?)null,
         };
 

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Anthropic.Models.Beta.Messages;
 using Microsoft.Extensions.AI;
 using Umbraco.AI.Core.Models;
 using Umbraco.AI.Core.Providers;
@@ -9,9 +10,16 @@ namespace Umbraco.AI.Anthropic;
 /// <summary>
 /// AI chat capability for Anthropic provider.
 /// </summary>
-public class AnthropicChatCapability(AnthropicProvider provider) : AIChatCapabilityBase<AnthropicProviderSettings>(provider)
+public class AnthropicChatCapability(AnthropicProvider provider)
+    : AIChatCapabilityBase<AnthropicProviderSettings, AnthropicChatCapabilitySettings>(provider)
 {
     private const string DefaultChatModel = "claude-sonnet-4-20250514";
+
+    /// <summary>
+    /// The max-tokens value the SDK's Microsoft.Extensions.AI adapter sends when the caller sets none.
+    /// Mirrored here because a raw representation must supply the value itself.
+    /// </summary>
+    private const int AdapterDefaultMaxTokens = 1024;
     
     private new AnthropicProvider Provider => (AnthropicProvider)base.Provider;
 
@@ -39,9 +47,103 @@ public class AnthropicChatCapability(AnthropicProvider provider) : AIChatCapabil
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Effort is not accepted by Claude 3.x, the base Claude 4 models, Opus 4.1, Sonnet 4.5 or Haiku 4.5,
+    /// so it is declared per model — otherwise the profile editor would offer it on a model that rejects
+    /// it. That legacy set is closed, so the predicate is a deny-list and an unrecognised model is treated
+    /// as supporting effort.
+    /// </remarks>
+    public override AIModelSettingSupport GetSettingSupport(string modelId)
+        => AnthropicModelUtilities.SupportsEffort(modelId)
+            ? AIModelSettingSupport.Default
+            : new AIModelSettingSupport
+            {
+                UnsupportedCapabilitySettings = [nameof(AnthropicChatCapabilitySettings.Effort)],
+            };
+
+    /// <inheritdoc />
     protected override IChatClient CreateClient(AnthropicProviderSettings settings, string? modelId)
         => AnthropicProvider.CreateAnthropicClient(settings)
             .Beta.AsIChatClient(modelId);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// <para>
+    /// Sets <c>output_config.effort</c> through <see cref="ChatOptions.RawRepresentationFactory"/>, the
+    /// only channel the SDK's Microsoft.Extensions.AI adapter reads — values placed in
+    /// <see cref="ChatOptions.AdditionalProperties"/> are dropped before the request is built.
+    /// </para>
+    /// <para>
+    /// The adapter treats the factory's result as the request base and overwrites only the messages, so
+    /// the model and max-tokens values have to be carried into it here or the request would be sent with
+    /// whatever this method put there. <c>AnthropicEffortWireTests</c> pins both behaviours down.
+    /// </para>
+    /// <para>
+    /// Skipped when the model does not accept effort at all, or does not accept the configured level —
+    /// the same predicates that drive <see cref="GetSettingSupport"/> — so a profile carrying a value the
+    /// model rejects cannot fail the request.
+    /// </para>
+    /// </remarks>
+    protected override void ApplyCapabilitySettings(
+        AnthropicChatCapabilitySettings capabilitySettings,
+        string? modelId,
+        ChatOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(capabilitySettings.Effort))
+        {
+            return;
+        }
+
+        var model = modelId ?? DefaultChatModel;
+        var level = capabilitySettings.Effort.Trim().ToLowerInvariant();
+
+        if (!AnthropicModelUtilities.SupportsEffortLevel(model, level))
+        {
+            return;
+        }
+
+        var effort = level switch
+        {
+            "low" => Effort.Low,
+            "medium" => Effort.Medium,
+            "high" => Effort.High,
+            "xhigh" => Effort.Xhigh,
+            "max" => Effort.Max,
+            _ => (Effort?)null,
+        };
+
+        if (effort is null)
+        {
+            return;
+        }
+
+        var previousFactory = options.RawRepresentationFactory;
+        var maxTokens = options.MaxOutputTokens ?? AdapterDefaultMaxTokens;
+
+        options.RawRepresentationFactory = client =>
+        {
+            var existing = previousFactory?.Invoke(client) as MessageCreateParams;
+
+            // OutputConfig is init-only, so an existing representation is copied with the effort applied
+            // and any sibling output settings preserved.
+            var outputConfig = new BetaOutputConfig
+            {
+                Effort = effort,
+                Format = existing?.OutputConfig?.Format,
+                TaskBudget = existing?.OutputConfig?.TaskBudget,
+            };
+
+            return existing is null
+                ? new MessageCreateParams
+                {
+                    Model = model,
+                    MaxTokens = maxTokens,
+                    Messages = [],
+                    OutputConfig = outputConfig,
+                }
+                : existing with { OutputConfig = outputConfig };
+        };
+    }
 
     private static bool IsChatModel(string modelId)
         => IncludePatterns.Any(p => p.IsMatch(modelId));

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
@@ -104,10 +104,18 @@ public class AnthropicChatCapability(
 
     /// <inheritdoc />
     /// <remarks>
+    /// <para>
     /// Fetches the model list (cached) before handing back the client, so the per-request settings hook can
-    /// read the target model's reported capabilities synchronously. A failure here is swallowed: capability
-    /// data refines the decision but is not required to make a request, and losing the model list must not
-    /// stop chat from working.
+    /// read the target model's reported capabilities synchronously. Both interface entry points route
+    /// through here rather than the synchronous <see cref="CreateClient"/>, so the prefetch cannot be
+    /// bypassed from outside the capability.
+    /// </para>
+    /// <para>
+    /// A failure is not fatal — capability data refines the decision but is not required to make a request,
+    /// and losing the model list must not stop chat from working — so it degrades to inferring support from
+    /// the model ID, and logs, because that fallback is less accurate and otherwise invisible. Cancellation
+    /// is not caught: if the caller has given up, this should too rather than continue building a client.
+    /// </para>
     /// </remarks>
     protected override async Task<IChatClient> CreateClientAsync(
         AnthropicProviderSettings settings,
@@ -118,9 +126,12 @@ public class AnthropicChatCapability(
         {
             await Provider.GetAvailableModelsAsync(settings, cancellationToken).ConfigureAwait(false);
         }
-        catch (Exception)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            // Fall back to inferring support from the model ID.
+            logger?.LogDebug(
+                ex,
+                "Could not list Anthropic models while creating a chat client. Per-model capability data "
+                + "is unavailable, so setting support will be inferred from the model ID instead.");
         }
 
         return CreateClient(settings, modelId);

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
@@ -179,14 +179,12 @@ public class AnthropicChatCapability(
         {
             var existing = previousFactory?.Invoke(client) as MessageCreateParams;
 
-            // OutputConfig is init-only, so an existing representation is copied with the effort applied
-            // and any sibling output settings preserved.
-            var outputConfig = new BetaOutputConfig
-            {
-                Effort = effort,
-                Format = existing?.OutputConfig?.Format,
-                TaskBudget = existing?.OutputConfig?.TaskBudget,
-            };
+            // Copy an existing output config rather than rebuilding it: assigning a sibling property marks
+            // it present in the payload even when the value is null, and the API rejects the ones it does
+            // not expect ("output_config.task_budget: Extra inputs are not permitted"). Only effort is set.
+            var outputConfig = existing?.OutputConfig is { } priorOutputConfig
+                ? priorOutputConfig with { Effort = effort }
+                : new BetaOutputConfig { Effort = effort };
 
             return existing is null
                 ? new MessageCreateParams

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapabilitySettings.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapabilitySettings.cs
@@ -1,0 +1,27 @@
+using Umbraco.AI.Core.EditableModels;
+
+namespace Umbraco.AI.Anthropic;
+
+/// <summary>
+/// Provider-declared, profile-level chat settings for Anthropic (surfaced on the profile editor and
+/// applied to each request).
+/// </summary>
+public class AnthropicChatCapabilitySettings
+{
+    /// <summary>
+    /// How many tokens Claude spends on a response, including thinking and tool calls. Leave empty for
+    /// the model default (high).
+    /// </summary>
+    /// <remarks>
+    /// Maps to <c>output_config.effort</c>. Supported on Claude Opus 4.5 and everything from the 4.6
+    /// generation onwards; the <c>xhigh</c> and <c>max</c> levels are available on fewer models than the
+    /// rest, and a level the selected model does not accept is dropped rather than sent.
+    /// </remarks>
+    [AIField(
+        Label = "Effort",
+        Description = "How many tokens Claude spends on a response, including thinking and tool calls. Leave empty for the model default (high). The xhigh and max levels are only available on newer models.",
+        EditorUiAlias = "Umb.PropertyEditorUi.Dropdown",
+        EditorConfig = "[{\"alias\":\"multiple\",\"value\":false},{\"alias\":\"items\",\"value\":[\"low\",\"medium\",\"high\",\"xhigh\",\"max\"]}]",
+        SortOrder = 1)]
+    public string? Effort { get; set; }
+}

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapabilitySettings.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapabilitySettings.cs
@@ -1,4 +1,6 @@
+using System.Text.Json.Serialization;
 using Umbraco.AI.Core.EditableModels;
+using Umbraco.AI.Core.Serialization;
 
 namespace Umbraco.AI.Anthropic;
 
@@ -29,5 +31,6 @@ public class AnthropicChatCapabilitySettings
         EditorUiAlias = "Umb.PropertyEditorUi.Dropdown",
         EditorConfig = "[{\"alias\":\"multiple\",\"value\":false},{\"alias\":\"items\",\"value\":[\"low\",\"medium\",\"high\"]}]",
         SortOrder = 1)]
+    [JsonConverter(typeof(DropdownStringJsonConverter))]
     public string? Effort { get; set; }
 }

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapabilitySettings.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapabilitySettings.cs
@@ -13,15 +13,21 @@ public class AnthropicChatCapabilitySettings
     /// the model default (high).
     /// </summary>
     /// <remarks>
-    /// Maps to <c>output_config.effort</c>. Supported on Claude Opus 4.5 and everything from the 4.6
-    /// generation onwards; the <c>xhigh</c> and <c>max</c> levels are available on fewer models than the
-    /// rest, and a level the selected model does not accept is dropped rather than sent.
+    /// Maps to <c>output_config.effort</c>, supported on Claude Opus 4.5 and everything from the 4.6
+    /// generation onwards.
+    /// <para>
+    /// Only the three levels every effort-capable model accepts are offered. Anthropic's <c>xhigh</c> and
+    /// <c>max</c> levels reach a subset of models that cannot be tracked accurately with a hard-coded
+    /// list — the set with <c>xhigh</c> grows with each release, so an allow-list goes stale silently and a
+    /// deny-list risks sending a level that is rejected. They belong with a declaration read from the
+    /// models endpoint's per-model <c>capabilities.effort</c>, which reports the levels directly.
+    /// </para>
     /// </remarks>
     [AIField(
         Label = "Effort",
-        Description = "How many tokens Claude spends on a response, including thinking and tool calls. Leave empty for the model default (high). The xhigh and max levels are only available on newer models.",
+        Description = "How many tokens Claude spends on a response, including thinking and tool calls. Leave empty for the model default (high).",
         EditorUiAlias = "Umb.PropertyEditorUi.Dropdown",
-        EditorConfig = "[{\"alias\":\"multiple\",\"value\":false},{\"alias\":\"items\",\"value\":[\"low\",\"medium\",\"high\",\"xhigh\",\"max\"]}]",
+        EditorConfig = "[{\"alias\":\"multiple\",\"value\":false},{\"alias\":\"items\",\"value\":[\"low\",\"medium\",\"high\"]}]",
         SortOrder = 1)]
     public string? Effort { get; set; }
 }

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicModelCapability.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicModelCapability.cs
@@ -1,0 +1,11 @@
+namespace Umbraco.AI.Anthropic;
+
+/// <summary>
+/// The per-model capability facts Umbraco.AI consumes from Anthropic's models endpoint.
+/// </summary>
+/// <param name="Id">The model ID.</param>
+/// <param name="SupportsEffort">
+/// Whether the model accepts <c>output_config.effort</c>, or <c>null</c> when the API did not report it —
+/// in which case the caller infers support from the model ID instead of assuming either way.
+/// </param>
+internal sealed record AnthropicModelCapability(string Id, bool? SupportsEffort);

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicModelUtilities.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicModelUtilities.cs
@@ -26,20 +26,6 @@ internal static class AnthropicModelUtilities
     ];
 
     /// <summary>
-    /// Models that accept the <c>xhigh</c> effort level: Fable 5, Mythos 5, Opus 5, Opus 4.8, Opus 4.7
-    /// and Sonnet 5. Fewer models support it than support effort itself.
-    /// </summary>
-    private static readonly Regex[] XhighEffortPatterns =
-    [
-        new(@"^claude-fable-5", RegexOptions.IgnoreCase | RegexOptions.Compiled),
-        new(@"^claude-mythos-5", RegexOptions.IgnoreCase | RegexOptions.Compiled),
-        new(@"^claude-opus-5", RegexOptions.IgnoreCase | RegexOptions.Compiled),
-        new(@"^claude-opus-4-8", RegexOptions.IgnoreCase | RegexOptions.Compiled),
-        new(@"^claude-opus-4-7", RegexOptions.IgnoreCase | RegexOptions.Compiled),
-        new(@"^claude-sonnet-5", RegexOptions.IgnoreCase | RegexOptions.Compiled),
-    ];
-
-    /// <summary>
     /// Whether the model accepts <c>output_config.effort</c> at all.
     /// </summary>
     /// <param name="modelId">The model ID, or null when unresolved.</param>
@@ -48,28 +34,20 @@ internal static class AnthropicModelUtilities
            && !NoEffortPatterns.Any(p => p.IsMatch(modelId));
 
     /// <summary>
-    /// Whether the model accepts a specific effort level. The <c>xhigh</c> and <c>max</c> levels are
-    /// available on fewer models than <c>low</c>/<c>medium</c>/<c>high</c>: <c>xhigh</c> on the Opus 4.7+
-    /// and 5 families, <c>max</c> on the 4.6 generation onwards (so not on Opus 4.5).
+    /// Whether the model accepts the given effort level.
     /// </summary>
     /// <param name="modelId">The model ID, or null when unresolved.</param>
     /// <param name="level">The effort level (case-insensitive).</param>
+    /// <remarks>
+    /// Only <c>low</c>, <c>medium</c> and <c>high</c> are recognised: those are accepted by every model
+    /// that accepts effort at all, so no per-model list is needed. Anthropic's <c>xhigh</c> and <c>max</c>
+    /// reach a subset that a hard-coded list cannot track — the set with <c>xhigh</c> grows with each
+    /// release — so they are treated as unrecognised and skipped rather than guessed at. Adding them means
+    /// reading the models endpoint's per-model <c>capabilities.effort</c>.
+    /// </remarks>
     public static bool SupportsEffortLevel(string? modelId, string level)
-    {
-        if (!SupportsEffort(modelId))
-        {
-            return false;
-        }
-
-        return level.Trim().ToLowerInvariant() switch
-        {
-            "low" or "medium" or "high" => true,
-            "xhigh" => XhighEffortPatterns.Any(p => p.IsMatch(modelId!)),
-            // max arrived with the 4.6 generation; Opus 4.5 is the one effort-capable model without it.
-            "max" => !modelId!.StartsWith("claude-opus-4-5", StringComparison.OrdinalIgnoreCase),
-            _ => false,
-        };
-    }
+        => SupportsEffort(modelId)
+           && level.Trim().ToLowerInvariant() is "low" or "medium" or "high";
 
     /// <summary>
     /// Formats a Claude model ID into a human-readable display name.

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicModelUtilities.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicModelUtilities.cs
@@ -34,24 +34,16 @@ internal static class AnthropicModelUtilities
            && !NoEffortPatterns.Any(p => p.IsMatch(modelId));
 
     /// <summary>
-    /// Whether the model accepts the given effort level.
-    /// </summary>
-    /// <param name="modelId">The model ID, or null when unresolved.</param>
-    /// <param name="level">The effort level (case-insensitive).</param>
-    /// <remarks>
-    /// Only <c>low</c>, <c>medium</c> and <c>high</c> are recognised: those are accepted by every model
-    /// that accepts effort at all, so no per-model list is needed. Anthropic's <c>xhigh</c> and <c>max</c>
-    /// reach a subset that a hard-coded list cannot track — the set with <c>xhigh</c> grows with each
-    /// release — so they are treated as unrecognised and skipped rather than guessed at. Adding them means
-    /// reading the models endpoint's per-model <c>capabilities.effort</c>.
-    /// </remarks>
-    public static bool SupportsEffortLevel(string? modelId, string level)
-        => SupportsEffort(modelId) && IsKnownEffortLevel(level);
-
-    /// <summary>
     /// Whether the effort level is one this package offers, independent of any model.
     /// </summary>
     /// <param name="level">The effort level (case-insensitive).</param>
+    /// <remarks>
+    /// Only <c>low</c>, <c>medium</c> and <c>high</c>: those are accepted by every model that accepts
+    /// effort at all, so no per-model list is needed. Anthropic's <c>xhigh</c> and <c>max</c> reach a
+    /// subset that a hard-coded list cannot track — the set with <c>xhigh</c> grows with each release —
+    /// so they are treated as unrecognised and skipped rather than guessed at. Offering them means
+    /// reading the per-level flags the models endpoint already reports.
+    /// </remarks>
     public static bool IsKnownEffortLevel(string level)
         => level.Trim().ToLowerInvariant() is "low" or "medium" or "high";
 

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicModelUtilities.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicModelUtilities.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+
 namespace Umbraco.AI.Extensions;
 
 /// <summary>
@@ -5,6 +7,70 @@ namespace Umbraco.AI.Extensions;
 /// </summary>
 internal static class AnthropicModelUtilities
 {
+    /// <summary>
+    /// Models that do not accept <c>output_config.effort</c>: Claude 3.x, the base Claude 4 models,
+    /// Opus 4.1, Sonnet 4.5 and Haiku 4.5.
+    /// </summary>
+    /// <remarks>
+    /// A closed set of legacy models. Effort is supported on Opus 4.5 and everything from the 4.6
+    /// generation onwards, so every model released from here on supports it and an unrecognised model is
+    /// treated as supporting it.
+    /// </remarks>
+    private static readonly Regex[] NoEffortPatterns =
+    [
+        new(@"^claude-3", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"^claude-(opus|sonnet)-4-\d{8}", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"^claude-opus-4-1", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"^claude-sonnet-4-5", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"^claude-haiku-4-5", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+    ];
+
+    /// <summary>
+    /// Models that accept the <c>xhigh</c> effort level: Fable 5, Mythos 5, Opus 5, Opus 4.8, Opus 4.7
+    /// and Sonnet 5. Fewer models support it than support effort itself.
+    /// </summary>
+    private static readonly Regex[] XhighEffortPatterns =
+    [
+        new(@"^claude-fable-5", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"^claude-mythos-5", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"^claude-opus-5", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"^claude-opus-4-8", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"^claude-opus-4-7", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"^claude-sonnet-5", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+    ];
+
+    /// <summary>
+    /// Whether the model accepts <c>output_config.effort</c> at all.
+    /// </summary>
+    /// <param name="modelId">The model ID, or null when unresolved.</param>
+    public static bool SupportsEffort(string? modelId)
+        => !string.IsNullOrWhiteSpace(modelId)
+           && !NoEffortPatterns.Any(p => p.IsMatch(modelId));
+
+    /// <summary>
+    /// Whether the model accepts a specific effort level. The <c>xhigh</c> and <c>max</c> levels are
+    /// available on fewer models than <c>low</c>/<c>medium</c>/<c>high</c>: <c>xhigh</c> on the Opus 4.7+
+    /// and 5 families, <c>max</c> on the 4.6 generation onwards (so not on Opus 4.5).
+    /// </summary>
+    /// <param name="modelId">The model ID, or null when unresolved.</param>
+    /// <param name="level">The effort level (case-insensitive).</param>
+    public static bool SupportsEffortLevel(string? modelId, string level)
+    {
+        if (!SupportsEffort(modelId))
+        {
+            return false;
+        }
+
+        return level.Trim().ToLowerInvariant() switch
+        {
+            "low" or "medium" or "high" => true,
+            "xhigh" => XhighEffortPatterns.Any(p => p.IsMatch(modelId!)),
+            // max arrived with the 4.6 generation; Opus 4.5 is the one effort-capable model without it.
+            "max" => !modelId!.StartsWith("claude-opus-4-5", StringComparison.OrdinalIgnoreCase),
+            _ => false,
+        };
+    }
+
     /// <summary>
     /// Formats a Claude model ID into a human-readable display name.
     /// </summary>

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicModelUtilities.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicModelUtilities.cs
@@ -46,8 +46,14 @@ internal static class AnthropicModelUtilities
     /// reading the models endpoint's per-model <c>capabilities.effort</c>.
     /// </remarks>
     public static bool SupportsEffortLevel(string? modelId, string level)
-        => SupportsEffort(modelId)
-           && level.Trim().ToLowerInvariant() is "low" or "medium" or "high";
+        => SupportsEffort(modelId) && IsKnownEffortLevel(level);
+
+    /// <summary>
+    /// Whether the effort level is one this package offers, independent of any model.
+    /// </summary>
+    /// <param name="level">The effort level (case-insensitive).</param>
+    public static bool IsKnownEffortLevel(string level)
+        => level.Trim().ToLowerInvariant() is "low" or "medium" or "high";
 
     /// <summary>
     /// Formats a Claude model ID into a human-readable display name.

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicProvider.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicProvider.cs
@@ -48,21 +48,6 @@ public class AnthropicProvider : AIProviderBase<AnthropicProviderSettings>
         => AnthropicErrorMapping.TryClassify(exception) ?? base.ClassifyError(exception);
 
     /// <summary>
-    /// Gets all available model IDs from the Anthropic API with caching.
-    /// </summary>
-    /// <param name="settings">The provider settings containing API credentials.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>A list of all available model IDs.</returns>
-    internal async Task<IReadOnlyList<string>> GetAvailableModelIdsAsync(
-        AnthropicProviderSettings settings,
-        CancellationToken cancellationToken = default)
-    {
-        var models = await GetAvailableModelsAsync(settings, cancellationToken).ConfigureAwait(false);
-
-        return models.Select(m => m.Id).OrderBy(id => id).ToList();
-    }
-
-    /// <summary>
     /// Gets all available models from the Anthropic API with caching, including the per-model capability
     /// facts the API reports.
     /// </summary>

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicProvider.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicProvider.cs
@@ -75,7 +75,7 @@ public class AnthropicProvider : AIProviderBase<AnthropicProviderSettings>
             return cached;
         }
 
-        var client = CreateModelListClient(settings);
+        var client = CreateSdkClient(settings);
         var models = new List<AnthropicModelCapability>();
 
         var page = await client.Models.List(new ModelListParams { Limit = ModelPageSize }, cancellationToken);
@@ -140,11 +140,12 @@ public class AnthropicProvider : AIProviderBase<AnthropicProviderSettings>
     }
 
     /// <summary>
-    /// Creates the client used to list models. Overridable so a test can serve canned responses without
-    /// reaching the API; production behaviour is <see cref="CreateAnthropicClient"/>.
+    /// Creates the Anthropic SDK client, for both the models call and chat. Overridable so a test can
+    /// serve canned responses without reaching the API; production behaviour is
+    /// <see cref="CreateAnthropicClient"/>.
     /// </summary>
     /// <param name="settings">The provider settings containing API credentials.</param>
-    internal virtual AnthropicClient CreateModelListClient(AnthropicProviderSettings settings)
+    internal virtual AnthropicClient CreateSdkClient(AnthropicProviderSettings settings)
         => CreateAnthropicClient(settings);
 
     /// <summary>

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicProvider.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicProvider.cs
@@ -1,4 +1,5 @@
 using Anthropic;
+using Anthropic.Models.Models;
 using Microsoft.Extensions.Caching.Memory;
 using Umbraco.AI.Anthropic.Errors;
 using Umbraco.AI.Core.Providers;
@@ -13,6 +14,13 @@ namespace Umbraco.AI.Anthropic;
 public class AnthropicProvider : AIProviderBase<AnthropicProviderSettings>
 {
     private const string CacheKeyPrefix = "Anthropic_Models_";
+    private const string ModelCapabilityCacheKeyPrefix = "Anthropic_ModelCapability_";
+
+    /// <summary>
+    /// The API's maximum page size for the models endpoint. Without it the endpoint pages at 20, which
+    /// silently truncates the model list.
+    /// </summary>
+    private const int ModelPageSize = 1000;
     private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(1);
 
     private readonly IMemoryCache _cache;
@@ -40,12 +48,33 @@ public class AnthropicProvider : AIProviderBase<AnthropicProviderSettings>
         => AnthropicErrorMapping.TryClassify(exception) ?? base.ClassifyError(exception);
 
     /// <summary>
-    /// Gets all available models from the Anthropic API with caching.
+    /// Gets all available model IDs from the Anthropic API with caching.
     /// </summary>
     /// <param name="settings">The provider settings containing API credentials.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A list of all available model IDs.</returns>
     internal async Task<IReadOnlyList<string>> GetAvailableModelIdsAsync(
+        AnthropicProviderSettings settings,
+        CancellationToken cancellationToken = default)
+    {
+        var models = await GetAvailableModelsAsync(settings, cancellationToken).ConfigureAwait(false);
+
+        return models.Select(m => m.Id).OrderBy(id => id).ToList();
+    }
+
+    /// <summary>
+    /// Gets all available models from the Anthropic API with caching, including the per-model capability
+    /// facts the API reports.
+    /// </summary>
+    /// <param name="settings">The provider settings containing API credentials.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <remarks>
+    /// The models endpoint reports a <c>capabilities</c> object per model, so which settings a model
+    /// accepts is available as data rather than inferred from its ID. Each model's facts are additionally
+    /// cached under their own key so the per-request path can read them without any I/O — see
+    /// <see cref="TryGetModelCapability"/>.
+    /// </remarks>
+    internal async Task<IReadOnlyList<AnthropicModelCapability>> GetAvailableModelsAsync(
         AnthropicProviderSettings settings,
         CancellationToken cancellationToken = default)
     {
@@ -56,23 +85,82 @@ public class AnthropicProvider : AIProviderBase<AnthropicProviderSettings>
 
         var cacheKey = GetCacheKey(settings);
 
-        if (_cache.TryGetValue<IReadOnlyList<string>>(cacheKey, out var cachedModels) && cachedModels is not null)
+        if (_cache.TryGetValue<IReadOnlyList<AnthropicModelCapability>>(cacheKey, out var cached) && cached is not null)
         {
-            return cachedModels;
+            return cached;
         }
 
-        var client = CreateAnthropicClient(settings);
-        var result = await client.Models.List(cancellationToken: cancellationToken);
+        var client = CreateModelListClient(settings);
+        var models = new List<AnthropicModelCapability>();
 
-        var modelIds = result.Items
-            .Select(m => m.ID)
-            .OrderBy(id => id)
-            .ToList();
+        var page = await client.Models.List(new ModelListParams { Limit = ModelPageSize }, cancellationToken);
+        while (true)
+        {
+            foreach (var model in page.Items)
+            {
+                models.Add(new AnthropicModelCapability(model.ID, ReadEffortSupport(model)));
+            }
 
-        _cache.Set(cacheKey, (IReadOnlyList<string>)modelIds, CacheDuration);
+            if (!page.HasNext())
+            {
+                break;
+            }
 
-        return modelIds;
+            page = await page.Next(cancellationToken);
+        }
+
+        _cache.Set(cacheKey, (IReadOnlyList<AnthropicModelCapability>)models, CacheDuration);
+
+        // Capability facts belong to the model, not to the connection, so they are cached per model ID as
+        // well. This is what lets the per-request path consult them synchronously.
+        foreach (var model in models)
+        {
+            _cache.Set(ModelCapabilityCacheKeyPrefix + model.Id, model, CacheDuration);
+        }
+
+        return models;
     }
+
+    /// <summary>
+    /// Reads a model's cached capability facts, or <c>null</c> when the model has not been fetched.
+    /// </summary>
+    /// <param name="modelId">The model ID.</param>
+    /// <remarks>
+    /// Warm by construction on the request path: a chat client cannot exist without the capability having
+    /// fetched the model list first. Returns null for a model absent from that list, where the caller
+    /// falls back to inferring support from the ID.
+    /// </remarks>
+    internal AnthropicModelCapability? TryGetModelCapability(string? modelId)
+        => string.IsNullOrWhiteSpace(modelId)
+            ? null
+            : _cache.TryGetValue<AnthropicModelCapability>(ModelCapabilityCacheKeyPrefix + modelId, out var cached)
+                ? cached
+                : null;
+
+    /// <summary>
+    /// Reads whether the API reported effort support for a model, treating an absent capabilities object
+    /// as "not reported" rather than as unsupported.
+    /// </summary>
+    private static bool? ReadEffortSupport(ModelInfo model)
+    {
+        try
+        {
+            return model.Capabilities?.Effort?.Supported;
+        }
+        catch (Exception)
+        {
+            // Older API versions and non-first-party gateways may omit the capabilities object entirely.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Creates the client used to list models. Overridable so a test can serve canned responses without
+    /// reaching the API; production behaviour is <see cref="CreateAnthropicClient"/>.
+    /// </summary>
+    /// <param name="settings">The provider settings containing API credentials.</param>
+    internal virtual AnthropicClient CreateModelListClient(AnthropicProviderSettings settings)
+        => CreateAnthropicClient(settings);
 
     /// <summary>
     /// Creates an Anthropic client configured with the provided settings.

--- a/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicApplyEffortWireTests.cs
+++ b/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicApplyEffortWireTests.cs
@@ -105,7 +105,7 @@ public class AnthropicApplyEffortWireTests
     /// builds is exercised through the SDK's own serialization.
     /// </summary>
     private sealed class StubbedChatCapability(AnthropicProvider provider, HttpMessageHandler handler)
-        : AnthropicChatCapability(provider)
+        : AnthropicChatCapability(provider, logger: null)
     {
         protected override IChatClient CreateClient(AnthropicProviderSettings settings, string? modelId)
             => new AnthropicClient

--- a/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicApplyEffortWireTests.cs
+++ b/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicApplyEffortWireTests.cs
@@ -72,6 +72,59 @@ public class AnthropicApplyEffortWireTests
         body.ShouldNotContain("output_config");
     }
 
+    [Fact]
+    public async Task ModelListUnavailable_StillSendsEffortByInferringFromTheModelId()
+    {
+        // Arrange — the models call fails, so there are no reported capabilities to consult
+        var chatHandler = new CapturingHttpMessageHandler();
+        var provider = new StubbedAnthropicProvider(
+            new FakeProviderInfrastructure(),
+            new MemoryCache(new MemoryCacheOptions()),
+            new FailingHttpMessageHandler());
+
+        IAIChatCapability capability = new StubbedChatCapability(provider, chatHandler);
+        var settings = new AnthropicProviderSettings { ApiKey = "test-key" };
+
+        // Act — client creation must not fail, and the ID predicate says Opus 5 accepts effort
+        var chatClient = await capability.CreateClientAsync(
+            settings,
+            new AnthropicChatCapabilitySettings { Effort = "medium" },
+            "claude-opus-5",
+            default);
+
+        await SendAndIgnoreFailureAsync(chatClient);
+
+        // Assert
+        var body = chatHandler.RequestBodies.ShouldHaveSingleItem();
+        body.ShouldContain("\"output_config\":{\"effort\":\"medium\"}");
+    }
+
+    [Fact]
+    public async Task ModelListUnavailable_ModelTheIdPredicateRejects_SendsNoOutputConfig()
+    {
+        // Arrange — the fallback must still refuse a model known not to accept effort
+        var chatHandler = new CapturingHttpMessageHandler();
+        var provider = new StubbedAnthropicProvider(
+            new FakeProviderInfrastructure(),
+            new MemoryCache(new MemoryCacheOptions()),
+            new FailingHttpMessageHandler());
+
+        IAIChatCapability capability = new StubbedChatCapability(provider, chatHandler);
+
+        // Act
+        var chatClient = await capability.CreateClientAsync(
+            new AnthropicProviderSettings { ApiKey = "test-key" },
+            new AnthropicChatCapabilitySettings { Effort = "medium" },
+            "claude-haiku-4-5-20251001",
+            default);
+
+        await SendAndIgnoreFailureAsync(chatClient);
+
+        // Assert
+        var body = chatHandler.RequestBodies.ShouldHaveSingleItem();
+        body.ShouldNotContain("output_config");
+    }
+
     private static async Task<IChatClient> CreateConfiguredClientAsync(
         CapturingHttpMessageHandler chatHandler,
         string? effort)
@@ -130,5 +183,16 @@ public class AnthropicApplyEffortWireTests
                 MaxRetries = 0,
                 HttpClient = new HttpClient(handler),
             };
+    }
+
+    /// <summary>
+    /// Fails every request, standing in for a models endpoint that cannot be reached.
+    /// </summary>
+    private sealed class FailingHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => throw new HttpRequestException("models endpoint unreachable");
     }
 }

--- a/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicApplyEffortWireTests.cs
+++ b/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicApplyEffortWireTests.cs
@@ -1,0 +1,134 @@
+using Anthropic;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Caching.Memory;
+using Umbraco.AI.Anthropic.Tests.Unit.Fakes;
+using Umbraco.AI.Core.Providers;
+
+namespace Umbraco.AI.Anthropic.Tests.Unit;
+
+/// <summary>
+/// Drives the capability's own settings hook end to end — resolved settings in, request body out.
+/// </summary>
+/// <remarks>
+/// <see cref="AnthropicEffortWireTests"/> asserts what the SDK adapter does with a representation built by
+/// the test. These tests assert what the representation <em>the capability builds</em> serialises to, which
+/// is a different thing and the gap that let a request go out carrying <c>output_config.task_budget: null</c>
+/// — rejected by the API as an extra input, because assigning a sibling property marks it present even when
+/// its value is null.
+/// </remarks>
+public class AnthropicApplyEffortWireTests
+{
+    private const string ModelsResponse = """
+        { "data": [ { "type": "model", "id": "claude-opus-5", "display_name": "Claude Opus 5",
+                      "created_at": "2026-06-09T00:00:00Z", "max_input_tokens": 1, "max_tokens": 1,
+                      "capabilities": { "effort": { "supported": true } } } ],
+          "has_more": false }
+        """;
+
+    [Fact]
+    public async Task ApplyCapabilitySettings_SendsEffortAndNothingElseInOutputConfig()
+    {
+        // Arrange
+        var chatHandler = new CapturingHttpMessageHandler();
+        var chatClient = await CreateConfiguredClientAsync(chatHandler, effort: "medium");
+
+        // Act
+        await SendAndIgnoreFailureAsync(chatClient);
+
+        // Assert — exactly one key inside output_config
+        var body = chatHandler.RequestBodies.ShouldHaveSingleItem();
+        body.ShouldContain("\"output_config\":{\"effort\":\"medium\"}");
+        body.ShouldNotContain("task_budget");
+        body.ShouldNotContain("format");
+    }
+
+    [Fact]
+    public async Task ApplyCapabilitySettings_NoEffortConfigured_SendsNoOutputConfig()
+    {
+        // Arrange
+        var chatHandler = new CapturingHttpMessageHandler();
+        var chatClient = await CreateConfiguredClientAsync(chatHandler, effort: null);
+
+        // Act
+        await SendAndIgnoreFailureAsync(chatClient);
+
+        // Assert
+        var body = chatHandler.RequestBodies.ShouldHaveSingleItem();
+        body.ShouldNotContain("output_config");
+    }
+
+    [Fact]
+    public async Task ApplyCapabilitySettings_LevelTheModelDoesNotAccept_SendsNoOutputConfig()
+    {
+        // Arrange — xhigh is not offered, so a value stored by an API caller must not be forwarded
+        var chatHandler = new CapturingHttpMessageHandler();
+        var chatClient = await CreateConfiguredClientAsync(chatHandler, effort: "xhigh");
+
+        // Act
+        await SendAndIgnoreFailureAsync(chatClient);
+
+        // Assert
+        var body = chatHandler.RequestBodies.ShouldHaveSingleItem();
+        body.ShouldNotContain("output_config");
+    }
+
+    private static async Task<IChatClient> CreateConfiguredClientAsync(
+        CapturingHttpMessageHandler chatHandler,
+        string? effort)
+    {
+        var provider = new StubbedAnthropicProvider(
+            new FakeProviderInfrastructure(),
+            new MemoryCache(new MemoryCacheOptions()),
+            new StubHttpMessageHandler(ModelsResponse));
+
+        IAIChatCapability capability = new StubbedChatCapability(provider, chatHandler);
+        var settings = new AnthropicProviderSettings { ApiKey = "test-key" };
+        var capabilitySettings = effort is null ? new AnthropicChatCapabilitySettings() : new() { Effort = effort };
+
+        return await capability.CreateClientAsync(settings, capabilitySettings, "claude-opus-5", default);
+    }
+
+    private static async Task SendAndIgnoreFailureAsync(IChatClient chatClient)
+    {
+        try
+        {
+            await chatClient.GetResponseAsync("hello", new ChatOptions { MaxOutputTokens = 64 });
+        }
+        catch (Exception)
+        {
+            // The capturing handler always fails the request; only the captured body matters here.
+        }
+    }
+
+    /// <summary>
+    /// The real capability with its chat client pointed at a capturing handler, so the representation it
+    /// builds is exercised through the SDK's own serialization.
+    /// </summary>
+    private sealed class StubbedChatCapability(AnthropicProvider provider, HttpMessageHandler handler)
+        : AnthropicChatCapability(provider)
+    {
+        protected override IChatClient CreateClient(AnthropicProviderSettings settings, string? modelId)
+            => new AnthropicClient
+            {
+                ApiKey = "test-key",
+                MaxRetries = 0,
+                HttpClient = new HttpClient(handler),
+            }.Beta.AsIChatClient(modelId);
+    }
+
+    [AIProvider("anthropic", "Anthropic")]
+    private sealed class StubbedAnthropicProvider(
+        IAIProviderInfrastructure infrastructure,
+        IMemoryCache cache,
+        HttpMessageHandler handler)
+        : AnthropicProvider(infrastructure, cache)
+    {
+        internal override AnthropicClient CreateModelListClient(AnthropicProviderSettings settings)
+            => new()
+            {
+                ApiKey = "test-key",
+                MaxRetries = 0,
+                HttpClient = new HttpClient(handler),
+            };
+    }
+}

--- a/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicApplyEffortWireTests.cs
+++ b/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicApplyEffortWireTests.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Text;
 using Anthropic;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Caching.Memory;
@@ -29,14 +31,14 @@ public class AnthropicApplyEffortWireTests
     public async Task ApplyCapabilitySettings_SendsEffortAndNothingElseInOutputConfig()
     {
         // Arrange
-        var chatHandler = new CapturingHttpMessageHandler();
-        var chatClient = await CreateConfiguredClientAsync(chatHandler, effort: "medium");
+        var handler = new AnthropicApiHandler(ModelsResponse);
+        var chatClient = await CreateConfiguredClientAsync(handler, effort: "medium");
 
         // Act
         await SendAndIgnoreFailureAsync(chatClient);
 
         // Assert — exactly one key inside output_config
-        var body = chatHandler.RequestBodies.ShouldHaveSingleItem();
+        var body = handler.ChatRequestBodies.ShouldHaveSingleItem();
         body.ShouldContain("\"output_config\":{\"effort\":\"medium\"}");
         body.ShouldNotContain("task_budget");
         body.ShouldNotContain("format");
@@ -46,14 +48,14 @@ public class AnthropicApplyEffortWireTests
     public async Task ApplyCapabilitySettings_NoEffortConfigured_SendsNoOutputConfig()
     {
         // Arrange
-        var chatHandler = new CapturingHttpMessageHandler();
-        var chatClient = await CreateConfiguredClientAsync(chatHandler, effort: null);
+        var handler = new AnthropicApiHandler(ModelsResponse);
+        var chatClient = await CreateConfiguredClientAsync(handler, effort: null);
 
         // Act
         await SendAndIgnoreFailureAsync(chatClient);
 
         // Assert
-        var body = chatHandler.RequestBodies.ShouldHaveSingleItem();
+        var body = handler.ChatRequestBodies.ShouldHaveSingleItem();
         body.ShouldNotContain("output_config");
     }
 
@@ -61,14 +63,14 @@ public class AnthropicApplyEffortWireTests
     public async Task ApplyCapabilitySettings_LevelTheModelDoesNotAccept_SendsNoOutputConfig()
     {
         // Arrange — xhigh is not offered, so a value stored by an API caller must not be forwarded
-        var chatHandler = new CapturingHttpMessageHandler();
-        var chatClient = await CreateConfiguredClientAsync(chatHandler, effort: "xhigh");
+        var handler = new AnthropicApiHandler(ModelsResponse);
+        var chatClient = await CreateConfiguredClientAsync(handler, effort: "xhigh");
 
         // Act
         await SendAndIgnoreFailureAsync(chatClient);
 
         // Assert
-        var body = chatHandler.RequestBodies.ShouldHaveSingleItem();
+        var body = handler.ChatRequestBodies.ShouldHaveSingleItem();
         body.ShouldNotContain("output_config");
     }
 
@@ -76,18 +78,17 @@ public class AnthropicApplyEffortWireTests
     public async Task ModelListUnavailable_StillSendsEffortByInferringFromTheModelId()
     {
         // Arrange — the models call fails, so there are no reported capabilities to consult
-        var chatHandler = new CapturingHttpMessageHandler();
+        var handler = new AnthropicApiHandler(modelsResponse: null);
         var provider = new StubbedAnthropicProvider(
             new FakeProviderInfrastructure(),
             new MemoryCache(new MemoryCacheOptions()),
-            new FailingHttpMessageHandler());
+            handler);
 
-        IAIChatCapability capability = new StubbedChatCapability(provider, chatHandler);
-        var settings = new AnthropicProviderSettings { ApiKey = "test-key" };
+        IAIChatCapability capability = new AnthropicChatCapability(provider, logger: null);
 
         // Act — client creation must not fail, and the ID predicate says Opus 5 accepts effort
         var chatClient = await capability.CreateClientAsync(
-            settings,
+            new AnthropicProviderSettings { ApiKey = "test-key" },
             new AnthropicChatCapabilitySettings { Effort = "medium" },
             "claude-opus-5",
             default);
@@ -95,7 +96,7 @@ public class AnthropicApplyEffortWireTests
         await SendAndIgnoreFailureAsync(chatClient);
 
         // Assert
-        var body = chatHandler.RequestBodies.ShouldHaveSingleItem();
+        var body = handler.ChatRequestBodies.ShouldHaveSingleItem();
         body.ShouldContain("\"output_config\":{\"effort\":\"medium\"}");
     }
 
@@ -103,13 +104,13 @@ public class AnthropicApplyEffortWireTests
     public async Task ModelListUnavailable_ModelTheIdPredicateRejects_SendsNoOutputConfig()
     {
         // Arrange — the fallback must still refuse a model known not to accept effort
-        var chatHandler = new CapturingHttpMessageHandler();
+        var handler = new AnthropicApiHandler(modelsResponse: null);
         var provider = new StubbedAnthropicProvider(
             new FakeProviderInfrastructure(),
             new MemoryCache(new MemoryCacheOptions()),
-            new FailingHttpMessageHandler());
+            handler);
 
-        IAIChatCapability capability = new StubbedChatCapability(provider, chatHandler);
+        IAIChatCapability capability = new AnthropicChatCapability(provider, logger: null);
 
         // Act
         var chatClient = await capability.CreateClientAsync(
@@ -121,20 +122,20 @@ public class AnthropicApplyEffortWireTests
         await SendAndIgnoreFailureAsync(chatClient);
 
         // Assert
-        var body = chatHandler.RequestBodies.ShouldHaveSingleItem();
+        var body = handler.ChatRequestBodies.ShouldHaveSingleItem();
         body.ShouldNotContain("output_config");
     }
 
     private static async Task<IChatClient> CreateConfiguredClientAsync(
-        CapturingHttpMessageHandler chatHandler,
+        AnthropicApiHandler handler,
         string? effort)
     {
         var provider = new StubbedAnthropicProvider(
             new FakeProviderInfrastructure(),
             new MemoryCache(new MemoryCacheOptions()),
-            new StubHttpMessageHandler(ModelsResponse));
+            handler);
 
-        IAIChatCapability capability = new StubbedChatCapability(provider, chatHandler);
+        IAIChatCapability capability = new AnthropicChatCapability(provider, logger: null);
         var settings = new AnthropicProviderSettings { ApiKey = "test-key" };
         var capabilitySettings = effort is null ? new AnthropicChatCapabilitySettings() : new() { Effort = effort };
 
@@ -153,22 +154,6 @@ public class AnthropicApplyEffortWireTests
         }
     }
 
-    /// <summary>
-    /// The real capability with its chat client pointed at a capturing handler, so the representation it
-    /// builds is exercised through the SDK's own serialization.
-    /// </summary>
-    private sealed class StubbedChatCapability(AnthropicProvider provider, HttpMessageHandler handler)
-        : AnthropicChatCapability(provider, logger: null)
-    {
-        protected override IChatClient CreateClient(AnthropicProviderSettings settings, string? modelId)
-            => new AnthropicClient
-            {
-                ApiKey = "test-key",
-                MaxRetries = 0,
-                HttpClient = new HttpClient(handler),
-            }.Beta.AsIChatClient(modelId);
-    }
-
     [AIProvider("anthropic", "Anthropic")]
     private sealed class StubbedAnthropicProvider(
         IAIProviderInfrastructure infrastructure,
@@ -176,7 +161,7 @@ public class AnthropicApplyEffortWireTests
         HttpMessageHandler handler)
         : AnthropicProvider(infrastructure, cache)
     {
-        internal override AnthropicClient CreateModelListClient(AnthropicProviderSettings settings)
+        internal override AnthropicClient CreateSdkClient(AnthropicProviderSettings settings)
             => new()
             {
                 ApiKey = "test-key",
@@ -186,13 +171,37 @@ public class AnthropicApplyEffortWireTests
     }
 
     /// <summary>
-    /// Fails every request, standing in for a models endpoint that cannot be reached.
+    /// Stands in for the Anthropic API: serves the models call from a canned response (or fails it, when
+    /// none is given) and captures chat request bodies.
     /// </summary>
-    private sealed class FailingHttpMessageHandler : HttpMessageHandler
+    private sealed class AnthropicApiHandler(string? modelsResponse) : HttpMessageHandler
     {
-        protected override Task<HttpResponseMessage> SendAsync(
+        public List<string> ChatRequestBodies { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
-            => throw new HttpRequestException("models endpoint unreachable");
+        {
+            if (request.RequestUri?.AbsolutePath.Contains("/models", StringComparison.Ordinal) == true)
+            {
+                return modelsResponse is null
+                    ? throw new HttpRequestException("models endpoint unreachable")
+                    : new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(modelsResponse, Encoding.UTF8, "application/json"),
+                    };
+            }
+
+            if (request.Content is not null)
+            {
+                ChatRequestBodies.Add(await request.Content.ReadAsStringAsync(cancellationToken));
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent(
+                    """{"type":"error","error":{"type":"invalid_request_error","message":"captured"}}"""),
+            };
+        }
     }
 }

--- a/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicEffortSupportTests.cs
+++ b/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicEffortSupportTests.cs
@@ -1,0 +1,109 @@
+using Umbraco.AI.Extensions;
+
+namespace Umbraco.AI.Anthropic.Tests.Unit;
+
+/// <summary>
+/// <c>output_config.effort</c> is not accepted by the older Claude models, and its <c>xhigh</c> and
+/// <c>max</c> levels are accepted by fewer models than the rest. These predicates are the single source
+/// for both the per-model declaration surfaced to the profile editor and the decision to send a level at
+/// all, so they are worth pinning down.
+/// </summary>
+/// <remarks>
+/// Model IDs and per-model support taken from Anthropic's models overview and effort docs (July 2026).
+/// </remarks>
+public class AnthropicEffortSupportTests
+{
+    [Theory]
+    [InlineData("claude-opus-4-5-20251101")]
+    [InlineData("claude-opus-4-6")]
+    [InlineData("claude-sonnet-4-6")]
+    [InlineData("claude-opus-4-7")]
+    [InlineData("claude-opus-4-8")]
+    [InlineData("claude-opus-5")]
+    [InlineData("claude-sonnet-5")]
+    [InlineData("claude-fable-5")]
+    [InlineData("claude-mythos-5")]
+    [InlineData("claude-mythos-preview")]
+    [InlineData("some-future-claude-model")]
+    public void SupportsEffort_ModelAcceptingEffort_ReturnsTrue(string modelId)
+    {
+        // A deny-list of legacy models, so anything newer — including models this package has not heard
+        // of — is treated as supporting effort.
+        AnthropicModelUtilities.SupportsEffort(modelId).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("claude-3-5-sonnet-20241022")]
+    [InlineData("claude-3-7-sonnet-20250219")]
+    [InlineData("claude-sonnet-4-20250514")]
+    [InlineData("claude-opus-4-20250514")]
+    [InlineData("claude-opus-4-1-20250805")]
+    [InlineData("claude-sonnet-4-5-20250929")]
+    [InlineData("claude-haiku-4-5-20251001")]
+    [InlineData(null)]
+    [InlineData("")]
+    public void SupportsEffort_ModelRejectingEffort_ReturnsFalse(string? modelId)
+    {
+        AnthropicModelUtilities.SupportsEffort(modelId).ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("claude-opus-5", "low")]
+    [InlineData("claude-opus-5", "medium")]
+    [InlineData("claude-opus-5", "high")]
+    [InlineData("claude-opus-4-5-20251101", "high")]
+    [InlineData("claude-sonnet-4-6", "medium")]
+    public void SupportsEffortLevel_BaseLevelsOnAnEffortModel_ReturnsTrue(string modelId, string level)
+    {
+        AnthropicModelUtilities.SupportsEffortLevel(modelId, level).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("claude-opus-4-7")]
+    [InlineData("claude-opus-4-8")]
+    [InlineData("claude-opus-5")]
+    [InlineData("claude-sonnet-5")]
+    [InlineData("claude-fable-5")]
+    [InlineData("claude-mythos-5")]
+    public void SupportsEffortLevel_Xhigh_OnModelsThatHaveIt_ReturnsTrue(string modelId)
+    {
+        AnthropicModelUtilities.SupportsEffortLevel(modelId, "xhigh").ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("claude-opus-4-5-20251101")]
+    [InlineData("claude-opus-4-6")]
+    [InlineData("claude-sonnet-4-6")]
+    [InlineData("claude-mythos-preview")]
+    public void SupportsEffortLevel_Xhigh_OnModelsWithoutIt_ReturnsFalse(string modelId)
+    {
+        // xhigh is newer than effort itself: some models that support max don't support xhigh.
+        AnthropicModelUtilities.SupportsEffortLevel(modelId, "xhigh").ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("claude-opus-4-6", true)]
+    [InlineData("claude-sonnet-4-6", true)]
+    [InlineData("claude-opus-5", true)]
+    [InlineData("claude-mythos-preview", true)]
+    [InlineData("claude-opus-4-5-20251101", false)]
+    public void SupportsEffortLevel_Max_FollowsTheFourSixCutoff(string modelId, bool expected)
+    {
+        // max arrived with the 4.6 generation, so Opus 4.5 is the one effort-capable model without it.
+        AnthropicModelUtilities.SupportsEffortLevel(modelId, "max").ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("claude-haiku-4-5-20251001", "high")]
+    [InlineData("claude-sonnet-4-5-20250929", "low")]
+    public void SupportsEffortLevel_ModelWithoutEffort_ReturnsFalseForEveryLevel(string modelId, string level)
+    {
+        AnthropicModelUtilities.SupportsEffortLevel(modelId, level).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SupportsEffortLevel_UnrecognisedLevel_ReturnsFalse()
+    {
+        AnthropicModelUtilities.SupportsEffortLevel("claude-opus-5", "turbo").ShouldBeFalse();
+    }
+}

--- a/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicEffortSupportTests.cs
+++ b/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicEffortSupportTests.cs
@@ -3,10 +3,9 @@ using Umbraco.AI.Extensions;
 namespace Umbraco.AI.Anthropic.Tests.Unit;
 
 /// <summary>
-/// <c>output_config.effort</c> is not accepted by the older Claude models, and its <c>xhigh</c> and
-/// <c>max</c> levels are accepted by fewer models than the rest. These predicates are the single source
-/// for both the per-model declaration surfaced to the profile editor and the decision to send a level at
-/// all, so they are worth pinning down.
+/// <c>output_config.effort</c> is not accepted by the older Claude models. These predicates are the single
+/// source for both the per-model declaration surfaced to the profile editor and the decision to send a
+/// level at all, so they are worth pinning down.
 /// </summary>
 /// <remarks>
 /// Model IDs and per-model support taken from Anthropic's models overview and effort docs (July 2026).
@@ -59,38 +58,14 @@ public class AnthropicEffortSupportTests
     }
 
     [Theory]
-    [InlineData("claude-opus-4-7")]
-    [InlineData("claude-opus-4-8")]
-    [InlineData("claude-opus-5")]
-    [InlineData("claude-sonnet-5")]
-    [InlineData("claude-fable-5")]
-    [InlineData("claude-mythos-5")]
-    public void SupportsEffortLevel_Xhigh_OnModelsThatHaveIt_ReturnsTrue(string modelId)
+    [InlineData("xhigh")]
+    [InlineData("max")]
+    public void SupportsEffortLevel_XhighOrMax_ReturnsFalseEvenOnModelsThatAcceptThem(string level)
     {
-        AnthropicModelUtilities.SupportsEffortLevel(modelId, "xhigh").ShouldBeTrue();
-    }
-
-    [Theory]
-    [InlineData("claude-opus-4-5-20251101")]
-    [InlineData("claude-opus-4-6")]
-    [InlineData("claude-sonnet-4-6")]
-    [InlineData("claude-mythos-preview")]
-    public void SupportsEffortLevel_Xhigh_OnModelsWithoutIt_ReturnsFalse(string modelId)
-    {
-        // xhigh is newer than effort itself: some models that support max don't support xhigh.
-        AnthropicModelUtilities.SupportsEffortLevel(modelId, "xhigh").ShouldBeFalse();
-    }
-
-    [Theory]
-    [InlineData("claude-opus-4-6", true)]
-    [InlineData("claude-sonnet-4-6", true)]
-    [InlineData("claude-opus-5", true)]
-    [InlineData("claude-mythos-preview", true)]
-    [InlineData("claude-opus-4-5-20251101", false)]
-    public void SupportsEffortLevel_Max_FollowsTheFourSixCutoff(string modelId, bool expected)
-    {
-        // max arrived with the 4.6 generation, so Opus 4.5 is the one effort-capable model without it.
-        AnthropicModelUtilities.SupportsEffortLevel(modelId, "max").ShouldBe(expected);
+        // Neither level is offered: which models accept them cannot be tracked with a hard-coded list —
+        // the set with xhigh grows with each release — so a stored value is skipped rather than guessed at.
+        // Adding them means reading the models endpoint's per-model capabilities.effort.
+        AnthropicModelUtilities.SupportsEffortLevel("claude-opus-5", level).ShouldBeFalse();
     }
 
     [Theory]

--- a/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicEffortSupportTests.cs
+++ b/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicEffortSupportTests.cs
@@ -47,38 +47,25 @@ public class AnthropicEffortSupportTests
     }
 
     [Theory]
-    [InlineData("claude-opus-5", "low")]
-    [InlineData("claude-opus-5", "medium")]
-    [InlineData("claude-opus-5", "high")]
-    [InlineData("claude-opus-4-5-20251101", "high")]
-    [InlineData("claude-sonnet-4-6", "medium")]
-    public void SupportsEffortLevel_BaseLevelsOnAnEffortModel_ReturnsTrue(string modelId, string level)
+    [InlineData("low")]
+    [InlineData("medium")]
+    [InlineData("high")]
+    [InlineData("HIGH")]
+    [InlineData(" high ")]
+    public void IsKnownEffortLevel_OfferedLevel_ReturnsTrue(string level)
     {
-        AnthropicModelUtilities.SupportsEffortLevel(modelId, level).ShouldBeTrue();
+        AnthropicModelUtilities.IsKnownEffortLevel(level).ShouldBeTrue();
     }
 
     [Theory]
     [InlineData("xhigh")]
     [InlineData("max")]
-    public void SupportsEffortLevel_XhighOrMax_ReturnsFalseEvenOnModelsThatAcceptThem(string level)
+    [InlineData("turbo")]
+    [InlineData("")]
+    public void IsKnownEffortLevel_LevelNotOffered_ReturnsFalse(string level)
     {
-        // Neither level is offered: which models accept them cannot be tracked with a hard-coded list —
-        // the set with xhigh grows with each release — so a stored value is skipped rather than guessed at.
-        // Adding them means reading the models endpoint's per-model capabilities.effort.
-        AnthropicModelUtilities.SupportsEffortLevel("claude-opus-5", level).ShouldBeFalse();
-    }
-
-    [Theory]
-    [InlineData("claude-haiku-4-5-20251001", "high")]
-    [InlineData("claude-sonnet-4-5-20250929", "low")]
-    public void SupportsEffortLevel_ModelWithoutEffort_ReturnsFalseForEveryLevel(string modelId, string level)
-    {
-        AnthropicModelUtilities.SupportsEffortLevel(modelId, level).ShouldBeFalse();
-    }
-
-    [Fact]
-    public void SupportsEffortLevel_UnrecognisedLevel_ReturnsFalse()
-    {
-        AnthropicModelUtilities.SupportsEffortLevel("claude-opus-5", "turbo").ShouldBeFalse();
+        // xhigh and max reach a subset of models that a hard-coded list cannot track, so a value stored
+        // by an API caller is skipped rather than guessed at.
+        AnthropicModelUtilities.IsKnownEffortLevel(level).ShouldBeFalse();
     }
 }

--- a/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicEffortWireTests.cs
+++ b/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicEffortWireTests.cs
@@ -1,0 +1,127 @@
+using Anthropic;
+using Anthropic.Models.Beta.Messages;
+using Microsoft.Extensions.AI;
+using Umbraco.AI.Anthropic.Tests.Unit.Fakes;
+
+namespace Umbraco.AI.Anthropic.Tests.Unit;
+
+/// <summary>
+/// Pins down how a provider-declared setting reaches the Anthropic wire, asserted against a captured
+/// request body rather than a live call.
+/// </summary>
+/// <remarks>
+/// These are the constraints <c>AnthropicChatCapability.ApplyCapabilitySettings</c> is written against:
+/// <see cref="ChatOptions.AdditionalProperties"/> never arrives, and
+/// <see cref="ChatOptions.RawRepresentationFactory"/> does but takes precedence over the options the
+/// adapter would otherwise apply. If a future SDK version changes either, these fail rather than the
+/// setting silently going missing.
+/// </remarks>
+public class AnthropicEffortWireTests
+{
+    [Fact]
+    public async Task RawRepresentationFactory_SetsOutputConfigEffort_ReachesTheRequestBody()
+    {
+        // Arrange
+        var handler = new CapturingHttpMessageHandler();
+        var chatClient = CreateChatClient(handler, "claude-opus-5");
+
+        var options = new ChatOptions
+        {
+            MaxOutputTokens = 64,
+            RawRepresentationFactory = _ => new MessageCreateParams
+            {
+                Model = "claude-opus-5",
+                MaxTokens = 64,
+                Messages = [],
+                OutputConfig = new BetaOutputConfig { Effort = Effort.Medium },
+            },
+        };
+
+        // Act
+        await SendAndIgnoreFailureAsync(chatClient, options);
+
+        // Assert
+        var body = handler.RequestBodies.ShouldHaveSingleItem();
+        body.ShouldContain("\"output_config\":{\"effort\":\"medium\"}");
+        body.ShouldContain("\"model\":\"claude-opus-5\"");
+        body.ShouldContain("\"max_tokens\":64");
+        // The adapter supplies the conversation even though the representation carried no messages.
+        body.ShouldContain("hello");
+    }
+
+    [Fact]
+    public async Task RawRepresentationFactory_TakesPrecedenceOverChatOptions()
+    {
+        // Arrange — deliberately mismatched values, to show which side wins
+        var handler = new CapturingHttpMessageHandler();
+        var chatClient = CreateChatClient(handler, "claude-opus-5");
+
+        var options = new ChatOptions
+        {
+            MaxOutputTokens = 4096,
+            RawRepresentationFactory = _ => new MessageCreateParams
+            {
+                Model = "from-representation",
+                MaxTokens = 7,
+                Messages = [],
+            },
+        };
+
+        // Act
+        await SendAndIgnoreFailureAsync(chatClient, options);
+
+        // Assert — this is why the capability carries the model and max tokens into the representation
+        // itself: the adapter does not put them back.
+        var body = handler.RequestBodies.ShouldHaveSingleItem();
+        body.ShouldContain("\"model\":\"from-representation\"");
+        body.ShouldContain("\"max_tokens\":7");
+        body.ShouldNotContain("4096");
+    }
+
+    [Fact]
+    public async Task AdditionalProperties_AreDroppedBeforeTheRequestIsBuilt()
+    {
+        // Arrange
+        var handler = new CapturingHttpMessageHandler();
+        var chatClient = CreateChatClient(handler, "claude-sonnet-4-6");
+
+        var options = new ChatOptions
+        {
+            MaxOutputTokens = 64,
+            AdditionalProperties = new AdditionalPropertiesDictionary
+            {
+                ["thinking"] = 2048,
+                ["output_config"] = new Dictionary<string, object?> { ["effort"] = "medium" },
+            },
+        };
+
+        // Act
+        await SendAndIgnoreFailureAsync(chatClient, options);
+
+        // Assert — nothing from AdditionalProperties survives, so it is not a usable channel for
+        // provider-specific request options.
+        var body = handler.RequestBodies.ShouldHaveSingleItem();
+        body.ShouldNotContain("thinking");
+        body.ShouldNotContain("output_config");
+    }
+
+    private static IChatClient CreateChatClient(CapturingHttpMessageHandler handler, string modelId)
+        => new AnthropicClient
+        {
+            ApiKey = "test-key",
+            MaxRetries = 0,
+            HttpClient = new HttpClient(handler),
+        }.Beta.AsIChatClient(modelId);
+
+    private static async Task SendAndIgnoreFailureAsync(IChatClient chatClient, ChatOptions options)
+    {
+        try
+        {
+            await chatClient.GetResponseAsync("hello", options);
+        }
+        catch (Exception)
+        {
+            // The capturing handler always fails the request; only the captured body matters here.
+        }
+    }
+}

--- a/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicModelCapabilityTests.cs
+++ b/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicModelCapabilityTests.cs
@@ -94,7 +94,7 @@ public class AnthropicModelCapabilityTests
     {
         // Arrange
         var (provider, settings, _) = CreateProvider(TwoModelsPage);
-        var capability = new AnthropicChatCapability(provider);
+        var capability = new AnthropicChatCapability(provider, logger: null);
 
         // Act
         var descriptors = await ((Core.Providers.IAICapability)capability).GetModelsAsync(settings);

--- a/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicModelCapabilityTests.cs
+++ b/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicModelCapabilityTests.cs
@@ -146,7 +146,7 @@ public class AnthropicModelCapabilityTests
         HttpMessageHandler handler)
         : AnthropicProvider(infrastructure, cache)
     {
-        internal override global::Anthropic.AnthropicClient CreateModelListClient(
+        internal override global::Anthropic.AnthropicClient CreateSdkClient(
             AnthropicProviderSettings settings)
             => new()
             {

--- a/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicModelCapabilityTests.cs
+++ b/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicModelCapabilityTests.cs
@@ -1,0 +1,158 @@
+using Microsoft.Extensions.Caching.Memory;
+using Umbraco.AI.Anthropic.Tests.Unit.Fakes;
+using Umbraco.AI.Core.Models;
+
+namespace Umbraco.AI.Anthropic.Tests.Unit;
+
+/// <summary>
+/// Anthropic's models endpoint reports a <c>capabilities</c> object per model, so which settings a model
+/// accepts is available as data rather than inferred from its ID. These tests cover reading it, paging
+/// through the response, and falling back to the ID predicate when the API says nothing.
+/// </summary>
+public class AnthropicModelCapabilityTests
+{
+    private const string TwoModelsPage = """
+        {
+          "data": [
+            { "type": "model", "id": "claude-opus-5", "display_name": "Claude Opus 5", "created_at": "2026-06-09T00:00:00Z",
+              "max_input_tokens": 1000000, "max_tokens": 128000,
+              "capabilities": { "effort": { "supported": true, "low": { "supported": true }, "medium": { "supported": true },
+                                            "high": { "supported": true }, "xhigh": { "supported": true }, "max": { "supported": true } },
+                                "thinking": { "supported": true, "types": { "adaptive": { "supported": true }, "enabled": { "supported": false } } } } },
+            { "type": "model", "id": "claude-haiku-4-5-20251001", "display_name": "Claude Haiku 4.5", "created_at": "2025-10-01T00:00:00Z",
+              "max_input_tokens": 200000, "max_tokens": 64000,
+              "capabilities": { "effort": { "supported": false },
+                                "thinking": { "supported": true, "types": { "adaptive": { "supported": false }, "enabled": { "supported": true } } } } }
+          ],
+          "first_id": "claude-opus-5",
+          "last_id": "claude-haiku-4-5-20251001",
+          "has_more": false
+        }
+        """;
+
+    [Fact]
+    public async Task GetAvailableModelsAsync_ReadsReportedEffortSupportPerModel()
+    {
+        // Arrange
+        var (provider, settings, _) = CreateProvider(TwoModelsPage);
+
+        // Act
+        var models = await provider.GetAvailableModelsAsync(settings);
+
+        // Assert
+        models.Single(m => m.Id == "claude-opus-5").SupportsEffort.ShouldBe(true);
+        models.Single(m => m.Id == "claude-haiku-4-5-20251001").SupportsEffort.ShouldBe(false);
+    }
+
+    [Fact]
+    public async Task GetAvailableModelsAsync_ApiOmitsCapabilities_ReportsNotKnown()
+    {
+        // Arrange — a gateway or older API version that returns no capabilities object
+        var (provider, settings, _) = CreateProvider("""
+            { "data": [ { "type": "model", "id": "claude-opus-5", "display_name": "Claude Opus 5",
+                          "created_at": "2026-06-09T00:00:00Z", "max_input_tokens": 1, "max_tokens": 1 } ],
+              "has_more": false }
+            """);
+
+        // Act
+        var models = await provider.GetAvailableModelsAsync(settings);
+
+        // Assert — null rather than false, so the caller falls back to the ID predicate
+        models.ShouldHaveSingleItem().SupportsEffort.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetAvailableModelsAsync_PagedResponse_FollowsEveryPage()
+    {
+        // Arrange — the endpoint pages, and the previous code took only the first page
+        var (provider, settings, handler) = CreateProvider(
+            """
+            { "data": [ { "type": "model", "id": "claude-opus-5", "display_name": "Claude Opus 5",
+                          "created_at": "2026-06-09T00:00:00Z", "max_input_tokens": 1, "max_tokens": 1,
+                          "capabilities": { "effort": { "supported": true } } } ],
+              "first_id": "claude-opus-5", "last_id": "claude-opus-5", "has_more": true }
+            """,
+            """
+            { "data": [ { "type": "model", "id": "claude-sonnet-4-6", "display_name": "Claude Sonnet 4.6",
+                          "created_at": "2026-02-04T00:00:00Z", "max_input_tokens": 1, "max_tokens": 1,
+                          "capabilities": { "effort": { "supported": true } } } ],
+              "first_id": "claude-sonnet-4-6", "last_id": "claude-sonnet-4-6", "has_more": false }
+            """);
+
+        // Act
+        var models = await provider.GetAvailableModelsAsync(settings);
+
+        // Assert
+        models.Select(m => m.Id).ShouldBe(["claude-opus-5", "claude-sonnet-4-6"]);
+        handler.RequestUris.Count.ShouldBe(2);
+        handler.RequestUris[0].ShouldContain("limit=1000");
+        handler.RequestUris[1].ShouldContain("after_id=claude-opus-5");
+    }
+
+    [Fact]
+    public async Task GetModelsAsync_DeclaresUnsupportedFromReportedCapabilities()
+    {
+        // Arrange
+        var (provider, settings, _) = CreateProvider(TwoModelsPage);
+        var capability = new AnthropicChatCapability(provider);
+
+        // Act
+        var descriptors = await ((Core.Providers.IAICapability)capability).GetModelsAsync(settings);
+
+        // Assert — Haiku 4.5 reports no effort support, so the setting is declared unsupported for it
+        var haiku = descriptors.Single(d => d.Model.ModelId == "claude-haiku-4-5-20251001");
+        haiku.Metadata[AIModelMetadataKeys.CapabilitySettingsUnsupported].ShouldBe("effort");
+
+        // ... and Opus 5 reports support, so nothing is declared
+        var opus = descriptors.Single(d => d.Model.ModelId == "claude-opus-5");
+        opus.Metadata.ContainsKey(AIModelMetadataKeys.CapabilitySettingsUnsupported).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task TryGetModelCapability_AfterFetch_IsReadableWithoutIo()
+    {
+        // Arrange — this is what lets the per-request settings hook consult reported capabilities
+        var (provider, settings, _) = CreateProvider(TwoModelsPage);
+
+        // Act
+        await provider.GetAvailableModelsAsync(settings);
+
+        // Assert
+        provider.TryGetModelCapability("claude-haiku-4-5-20251001")!.SupportsEffort.ShouldBe(false);
+        provider.TryGetModelCapability("claude-opus-5")!.SupportsEffort.ShouldBe(true);
+        provider.TryGetModelCapability("never-fetched-model").ShouldBeNull();
+    }
+
+    private static (AnthropicProvider Provider, AnthropicProviderSettings Settings, StubHttpMessageHandler Handler)
+        CreateProvider(params string[] responses)
+    {
+        var handler = new StubHttpMessageHandler(responses);
+        var provider = new StubbedAnthropicProvider(
+            new FakeProviderInfrastructure(),
+            new MemoryCache(new MemoryCacheOptions()),
+            handler);
+
+        return (provider, new AnthropicProviderSettings { ApiKey = "test-key" }, handler);
+    }
+
+    /// <summary>
+    /// A real provider with the model-list client pointed at a stub handler, so the SDK's own
+    /// deserialization and paging are exercised against canned responses.
+    /// </summary>
+    [Core.Providers.AIProvider("anthropic", "Anthropic")]
+    private sealed class StubbedAnthropicProvider(
+        Core.Providers.IAIProviderInfrastructure infrastructure,
+        IMemoryCache cache,
+        HttpMessageHandler handler)
+        : AnthropicProvider(infrastructure, cache)
+    {
+        internal override global::Anthropic.AnthropicClient CreateModelListClient(
+            AnthropicProviderSettings settings)
+            => new()
+            {
+                ApiKey = "test-key",
+                MaxRetries = 0,
+                HttpClient = new HttpClient(handler),
+            };
+    }
+}

--- a/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/Fakes/CapturingHttpMessageHandler.cs
+++ b/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/Fakes/CapturingHttpMessageHandler.cs
@@ -1,0 +1,27 @@
+using System.Net;
+
+namespace Umbraco.AI.Anthropic.Tests.Unit.Fakes;
+
+/// <summary>
+/// Captures the body of every request and short-circuits with an error response, so a test can assert on
+/// what would have gone over the wire without a real API call.
+/// </summary>
+internal sealed class CapturingHttpMessageHandler : HttpMessageHandler
+{
+    public List<string> RequestBodies { get; } = [];
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        if (request.Content is not null)
+        {
+            RequestBodies.Add(await request.Content.ReadAsStringAsync(cancellationToken));
+        }
+
+        return new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent("""{"type":"error","error":{"type":"invalid_request_error","message":"captured"}}"""),
+        };
+    }
+}

--- a/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/Fakes/FakeProviderInfrastructure.cs
+++ b/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/Fakes/FakeProviderInfrastructure.cs
@@ -1,0 +1,23 @@
+using Umbraco.AI.Core.EditableModels;
+using Umbraco.AI.Core.Providers;
+
+namespace Umbraco.AI.Anthropic.Tests.Unit.Fakes;
+
+/// <summary>
+/// Minimal provider infrastructure for constructing a real provider in a test. Capabilities are created by
+/// activation, which is enough for the provider's own capability wiring.
+/// </summary>
+internal sealed class FakeProviderInfrastructure : IAIProviderInfrastructure
+{
+    public IAICapabilityFactory CapabilityFactory { get; } = new ActivatorCapabilityFactory();
+
+    public IAIEditableModelSchemaBuilder SchemaBuilder
+        => throw new NotSupportedException("Schema building is not exercised by these tests.");
+
+    private sealed class ActivatorCapabilityFactory : IAICapabilityFactory
+    {
+        public TCapability Create<TCapability>(IAIProvider provider)
+            where TCapability : class, IAICapability
+            => (TCapability)Activator.CreateInstance(typeof(TCapability), provider)!;
+    }
+}

--- a/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/Fakes/StubHttpMessageHandler.cs
+++ b/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/Fakes/StubHttpMessageHandler.cs
@@ -1,0 +1,31 @@
+using System.Net;
+
+namespace Umbraco.AI.Anthropic.Tests.Unit.Fakes;
+
+/// <summary>
+/// Serves a queued sequence of canned JSON responses and records the request URIs, so a test can drive the
+/// SDK through a multi-page response without a real API call.
+/// </summary>
+internal sealed class StubHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Queue<string> _responses;
+
+    public StubHttpMessageHandler(params string[] jsonResponses)
+        => _responses = new Queue<string>(jsonResponses);
+
+    public List<string> RequestUris { get; } = [];
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        RequestUris.Add(request.RequestUri?.ToString() ?? string.Empty);
+
+        var body = _responses.Count > 0 ? _responses.Dequeue() : """{"data":[],"has_more":false}""";
+
+        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json"),
+        });
+    }
+}

--- a/Umbraco.AI.Deploy/src/Umbraco.AI.Deploy/Artifacts/AIProfileArtifact.cs
+++ b/Umbraco.AI.Deploy/src/Umbraco.AI.Deploy/Artifacts/AIProfileArtifact.cs
@@ -37,6 +37,12 @@ public class AIProfileArtifact(GuidUdi udi, IEnumerable<ArtifactDependency>? dep
     public JsonElement? Settings { get; set; }
 
     /// <summary>
+    /// Provider-declared capability settings (e.g. reasoning effort) serialized as JSON, or null when the
+    /// profile has none — including every profile created before providers could declare them.
+    /// </summary>
+    public JsonElement? CapabilitySettings { get; set; }
+
+    /// <summary>
     /// Tags for categorizing the profile.
     /// </summary>
     public IEnumerable<string> Tags { get; set; } = [];

--- a/Umbraco.AI.Deploy/src/Umbraco.AI.Deploy/Connectors/ServiceConnectors/UmbracoAIProfileServiceConnector.cs
+++ b/Umbraco.AI.Deploy/src/Umbraco.AI.Deploy/Connectors/ServiceConnectors/UmbracoAIProfileServiceConnector.cs
@@ -91,6 +91,11 @@ public class UmbracoAIProfileServiceConnector(
             // Serialize against the runtime type (Settings is declared as the marker interface
             // IAIProfileSettings, which would otherwise serialize as an empty object) using the
             // core serializer options so the artifact round-trips through AIProfileSettingsSerializer.
+            // The provider-declared bag is already shaped by the provider's schema, so it round-trips as
+            // whatever it holds — a JsonElement read from storage, or the object the API supplied.
+            CapabilitySettings = entity.CapabilitySettings != null
+                ? JsonSerializer.SerializeToElement(entity.CapabilitySettings, entity.CapabilitySettings.GetType(), Umbraco.AI.Core.Constants.DefaultJsonSerializerOptions)
+                : null,
             Settings = entity.Settings != null
                 ? JsonSerializer.SerializeToElement(entity.Settings, entity.Settings.GetType(), Umbraco.AI.Core.Constants.DefaultJsonSerializerOptions)
                 : null,
@@ -163,6 +168,7 @@ public class UmbracoAIProfileServiceConnector(
         profile.ConnectionId = connection.Id;
         profile.Model = modelRef;
         profile.Settings = settings;
+        profile.CapabilitySettings = artifact.CapabilitySettings;
         profile.Tags = artifact.Tags.ToList();
 
         state.Entity = await profileService.SaveProfileAsync(profile, cancellationToken);

--- a/Umbraco.AI.Deploy/tests/Umbraco.AI.Deploy.Tests.Unit/Connectors/ServiceConnectors/UmbracoAIProfileServiceConnectorTests.cs
+++ b/Umbraco.AI.Deploy/tests/Umbraco.AI.Deploy.Tests.Unit/Connectors/ServiceConnectors/UmbracoAIProfileServiceConnectorTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -251,5 +252,87 @@ public class UmbracoAIProfileServiceConnectorTests
         settings.MaxTokens.ShouldBe(1000);
         settings.SystemPromptTemplate.ShouldBe("You are helpful.");
         settings.GuardrailIds.ShouldBe([guardrailId]);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ProfileWithCapabilitySettings_RoundTripsThem()
+    {
+        // Arrange — provider-declared settings must survive a transfer, or the target environment
+        // silently loses the configured value
+        var connectionId = Guid.NewGuid();
+        var profile = new AIProfile
+        {
+            Alias = "chat-profile",
+            Name = "Chat Profile",
+            Capability = AICapability.Chat,
+            Model = new AIModelRef("openai", "gpt-5.6"),
+            ConnectionId = connectionId,
+            CapabilitySettings = JsonSerializer.Deserialize<JsonElement>("""{"reasoningEffort":"high"}"""),
+        };
+
+        var udi = new GuidUdi("umbraco-ai-profile", profile.Id);
+        var artifact = await _connector.GetArtifactAsync(udi, profile);
+        artifact.ShouldNotBeNull();
+        artifact.CapabilitySettings.ShouldNotBeNull();
+
+        _connectionServiceMock
+            .Setup(x => x.GetConnectionAsync(connectionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AIConnection { Alias = "conn", Name = "Conn", ProviderId = "openai" });
+
+        AIProfile? savedProfile = null;
+        _profileServiceMock
+            .Setup(x => x.SaveProfileAsync(It.IsAny<AIProfile>(), It.IsAny<CancellationToken>()))
+            .Callback<AIProfile, CancellationToken>((p, _) => savedProfile = p)
+            .ReturnsAsync((AIProfile p, CancellationToken _) => p);
+
+        var state = new ArtifactDeployState<AIProfileArtifact, AIProfile>(artifact, null, _connector, 2);
+
+        // Act
+        await _connector.ProcessAsync(state, Mock.Of<IDeployContext>(), 2);
+
+        // Assert
+        savedProfile.ShouldNotBeNull();
+        var restored = savedProfile.CapabilitySettings.ShouldBeOfType<JsonElement>();
+        restored.GetProperty("reasoningEffort").GetString().ShouldBe("high");
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ProfileWithoutCapabilitySettings_RoundTripsAsNull()
+    {
+        // Arrange — every profile created before providers could declare settings, and every profile whose
+        // provider declares none
+        var connectionId = Guid.NewGuid();
+        var profile = new AIProfile
+        {
+            Alias = "plain-profile",
+            Name = "Plain Profile",
+            Capability = AICapability.Chat,
+            Model = new AIModelRef("openai", "gpt-4o"),
+            ConnectionId = connectionId,
+        };
+
+        var udi = new GuidUdi("umbraco-ai-profile", profile.Id);
+        var artifact = await _connector.GetArtifactAsync(udi, profile);
+        artifact.ShouldNotBeNull();
+        artifact.CapabilitySettings.ShouldBeNull();
+
+        _connectionServiceMock
+            .Setup(x => x.GetConnectionAsync(connectionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AIConnection { Alias = "conn", Name = "Conn", ProviderId = "openai" });
+
+        AIProfile? savedProfile = null;
+        _profileServiceMock
+            .Setup(x => x.SaveProfileAsync(It.IsAny<AIProfile>(), It.IsAny<CancellationToken>()))
+            .Callback<AIProfile, CancellationToken>((p, _) => savedProfile = p)
+            .ReturnsAsync((AIProfile p, CancellationToken _) => p);
+
+        var state = new ArtifactDeployState<AIProfileArtifact, AIProfile>(artifact, null, _connector, 2);
+
+        // Act
+        await _connector.ProcessAsync(state, Mock.Of<IDeployContext>(), 2);
+
+        // Assert
+        savedProfile.ShouldNotBeNull();
+        savedProfile.CapabilitySettings.ShouldBeNull();
     }
 }

--- a/Umbraco.AI.OpenAI/Umbraco.AI.OpenAI.slnx
+++ b/Umbraco.AI.OpenAI/Umbraco.AI.OpenAI.slnx
@@ -1,3 +1,6 @@
 <Solution>
   <Project Path="src/Umbraco.AI.OpenAI/Umbraco.AI.OpenAI.csproj" />
+  <Folder Name="/Tests/">
+    <Project Path="tests/Umbraco.AI.OpenAI.Tests.Unit/Umbraco.AI.OpenAI.Tests.Unit.csproj" />
+  </Folder>
 </Solution>

--- a/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIChatCapability.cs
+++ b/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIChatCapability.cs
@@ -1,11 +1,13 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OpenAI.Responses;
 using Umbraco.AI.Core.Models;
 using Umbraco.AI.Core.Providers;
 using Umbraco.AI.Extensions;
+using Umbraco.Cms.Core.DependencyInjection;
 
 #pragma warning disable OPENAI001 // OpenAI Responses API (reasoning options) is experimental in the SDK
 
@@ -26,9 +28,16 @@ public class OpenAIChatCapability(
     /// Retained so adding the logger parameter stays binary compatible. An optional parameter would not
     /// achieve that — the compiler emits a single constructor and bakes the default in at each call site,
     /// so assemblies compiled against the previous signature would fail to bind.
+    /// <para>
+    /// The logger is resolved through the service locator, following the same approach as
+    /// <c>AIGuardrailEvaluatorBase</c>, so a consumer still on this signature gets real logging rather than
+    /// none. Null-conditional because the locator is unset before startup and in unit tests, and logging is
+    /// optional here — unlike the required services that pattern usually resolves.
+    /// </para>
     /// </remarks>
+    [Obsolete("Use the constructor that accepts a logger. Will be removed in v20.")]
     public OpenAIChatCapability(OpenAIProvider provider)
-        : this(provider, null)
+        : this(provider, StaticServiceProvider.Instance?.GetService<ILogger<OpenAIChatCapability>>())
     {
     }
 

--- a/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIChatCapability.cs
+++ b/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIChatCapability.cs
@@ -89,10 +89,10 @@ public class OpenAIChatCapability(
     /// here is the list of reasoning families, so the predicate is written as an allow-list and inverted
     /// into the declaration.
     /// </remarks>
-    public override AIModelSettingSupport GetSettingSupport(string modelId)
+    public override AIModelSettingsSupport GetSettingsSupport(string modelId)
         => OpenAIModelUtilities.SupportsReasoningEffort(modelId)
-            ? AIModelSettingSupport.Default
-            : new AIModelSettingSupport
+            ? AIModelSettingsSupport.Default
+            : new AIModelSettingsSupport
             {
                 UnsupportedCapabilitySettings = [nameof(OpenAIChatCapabilitySettings.ReasoningEffort)],
             };
@@ -118,7 +118,7 @@ public class OpenAIChatCapability(
     /// <see cref="ResponseReasoningOptions.ReasoningEffortLevel"/> via
     /// <see cref="ChatOptions.RawRepresentationFactory"/>. Any existing factory is preserved.
     /// Skipped entirely on models that do not accept a reasoning effort — the same predicate that drives
-    /// <see cref="GetSettingSupport"/> — so a profile carrying a stale value cannot fail the request.
+    /// <see cref="GetSettingsSupport"/> — so a profile carrying a stale value cannot fail the request.
     /// </remarks>
     protected override void ApplyCapabilitySettings(
         OpenAIChatCapabilitySettings capabilitySettings,

--- a/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIChatCapability.cs
+++ b/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIChatCapability.cs
@@ -1,16 +1,20 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.AI;
+using OpenAI.Responses;
 using Umbraco.AI.Core.Models;
 using Umbraco.AI.Core.Providers;
 using Umbraco.AI.Extensions;
+
+#pragma warning disable OPENAI001 // OpenAI Responses API (reasoning options) is experimental in the SDK
 
 namespace Umbraco.AI.OpenAI;
 
 /// <summary>
 /// AI chat capability for OpenAI provider.
 /// </summary>
-public class OpenAIChatCapability(OpenAIProvider provider) : AIChatCapabilityBase<OpenAIProviderSettings>(provider)
+public class OpenAIChatCapability(OpenAIProvider provider)
+    : AIChatCapabilityBase<OpenAIProviderSettings, OpenAIChatCapabilitySettings>(provider)
 {
     private const string DefaultChatModel = "gpt-4o";
 
@@ -24,6 +28,7 @@ public class OpenAIChatCapability(OpenAIProvider provider) : AIChatCapabilityBas
         new(@"^gpt-", RegexOptions.IgnoreCase | RegexOptions.Compiled),
         new(@"^o1", RegexOptions.IgnoreCase | RegexOptions.Compiled),
         new(@"^o3", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"^o4", RegexOptions.IgnoreCase | RegexOptions.Compiled),
         new(@"^chatgpt-", RegexOptions.IgnoreCase | RegexOptions.Compiled),
     ];
 
@@ -53,11 +58,76 @@ public class OpenAIChatCapability(OpenAIProvider provider) : AIChatCapabilityBas
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Reasoning effort applies to the o-series and GPT-5 only, so it is declared per model rather than
+    /// per provider — otherwise the profile editor would offer it on a gpt-4o profile. The stable set
+    /// here is the list of reasoning families, so the predicate is written as an allow-list and inverted
+    /// into the declaration.
+    /// </remarks>
+    public override AIModelSettingSupport GetSettingSupport(string modelId)
+        => OpenAIModelUtilities.SupportsReasoningEffort(modelId)
+            ? AIModelSettingSupport.Default
+            : new AIModelSettingSupport
+            {
+                UnsupportedCapabilitySettings = [nameof(OpenAIChatCapabilitySettings.ReasoningEffort)],
+            };
+
+    /// <inheritdoc />
     [Experimental("OPENAI001")]
     protected override IChatClient CreateClient(OpenAIProviderSettings settings, string? modelId)
         => OpenAIProvider.CreateOpenAIClient(settings)
             .GetResponsesClient()
             .AsIChatClient(modelId ?? DefaultChatModel);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Translates the profile's reasoning-effort setting into the Responses API's
+    /// <see cref="ResponseReasoningOptions.ReasoningEffortLevel"/> via
+    /// <see cref="ChatOptions.RawRepresentationFactory"/>. Any existing factory is preserved.
+    /// Skipped entirely on models that do not accept a reasoning effort — the same predicate that drives
+    /// <see cref="GetSettingSupport"/> — so a profile carrying a stale value cannot fail the request.
+    /// </remarks>
+    protected override void ApplyCapabilitySettings(
+        OpenAIChatCapabilitySettings capabilitySettings,
+        string? modelId,
+        ChatOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(capabilitySettings.ReasoningEffort))
+        {
+            return;
+        }
+
+        if (!OpenAIModelUtilities.SupportsReasoningEffort(modelId ?? DefaultChatModel))
+        {
+            return;
+        }
+
+        ResponseReasoningEffortLevel? effort = capabilitySettings.ReasoningEffort.Trim().ToLowerInvariant() switch
+        {
+            "none" => ResponseReasoningEffortLevel.None,
+            "minimal" => ResponseReasoningEffortLevel.Minimal,
+            "low" => ResponseReasoningEffortLevel.Low,
+            "medium" => ResponseReasoningEffortLevel.Medium,
+            "high" => ResponseReasoningEffortLevel.High,
+            // Unrecognised values (including xhigh/max, which the pinned SDK cannot express) are skipped
+            // rather than sent, so a stored value can never fail the request.
+            _ => null
+        };
+
+        if (effort is null)
+        {
+            return;
+        }
+
+        var previousFactory = options.RawRepresentationFactory;
+        options.RawRepresentationFactory = client =>
+        {
+            var raw = previousFactory?.Invoke(client) as CreateResponseOptions ?? new CreateResponseOptions();
+            raw.ReasoningOptions ??= new ResponseReasoningOptions();
+            raw.ReasoningOptions.ReasoningEffortLevel = effort;
+            return raw;
+        };
+    }
 
     private static bool IsChatModel(string modelId)
         => IncludePatterns.Any(p => p.IsMatch(modelId))

--- a/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIChatCapabilitySettings.cs
+++ b/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIChatCapabilitySettings.cs
@@ -1,4 +1,6 @@
+using System.Text.Json.Serialization;
 using Umbraco.AI.Core.EditableModels;
+using Umbraco.AI.Core.Serialization;
 
 namespace Umbraco.AI.OpenAI;
 
@@ -24,5 +26,6 @@ public class OpenAIChatCapabilitySettings
         EditorUiAlias = "Umb.PropertyEditorUi.Dropdown",
         EditorConfig = "[{\"alias\":\"multiple\",\"value\":false},{\"alias\":\"items\",\"value\":[\"none\",\"minimal\",\"low\",\"medium\",\"high\"]}]",
         SortOrder = 1)]
+    [JsonConverter(typeof(DropdownStringJsonConverter))]
     public string? ReasoningEffort { get; set; }
 }

--- a/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIChatCapabilitySettings.cs
+++ b/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIChatCapabilitySettings.cs
@@ -1,0 +1,28 @@
+using Umbraco.AI.Core.EditableModels;
+
+namespace Umbraco.AI.OpenAI;
+
+/// <summary>
+/// Provider-declared, profile-level chat settings for OpenAI (surfaced on the profile editor and
+/// applied to each request).
+/// </summary>
+public class OpenAIChatCapabilitySettings
+{
+    /// <summary>
+    /// Constrains the reasoning effort for reasoning-capable models (the o-series and the GPT-5 line).
+    /// Leave empty for the model default.
+    /// </summary>
+    /// <remarks>
+    /// The levels offered are the ones the pinned OpenAI SDK can express through
+    /// <c>ResponseReasoningEffortLevel</c>. The API also accepts <c>xhigh</c> and <c>max</c> on some
+    /// models; those need an SDK that exposes them and are deliberately not offered here rather than
+    /// silently dropped.
+    /// </remarks>
+    [AIField(
+        Label = "Reasoning effort",
+        Description = "Constrains reasoning effort for reasoning-capable models (the o-series and the GPT-5 line). Leave empty for the model default.",
+        EditorUiAlias = "Umb.PropertyEditorUi.Dropdown",
+        EditorConfig = "[{\"alias\":\"multiple\",\"value\":false},{\"alias\":\"items\",\"value\":[\"none\",\"minimal\",\"low\",\"medium\",\"high\"]}]",
+        SortOrder = 1)]
+    public string? ReasoningEffort { get; set; }
+}

--- a/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIModelUtilities.cs
+++ b/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIModelUtilities.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+
 namespace Umbraco.AI.Extensions;
 
 /// <summary>
@@ -5,6 +7,48 @@ namespace Umbraco.AI.Extensions;
 /// </summary>
 internal static class OpenAIModelUtilities
 {
+    /// <summary>
+    /// Model families that accept a reasoning effort: the o-series and the GPT-5 line, whose current
+    /// members use dotted minors (gpt-5.4, gpt-5.5, gpt-5.6 and its sol/terra/luna variants).
+    /// </summary>
+    /// <remarks>
+    /// The o-series is a closed set, not a snapshot: the naming was retired in favour of GPT-5, there is
+    /// no o5, and o1/o3 are scheduled for shutdown on 23 October 2026 (o3-deep-research on 11 December
+    /// 2026) with gpt-5.6-sol as the replacement. Those entries can be dropped once the shutdowns land;
+    /// they are kept for accounts that still have access. Future reasoning models arrive as gpt-5 minors,
+    /// which <c>^gpt-5</c> already covers — a further naming change is what would need a new pattern.
+    /// </remarks>
+    private static readonly Regex[] ReasoningModelPatterns =
+    [
+        new(@"^o1", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"^o3", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"^o4", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"^gpt-5", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+    ];
+
+    /// <summary>
+    /// GPT-5 variants that are not reasoning models despite the family prefix. Matches both the
+    /// undotted (<c>gpt-5-chat-latest</c>) and dotted (<c>gpt-5.6-chat</c>) naming.
+    /// </summary>
+    private static readonly Regex[] NonReasoningExceptionPatterns =
+    [
+        new(@"^gpt-5[\d.]*-chat", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+    ];
+
+    /// <summary>
+    /// Whether the model accepts a reasoning effort (<c>reasoning.effort</c> on the Responses API).
+    /// </summary>
+    /// <param name="modelId">The model ID, or null when unresolved.</param>
+    /// <remarks>
+    /// A positive list: a reasoning family released after this package ships reads as unsupported until
+    /// the list is updated. That only suppresses the setting in the editor and skips sending it — it
+    /// never produces a failed request — which is the safe direction for an unknown model.
+    /// </remarks>
+    public static bool SupportsReasoningEffort(string? modelId)
+        => !string.IsNullOrWhiteSpace(modelId)
+           && ReasoningModelPatterns.Any(p => p.IsMatch(modelId))
+           && !NonReasoningExceptionPatterns.Any(p => p.IsMatch(modelId));
+
     /// <summary>
     /// Formats a model ID into a human-readable display name.
     /// </summary>

--- a/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/Fakes/CapturingHttpMessageHandler.cs
+++ b/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/Fakes/CapturingHttpMessageHandler.cs
@@ -1,0 +1,27 @@
+using System.Net;
+
+namespace Umbraco.AI.OpenAI.Tests.Unit.Fakes;
+
+/// <summary>
+/// Captures the body of every request and short-circuits with an error response, so a test can assert on
+/// what would have gone over the wire without a real API call.
+/// </summary>
+internal sealed class CapturingHttpMessageHandler : HttpMessageHandler
+{
+    public List<string> RequestBodies { get; } = [];
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        if (request.Content is not null)
+        {
+            RequestBodies.Add(await request.Content.ReadAsStringAsync(cancellationToken));
+        }
+
+        return new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent("""{"type":"error","error":{"type":"invalid_request_error","message":"captured"}}"""),
+        };
+    }
+}

--- a/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/OpenAIReasoningEffortSupportTests.cs
+++ b/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/OpenAIReasoningEffortSupportTests.cs
@@ -1,0 +1,62 @@
+using Umbraco.AI.Extensions;
+
+namespace Umbraco.AI.OpenAI.Tests.Unit;
+
+/// <summary>
+/// The reasoning effort applies to the o-series and the GPT-5 line only. This predicate is the single
+/// source for both the per-model declaration surfaced to the profile editor and the decision to send an
+/// effort at all, so it is worth pinning down.
+/// </summary>
+/// <remarks>
+/// Model IDs taken from OpenAI's models list, reasoning guide and deprecations page (July 2026).
+/// </remarks>
+public class OpenAIReasoningEffortSupportTests
+{
+    [Theory]
+    [InlineData("gpt-5.6")]
+    [InlineData("gpt-5.6-sol")]
+    [InlineData("gpt-5.6-terra")]
+    [InlineData("gpt-5.6-luna")]
+    [InlineData("gpt-5.5")]
+    [InlineData("gpt-5.4")]
+    [InlineData("gpt-5")]
+    [InlineData("o1")]
+    [InlineData("o3-mini")]
+    [InlineData("o4-mini")]
+    public void SupportsReasoningEffort_ReasoningModel_ReturnsTrue(string modelId)
+    {
+        OpenAIModelUtilities.SupportsReasoningEffort(modelId).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("gpt-4o")]
+    [InlineData("gpt-4o-mini")]
+    [InlineData("gpt-4.1")]
+    [InlineData("gpt-4-turbo")]
+    [InlineData("gpt-3.5-turbo")]
+    [InlineData("chatgpt-4o-latest")]
+    [InlineData(null)]
+    [InlineData("")]
+    public void SupportsReasoningEffort_NonReasoningModel_ReturnsFalse(string? modelId)
+    {
+        OpenAIModelUtilities.SupportsReasoningEffort(modelId).ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("gpt-5-chat-latest")]
+    [InlineData("gpt-5.6-chat")]
+    public void SupportsReasoningEffort_NonReasoningChatVariant_ReturnsFalse(string modelId)
+    {
+        // Chat variants sit inside the GPT-5 family but are not reasoning models, under either the
+        // undotted or dotted naming.
+        OpenAIModelUtilities.SupportsReasoningEffort(modelId).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SupportsReasoningEffort_UnknownModel_ReturnsFalse()
+    {
+        // A positive list: a reasoning family released after this package ships reads as unsupported,
+        // which hides the setting and skips sending it rather than failing the request.
+        OpenAIModelUtilities.SupportsReasoningEffort("gpt-6").ShouldBeFalse();
+    }
+}

--- a/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/OpenAIReasoningEffortWireTests.cs
+++ b/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/OpenAIReasoningEffortWireTests.cs
@@ -1,0 +1,74 @@
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using Microsoft.Extensions.AI;
+using OpenAI;
+using OpenAI.Responses;
+using Umbraco.AI.OpenAI.Tests.Unit.Fakes;
+
+namespace Umbraco.AI.OpenAI.Tests.Unit;
+
+/// <summary>
+/// Pins down how the reasoning effort reaches the OpenAI wire, asserted against a captured request body
+/// rather than a live call.
+/// </summary>
+/// <remarks>
+/// The capability sets it through <see cref="ChatOptions.RawRepresentationFactory"/> on an otherwise empty
+/// <see cref="CreateResponseOptions"/>, which only works because the Microsoft.Extensions.AI adapter fills
+/// the rest of the request (model, input, token limits) around it. If that changes, this fails rather than
+/// the setting silently going missing — or worse, a request going out without a model.
+/// </remarks>
+public class OpenAIReasoningEffortWireTests
+{
+    [Fact]
+    public async Task RawRepresentationFactory_SetsReasoningEffort_ReachesTheRequestBodyWithTheModel()
+    {
+        // Arrange
+        var handler = new CapturingHttpMessageHandler();
+        var chatClient = CreateChatClient(handler, "gpt-5.6");
+
+        var options = new ChatOptions
+        {
+            MaxOutputTokens = 64,
+            RawRepresentationFactory = _ =>
+            {
+                var raw = new CreateResponseOptions();
+                raw.ReasoningOptions ??= new ResponseReasoningOptions();
+                raw.ReasoningOptions.ReasoningEffortLevel = ResponseReasoningEffortLevel.Low;
+                return raw;
+            },
+        };
+
+        // Act
+        await SendAndIgnoreFailureAsync(chatClient, options);
+
+        // Assert
+        var body = handler.RequestBodies.ShouldHaveSingleItem();
+        body.ShouldContain("\"effort\":\"low\"");
+        // The adapter must still supply everything the representation left empty.
+        body.ShouldContain("\"model\":\"gpt-5.6\"");
+        body.ShouldContain("hello");
+    }
+
+    private static IChatClient CreateChatClient(CapturingHttpMessageHandler handler, string modelId)
+        => new OpenAIClient(
+                new ApiKeyCredential("test-key"),
+                new OpenAIClientOptions
+                {
+                    Transport = new HttpClientPipelineTransport(new HttpClient(handler)),
+                    RetryPolicy = new ClientRetryPolicy(0),
+                })
+            .GetResponsesClient()
+            .AsIChatClient(modelId);
+
+    private static async Task SendAndIgnoreFailureAsync(IChatClient chatClient, ChatOptions options)
+    {
+        try
+        {
+            await chatClient.GetResponseAsync("hello", options);
+        }
+        catch (Exception)
+        {
+            // The capturing handler always fails the request; only the captured body matters here.
+        }
+    }
+}

--- a/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/Umbraco.AI.OpenAI.Tests.Unit.csproj
+++ b/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/Umbraco.AI.OpenAI.Tests.Unit.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsTestProject>true</IsTestProject>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <IsPackable>false</IsPackable>
+    <!-- The Responses API surface (reasoning options) is experimental in the OpenAI SDK -->
+    <NoWarn>$(NoWarn);OPENAI001</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Umbraco.AI.OpenAI\Umbraco.AI.OpenAI.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="Shouldly" />
+  </ItemGroup>
+
+</Project>

--- a/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/packages.lock.json
+++ b/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/packages.lock.json
@@ -979,6 +979,14 @@
         "resolved": "6.2.0",
         "contentHash": "DRx593fF5CJZ8pj94StWdZsE9/iXkJKp3L2xp6Y9EAliHf4+e1y4QvWL/jJmeZ7zb8NKpwyf6tq1CZDS2mQwAA=="
       },
+      "OpenAI": {
+        "type": "Transitive",
+        "resolved": "2.11.0",
+        "contentHash": "f0y5zOZVNhuc/gPQUHGkiljZlDUq2SddGOkGTPLHnjQC5mCiTCXq1BqxZ+xxxHU6bY0mEtFQJj1RlB2BpwD7Lw==",
+        "dependencies": {
+          "System.ClientModel": "1.10.0"
+        }
+      },
       "OpenIddict": {
         "type": "Transitive",
         "resolved": "7.4.0",
@@ -1440,8 +1448,8 @@
       },
       "System.Memory.Data": {
         "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "BVYuec3jV23EMRDeR7Dr1/qhx7369dZzJ9IWy2xylvb4YfXsrUxspWc4UWYid/tj4zZK58uGZqn2WQiaDMhmAg=="
+        "resolved": "10.0.3",
+        "contentHash": "MaGhRfGunmrj/nHjtsi9XkhlYJ/ERGWrbA+BiSKNtGnAjc9XlG5EhAvak6VRcX5LYzPF6pBO8nJ613dTgzabig=="
       },
       "System.Numerics.Tensors": {
         "type": "Transitive",
@@ -1642,13 +1650,6 @@
           "xunit.extensibility.core": "[2.9.3]"
         }
       },
-      "umbraco.ai.anthropic": {
-        "type": "Project",
-        "dependencies": {
-          "Anthropic": "[12.29.1, 12.999.999)",
-          "Umbraco.AI.Core": "[1.0.0, )"
-        }
-      },
       "umbraco.ai.core": {
         "type": "Project",
         "dependencies": {
@@ -1665,13 +1666,11 @@
           "Umbraco.Cms.Web.Common": "[17.4.0, 17.999.999)"
         }
       },
-      "Anthropic": {
-        "type": "CentralTransitive",
-        "requested": "[12.29.1, 12.999.999)",
-        "resolved": "12.29.1",
-        "contentHash": "EVq7ygOtMejWNXW+Dz+vv/ie50JgZB4jFc4gT2TTpBZXtp64zWRR7DqdGhbEaYThyMuaevN4ZRGUWBrSrb0+rg==",
+      "umbraco.ai.openai": {
+        "type": "Project",
         "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "10.5.1"
+          "Microsoft.Extensions.AI.OpenAI": "[10.7.0, 10.999.999)",
+          "Umbraco.AI.Core": "[1.0.0, )"
         }
       },
       "DocumentFormat.OpenXml": {
@@ -1694,6 +1693,16 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
           "System.Numerics.Tensors": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.AI.OpenAI": {
+        "type": "CentralTransitive",
+        "requested": "[10.7.0, 10.999.999)",
+        "resolved": "10.7.0",
+        "contentHash": "K/xC0SRJeQiHJNNx+ZIYq9liAB5Uy/wUGjHPljEtRW63TCyGWEBkNVU7/UwizTxQk0Tm9pclDEoNmKTw7xtKfg==",
+        "dependencies": {
+          "Microsoft.Extensions.AI.Abstractions": "10.7.0",
+          "OpenAI": "2.11.0"
         }
       },
       "Microsoft.Extensions.Caching.Memory": {
@@ -1737,11 +1746,13 @@
       "System.ClientModel": {
         "type": "CentralTransitive",
         "requested": "[1.5.0, 1.999.999)",
-        "resolved": "1.5.0",
-        "contentHash": "nyQUynSbLh8IVyETF2tN14IQwBYgif3gIBt2LAL3FSl0W5FIEJIog3sposTxdz23EqDN78LAQFpUxbaj1EsRJw==",
+        "resolved": "1.10.0",
+        "contentHash": "lBEWs54F5Y5pZ9hC+8z4S/X76957ex+DPk7WecRHlbIHtrPfbRMMlOgI3iDn4Jpb3bSxvBnKaaHoD59auFjlBA==",
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
-          "System.Memory.Data": "8.0.1"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "System.Memory.Data": "10.0.3"
         }
       },
       "Umbraco.Cms.Api.Management": {

--- a/Umbraco.AI/src/Umbraco.AI.Core/Chat/AIChatClientFactory.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Chat/AIChatClientFactory.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.AI;
 using Umbraco.AI.Core.Connections;
+using Umbraco.AI.Core.EditableModels;
 using Umbraco.AI.Core.Profiles;
 using Umbraco.AI.Core.Providers;
 using Umbraco.AI.Core.RuntimeContext;
@@ -13,19 +14,22 @@ internal sealed class AIChatClientFactory : IAIChatClientFactory
     private readonly IAIRuntimeContextAccessor _runtimeContextAccessor;
     private readonly IAIRuntimeContextScopeProvider _scopeProvider;
     private readonly AIRuntimeContextContributorCollection _contributors;
+    private readonly IAIEditableModelResolver _modelResolver;
 
     public AIChatClientFactory(
         IAIConnectionService connectionService,
         AIChatMiddlewareCollection middleware,
         IAIRuntimeContextAccessor runtimeContextAccessor,
         IAIRuntimeContextScopeProvider scopeProvider,
-        AIRuntimeContextContributorCollection contributors)
+        AIRuntimeContextContributorCollection contributors,
+        IAIEditableModelResolver modelResolver)
     {
         _connectionService = connectionService;
         _middleware = middleware;
         _runtimeContextAccessor = runtimeContextAccessor;
         _scopeProvider = scopeProvider;
         _contributors = contributors;
+        _modelResolver = modelResolver;
     }
 
     public async Task<IChatClient> CreateClientAsync(AIProfile profile, CancellationToken cancellationToken = default)
@@ -33,8 +37,19 @@ internal sealed class AIChatClientFactory : IAIChatClientFactory
         // Get configured provider with resolved settings
         var (chatCapability, provider) = await GetConfiguredChatCapabilityAsync(profile, cancellationToken);
 
-        // Create base client from provider with the profile's model
-        var chatClient = await chatCapability.CreateClientAsync(profile.Model.ModelId, cancellationToken);
+        // Resolve the provider-declared capability settings (e.g. reasoning effort) through the same
+        // editable-model pipeline connections use ($-config resolution + validation + typing), so the
+        // provider receives a strongly-typed, resolved object rather than a raw stored bag.
+        var resolvedCapabilitySettings = _modelResolver.ResolveCapabilitySettings(
+            provider,
+            profile.Capability,
+            profile.CapabilitySettings);
+
+        // Create base client from provider with the profile's model and resolved capability settings
+        var chatClient = await chatCapability.CreateClientAsync(
+            resolvedCapabilitySettings,
+            profile.Model.ModelId,
+            cancellationToken);
 
         // Wrap innermost so SDK exceptions are classified against the originating provider before
         // any middleware sees them (and every model round-trip inside function-invoking middleware

--- a/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/AIEditableModelResolverExtensions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/AIEditableModelResolverExtensions.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Umbraco.AI.Core.Models;
 using Umbraco.AI.Core.Providers;
 
 namespace Umbraco.AI.Core.EditableModels;
@@ -38,5 +39,44 @@ public static class AIEditableModelResolverExtensions
 
         // Provider doesn't have settings, return null
         return null;
+    }
+
+    /// <summary>
+    /// Resolves the provider-declared, profile-level settings (e.g. reasoning effort) for a given
+    /// capability into a typed instance. Mirrors <see cref="ResolveSettingsForProvider"/> but reads the
+    /// settings type/schema from the capability rather than the provider, so it can apply the same
+    /// <c>$</c>-config resolution and validation the connection settings get.
+    /// </summary>
+    /// <param name="resolver">The resolver instance.</param>
+    /// <param name="provider">The provider that owns the capability.</param>
+    /// <param name="capability">The capability whose profile settings should be resolved.</param>
+    /// <param name="capabilitySettings">The stored (untyped) capability-settings bag to resolve.</param>
+    /// <returns>
+    /// A typed capability-settings instance as <see cref="object"/>, or null if the bag was null or the
+    /// capability declares no profile settings.
+    /// </returns>
+    public static object? ResolveCapabilitySettings(
+        this IAIEditableModelResolver resolver,
+        IAIProvider provider,
+        AICapability capability,
+        object? capabilitySettings)
+    {
+        if (capabilitySettings is null)
+        {
+            return null;
+        }
+
+        var capabilitySettingsType = provider
+            .GetCapabilities()
+            .FirstOrDefault(c => c.Kind == capability)?
+            .CapabilitySettingsType;
+
+        if (capabilitySettingsType is null)
+        {
+            return null;
+        }
+
+        var schema = provider.GetCapabilitySettingsSchema(capability);
+        return resolver.ResolveModel(capabilitySettingsType, capabilitySettings, schema);
     }
 }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Extensions/AIModelDescriptorExtensions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Extensions/AIModelDescriptorExtensions.cs
@@ -9,7 +9,7 @@ public static class AIModelDescriptorExtensions
 {
     /// <summary>
     /// Whether a provider-declared capability setting applies to this model, per the capability's
-    /// declaration via <see cref="Core.Providers.IAICapability.GetSettingSupport"/>.
+    /// declaration via <see cref="Core.Providers.IAICapability.GetSettingsSupport"/>.
     /// </summary>
     /// <param name="model">The model descriptor.</param>
     /// <param name="fieldKey">The schema field key (or property name) of the setting.</param>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Extensions/AIModelDescriptorExtensions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Extensions/AIModelDescriptorExtensions.cs
@@ -1,0 +1,65 @@
+using Umbraco.AI.Core.Models;
+
+namespace Umbraco.AI.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="AIModelDescriptor"/>.
+/// </summary>
+public static class AIModelDescriptorExtensions
+{
+    /// <summary>
+    /// Whether a provider-declared capability setting applies to this model, per the capability's
+    /// declaration via <see cref="Core.Providers.IAICapability.GetSettingSupport"/>.
+    /// </summary>
+    /// <param name="model">The model descriptor.</param>
+    /// <param name="fieldKey">The schema field key (or property name) of the setting.</param>
+    /// <returns>
+    /// <c>false</c> only when the capability explicitly declared that this model rejects the setting.
+    /// Declarations are negative — a capability says nothing about models it has no knowledge of — so
+    /// this is "not known to be rejected" rather than an affirmative claim of support.
+    /// </returns>
+    public static bool IsCapabilitySettingSupported(this AIModelDescriptor model, string fieldKey)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+
+        if (string.IsNullOrWhiteSpace(fieldKey))
+        {
+            return true;
+        }
+
+        if (!model.Metadata.TryGetValue(AIModelMetadataKeys.CapabilitySettingsUnsupported, out var declared))
+        {
+            return true;
+        }
+
+        var key = fieldKey.Trim().ToCamelCase();
+
+        return !declared
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Any(k => string.Equals(k, key, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Returns a copy of the descriptor with the supplied metadata merged in. Existing entries win, so
+    /// a provider's own metadata is never overwritten.
+    /// </summary>
+    /// <param name="model">The model descriptor.</param>
+    /// <param name="additionalMetadata">The metadata entries to merge.</param>
+    internal static AIModelDescriptor WithMetadata(
+        this AIModelDescriptor model,
+        IReadOnlyDictionary<string, string> additionalMetadata)
+    {
+        if (additionalMetadata.Count == 0)
+        {
+            return model;
+        }
+
+        var merged = new Dictionary<string, string>(model.Metadata);
+        foreach (var (key, value) in additionalMetadata)
+        {
+            merged.TryAdd(key, value);
+        }
+
+        return new AIModelDescriptor(model.Model, model.Name, merged);
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Models/AIModelMetadataKeys.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Models/AIModelMetadataKeys.cs
@@ -1,0 +1,19 @@
+namespace Umbraco.AI.Core.Models;
+
+/// <summary>
+/// Well-known keys used in <see cref="AIModelDescriptor.Metadata"/>.
+/// </summary>
+/// <remarks>
+/// Metadata is a string dictionary so it can travel to the backoffice with the model list. This
+/// constant (plus <see cref="AIModelSettingSupport"/> for writing and the
+/// <c>IsCapabilitySettingSupported</c> extension for reading) keeps the convention in one place
+/// rather than repeated as literals across provider packages and the frontend.
+/// </remarks>
+public static class AIModelMetadataKeys
+{
+    /// <summary>
+    /// Comma-separated schema field keys of the provider-declared capability settings this model rejects.
+    /// Absent when the capability has nothing to declare for the model.
+    /// </summary>
+    public const string CapabilitySettingsUnsupported = "capabilitySettings.unsupported";
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Models/AIModelMetadataKeys.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Models/AIModelMetadataKeys.cs
@@ -5,7 +5,7 @@ namespace Umbraco.AI.Core.Models;
 /// </summary>
 /// <remarks>
 /// Metadata is a string dictionary so it can travel to the backoffice with the model list. This
-/// constant (plus <see cref="AIModelSettingSupport"/> for writing and the
+/// constant (plus <see cref="AIModelSettingsSupport"/> for writing and the
 /// <c>IsCapabilitySettingSupported</c> extension for reading) keeps the convention in one place
 /// rather than repeated as literals across provider packages and the frontend.
 /// </remarks>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Models/AIModelSettingSupport.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Models/AIModelSettingSupport.cs
@@ -1,0 +1,70 @@
+using Umbraco.AI.Extensions;
+
+namespace Umbraco.AI.Core.Models;
+
+/// <summary>
+/// A capability's declaration of which settings a given model does not accept.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Support for a setting usually varies by <em>model</em> rather than by provider — OpenAI's reasoning
+/// effort applies to the o-series and GPT-5 but not to gpt-4o; Anthropic's thinking budget is rejected
+/// by the newest Claude models. A capability returns this from
+/// <see cref="Providers.IAICapability.GetSettingSupport"/> and the core capability bases project it into
+/// <see cref="AIModelDescriptor.Metadata"/> when the model list is built, so the backoffice can hide the
+/// settings that don't apply to the selected model without an extra round trip.
+/// </para>
+/// <para>
+/// Declarations are negative only: a capability names the settings a model rejects and says nothing
+/// otherwise, so <see cref="Default"/> means "nothing to declare" and the setting renders. Whether the
+/// capability arrives at that by keeping an allow-list of models that support the setting or a deny-list
+/// of models that don't is its own business — write whichever set is more stable and convert at this
+/// boundary.
+/// </para>
+/// <para>
+/// This is the declaration channel for the <em>UI</em>. It is not an enforcement mechanism: the model
+/// list is fetched from the vendor and cannot be consulted per request, so a capability that declares a
+/// setting unsupported must also refrain from sending it (see
+/// <c>AIChatCapabilityBase&lt;TSettings, TCapabilitySettings&gt;.ApplyCapabilitySettings</c>, which receives
+/// the resolved model ID for exactly that purpose). Declare and enforce from one shared predicate.
+/// </para>
+/// <para>
+/// Entries may be given as property names (<c>nameof(MySettings.ReasoningEffort)</c>) or as schema field
+/// keys; both are normalised to the schema's camelCase key, so they cannot drift from the settings type.
+/// </para>
+/// </remarks>
+public sealed class AIModelSettingSupport
+{
+    /// <summary>
+    /// An empty declaration — the capability has nothing to say about this model, so every setting
+    /// applies.
+    /// </summary>
+    public static readonly AIModelSettingSupport Default = new();
+
+    /// <summary>
+    /// The provider-declared capability settings this model rejects or ignores.
+    /// </summary>
+    public IReadOnlyCollection<string> UnsupportedCapabilitySettings { get; init; } = [];
+
+    /// <summary>
+    /// Whether this declaration says anything at all.
+    /// </summary>
+    internal bool IsEmpty => UnsupportedCapabilitySettings.Count == 0;
+
+    /// <summary>
+    /// Projects the declaration into the metadata entries carried by <see cref="AIModelDescriptor.Metadata"/>.
+    /// </summary>
+    internal IReadOnlyDictionary<string, string> ToMetadata()
+        => IsEmpty
+            ? new Dictionary<string, string>()
+            : new Dictionary<string, string>
+            {
+                // Normalise to the same camelCase key the schema builder derives from the property name,
+                // so a declaration written as nameof(TSettings.ReasoningEffort) matches the field key.
+                [AIModelMetadataKeys.CapabilitySettingsUnsupported] = string.Join(
+                    ',',
+                    UnsupportedCapabilitySettings
+                        .Where(k => !string.IsNullOrWhiteSpace(k))
+                        .Select(k => k.Trim().ToCamelCase())),
+            };
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Models/AIModelSettingSupport.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Models/AIModelSettingSupport.cs
@@ -54,7 +54,13 @@ public sealed class AIModelSettingSupport
     /// <summary>
     /// Projects the declaration into the metadata entries carried by <see cref="AIModelDescriptor.Metadata"/>.
     /// </summary>
-    internal IReadOnlyDictionary<string, string> ToMetadata()
+    /// <remarks>
+    /// The capability bases call this for you when they project
+    /// <see cref="Providers.IAICapability.GetSettingSupport"/> over a model list. It is public for the other
+    /// route: a capability whose vendor reports support as data (Anthropic's models endpoint does) can build
+    /// its descriptors with the declaration already attached instead of implementing the hook.
+    /// </remarks>
+    public IReadOnlyDictionary<string, string> ToMetadata()
         => IsEmpty
             ? new Dictionary<string, string>()
             : new Dictionary<string, string>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Models/AIModelSettingsSupport.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Models/AIModelSettingsSupport.cs
@@ -10,7 +10,7 @@ namespace Umbraco.AI.Core.Models;
 /// Support for a setting usually varies by <em>model</em> rather than by provider — OpenAI's reasoning
 /// effort applies to the o-series and GPT-5 but not to gpt-4o; Anthropic's thinking budget is rejected
 /// by the newest Claude models. A capability returns this from
-/// <see cref="Providers.IAICapability.GetSettingSupport"/> and the core capability bases project it into
+/// <see cref="Providers.IAICapability.GetSettingsSupport"/> and the core capability bases project it into
 /// <see cref="AIModelDescriptor.Metadata"/> when the model list is built, so the backoffice can hide the
 /// settings that don't apply to the selected model without an extra round trip.
 /// </para>
@@ -33,13 +33,13 @@ namespace Umbraco.AI.Core.Models;
 /// keys; both are normalised to the schema's camelCase key, so they cannot drift from the settings type.
 /// </para>
 /// </remarks>
-public sealed class AIModelSettingSupport
+public sealed class AIModelSettingsSupport
 {
     /// <summary>
     /// An empty declaration — the capability has nothing to say about this model, so every setting
     /// applies.
     /// </summary>
-    public static readonly AIModelSettingSupport Default = new();
+    public static readonly AIModelSettingsSupport Default = new();
 
     /// <summary>
     /// The provider-declared capability settings this model rejects or ignores.
@@ -56,7 +56,7 @@ public sealed class AIModelSettingSupport
     /// </summary>
     /// <remarks>
     /// The capability bases call this for you when they project
-    /// <see cref="Providers.IAICapability.GetSettingSupport"/> over a model list. It is public for the other
+    /// <see cref="Providers.IAICapability.GetSettingsSupport"/> over a model list. It is public for the other
     /// route: a capability whose vendor reports support as data (Anthropic's models endpoint does) can build
     /// its descriptors with the declaration already attached instead of implementing the hook.
     /// </remarks>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Profiles/AIProfile.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Profiles/AIProfile.cs
@@ -46,6 +46,15 @@ public sealed class AIProfile : IAIVersionableEntity
     public IAIProfileSettings? Settings { get; set; }
 
     /// <summary>
+    /// Provider-declared, profile-level settings (e.g. reasoning effort) whose shape is defined by
+    /// the provider for this profile's <see cref="Capability"/>. Mirrors <see cref="Connections.AIConnection.Settings"/>:
+    /// holds the provider-specific bag (a raw <see cref="System.Text.Json.JsonElement"/> when read from
+    /// storage, or the value supplied by the API). Resolved into a typed instance at request time via
+    /// the provider's capability-settings schema.
+    /// </summary>
+    public object? CapabilitySettings { get; set; }
+
+    /// <summary>
     /// A list of tags associated with the AI profile for categorization and filtering.
     /// </summary>
     public IReadOnlyList<string> Tags { get; set; } = Array.Empty<string>();

--- a/Umbraco.AI/src/Umbraco.AI.Core/Providers/AIConfiguredCapability.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Providers/AIConfiguredCapability.cs
@@ -19,6 +19,10 @@ internal sealed class AIConfiguredChatCapability(IAIChatCapability inner, object
         => inner.CreateClientAsync(settings, modelId, cancellationToken);
 
     /// <inheritdoc />
+    public Task<IChatClient> CreateClientAsync(object? capabilitySettings, string? modelId, CancellationToken cancellationToken)
+        => inner.CreateClientAsync(settings, capabilitySettings, modelId, cancellationToken);
+
+    /// <inheritdoc />
     public Task<IReadOnlyList<AIModelDescriptor>> GetModelsAsync(CancellationToken cancellationToken = default)
         => inner.GetModelsAsync(settings, cancellationToken);
 }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Providers/AIProviderBase.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Providers/AIProviderBase.cs
@@ -104,6 +104,21 @@ public abstract class AIProviderBase : IAIProvider
     }
 
     /// <inheritdoc />
+    public virtual AIEditableModelSchema? GetCapabilitySettingsSchema(AICapability capability)
+    {
+        // A capability declares its capability-settings type via IAICapability.CapabilitySettingsType
+        // (set by the two-parameter AIChatCapabilityBase<TSettings, TCapabilitySettings>). Build the
+        // schema with the same builder used for connection settings.
+        var capabilitySettingsType = Capabilities
+            .FirstOrDefault(c => c.Kind == capability)?
+            .CapabilitySettingsType;
+
+        return capabilitySettingsType is null
+            ? null
+            : Infrastructure.SchemaBuilder.BuildForType(capabilitySettingsType, Id);
+    }
+
+    /// <inheritdoc />
     /// <remarks>
     /// Default implementation recognises the common transport exception types via
     /// <see cref="ProviderErrorMapping.FromException"/>. Providers whose SDK surfaces errors

--- a/Umbraco.AI/src/Umbraco.AI.Core/Providers/CapabilitySettingSupportProjection.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Providers/CapabilitySettingSupportProjection.cs
@@ -1,0 +1,51 @@
+using Umbraco.AI.Core.Models;
+using Umbraco.AI.Extensions;
+
+namespace Umbraco.AI.Core.Providers;
+
+/// <summary>
+/// Projects a capability's per-model setting declarations into the metadata carried by each
+/// <see cref="AIModelDescriptor"/>, so the model list the backoffice already fetches also says which
+/// settings apply to each model.
+/// </summary>
+/// <remarks>
+/// Applied by the capability bases around the provider's own <c>GetModelsAsync</c>, which keeps
+/// providers free of the metadata convention — they implement
+/// <see cref="IAICapability.GetSettingSupport"/> and nothing else.
+/// </remarks>
+internal static class CapabilitySettingSupportProjection
+{
+    internal static IReadOnlyList<AIModelDescriptor> Apply(
+        IAICapability capability,
+        IReadOnlyList<AIModelDescriptor> models)
+    {
+        if (models.Count == 0)
+        {
+            return models;
+        }
+
+        List<AIModelDescriptor>? projected = null;
+
+        for (var i = 0; i < models.Count; i++)
+        {
+            var model = models[i];
+            var support = capability.GetSettingSupport(model.Model.ModelId);
+            if (support.IsEmpty)
+            {
+                projected?.Add(model);
+                continue;
+            }
+
+            // First declaration seen — copy everything already walked past, then continue with the copy.
+            if (projected is null)
+            {
+                projected = new List<AIModelDescriptor>(models.Count);
+                projected.AddRange(models.Take(i));
+            }
+
+            projected.Add(model.WithMetadata(support.ToMetadata()));
+        }
+
+        return projected ?? models;
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Providers/CapabilitySettingsChatClient.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Providers/CapabilitySettingsChatClient.cs
@@ -1,0 +1,59 @@
+using Microsoft.Extensions.AI;
+
+namespace Umbraco.AI.Core.Providers;
+
+/// <summary>
+/// Chat client decorator that applies provider-declared capability settings (e.g. reasoning
+/// effort) onto each request's <see cref="ChatOptions"/> before delegating to the inner client.
+/// </summary>
+/// <remarks>
+/// Created by <see cref="AIChatCapabilityBase{TSettings, TCapabilitySettings}"/> with the resolved,
+/// typed capability settings baked in. The caller's <see cref="ChatOptions"/> instance is never mutated;
+/// a per-request copy is used.
+/// </remarks>
+/// <typeparam name="TCapabilitySettings">The provider-declared capability settings type.</typeparam>
+internal sealed class CapabilitySettingsChatClient<TCapabilitySettings> : DelegatingChatClient
+    where TCapabilitySettings : class
+{
+    private readonly TCapabilitySettings _capabilitySettings;
+    private readonly string? _boundModelId;
+    private readonly Action<TCapabilitySettings, string?, ChatOptions> _apply;
+
+    public CapabilitySettingsChatClient(
+        IChatClient innerClient,
+        TCapabilitySettings capabilitySettings,
+        string? boundModelId,
+        Action<TCapabilitySettings, string?, ChatOptions> apply)
+        : base(innerClient)
+    {
+        _capabilitySettings = capabilitySettings;
+        _boundModelId = boundModelId;
+        _apply = apply;
+    }
+
+    /// <inheritdoc />
+    public override Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => base.GetResponseAsync(messages, Apply(options), cancellationToken);
+
+    /// <inheritdoc />
+    public override IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => base.GetStreamingResponseAsync(messages, Apply(options), cancellationToken);
+
+    private ChatOptions Apply(ChatOptions? options)
+    {
+        // Clone so the caller's options instance is never mutated.
+        var effective = options?.Clone() ?? new ChatOptions();
+
+        // Resolve the model the request will actually run against so the provider can gate settings the
+        // model rejects. The bound fallback is load-bearing, not defensive: the agent runtime builds its
+        // ChatOptions without a ModelId, so the creation-time model is the only signal on that path.
+        _apply(_capabilitySettings, effective.ModelId ?? _boundModelId, effective);
+        return effective;
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Providers/CapabilitySettingsSupportProjection.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Providers/CapabilitySettingsSupportProjection.cs
@@ -11,9 +11,9 @@ namespace Umbraco.AI.Core.Providers;
 /// <remarks>
 /// Applied by the capability bases around the provider's own <c>GetModelsAsync</c>, which keeps
 /// providers free of the metadata convention — they implement
-/// <see cref="IAICapability.GetSettingSupport"/> and nothing else.
+/// <see cref="IAICapability.GetSettingsSupport"/> and nothing else.
 /// </remarks>
-internal static class CapabilitySettingSupportProjection
+internal static class CapabilitySettingsSupportProjection
 {
     internal static IReadOnlyList<AIModelDescriptor> Apply(
         IAICapability capability,
@@ -29,7 +29,7 @@ internal static class CapabilitySettingSupportProjection
         for (var i = 0; i < models.Count; i++)
         {
             var model = models[i];
-            var support = capability.GetSettingSupport(model.Model.ModelId);
+            var support = capability.GetSettingsSupport(model.Model.ModelId);
             if (support.IsEmpty)
             {
                 projected?.Add(model);

--- a/Umbraco.AI/src/Umbraco.AI.Core/Providers/IAICapability.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Providers/IAICapability.cs
@@ -40,6 +40,38 @@ public interface IAICapability
     AICapability Kind { get; }
 
     /// <summary>
+    /// Gets the type that represents the provider-declared capability settings for this
+    /// capability (e.g. reasoning effort), or <c>null</c> if the capability declares no such extras.
+    /// </summary>
+    /// <remarks>
+    /// This is the profile-level analogue of <see cref="IAIProvider.SettingsType"/> (which describes
+    /// connection settings). It is a reflection hook read by the provider/registry to build a schema
+    /// and to resolve the stored bag into a typed object; providers do not implement it directly but
+    /// instead derive their capability from the two-parameter <c>AIChatCapabilityBase&lt;TSettings, TCapabilitySettings&gt;</c>.
+    /// </remarks>
+    Type? CapabilitySettingsType => null;
+
+    /// <summary>
+    /// Declares which settings the given model does not accept. Defaults to
+    /// <see cref="AIModelSettingSupport.Default"/> — nothing declared, so every setting applies.
+    /// </summary>
+    /// <param name="modelId">The model ID to describe.</param>
+    /// <remarks>
+    /// <para>
+    /// Support for a setting usually varies by model, not by provider, so this is where a capability
+    /// says "reasoning effort does not apply to gpt-4o". The capability bases project the result into
+    /// <see cref="AIModelDescriptor.Metadata"/> as the model list is built, so the backoffice can hide
+    /// inapplicable settings without a second round trip.
+    /// </para>
+    /// <para>
+    /// Must be a cheap, local, synchronous decision — it runs once per model in the list. The same
+    /// predicate should also gate what the capability actually sends, since this declaration only
+    /// reaches the UI (see <see cref="AIModelSettingSupport"/>).
+    /// </para>
+    /// </remarks>
+    AIModelSettingSupport GetSettingSupport(string modelId) => AIModelSettingSupport.Default;
+
+    /// <summary>
     /// Gets the available AI models for this capability.
     /// </summary>
     /// <param name="settings"></param>
@@ -69,6 +101,23 @@ public interface IAIChatCapability : IAICapability
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A configured chat client.</returns>
     Task<IChatClient> CreateClientAsync(object? settings = null, string? modelId = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a chat client with the provided connection settings and resolved, provider-declared
+    /// profile settings (e.g. reasoning effort).
+    /// </summary>
+    /// <param name="settings">Provider-specific connection settings (e.g., API key). Must be resolved (not a raw <see cref="JsonElement"/>).</param>
+    /// <param name="capabilitySettings">The resolved, typed capability settings, or <c>null</c> when the profile declares none. Must be resolved (not a raw <see cref="JsonElement"/>).</param>
+    /// <param name="modelId">Optional model ID to use. If null, the provider's default model is used.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A configured chat client.</returns>
+    /// <remarks>
+    /// Default implementation ignores <paramref name="capabilitySettings"/> and delegates to
+    /// <see cref="CreateClientAsync(object?, string?, CancellationToken)"/> so existing capabilities keep working.
+    /// The two-parameter <c>AIChatCapabilityBase&lt;TSettings, TCapabilitySettings&gt;</c> overrides this to apply them per request.
+    /// </remarks>
+    Task<IChatClient> CreateClientAsync(object? settings, object? capabilitySettings, string? modelId, CancellationToken cancellationToken)
+        => CreateClientAsync(settings, modelId, cancellationToken);
 }
 
 /// <summary>
@@ -132,6 +181,17 @@ public abstract class AICapabilityBase(IAIProvider provider) : IAICapability
     /// </summary>
     public abstract AICapability Kind { get; }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// Implements the interface member as a real virtual class member (rather than relying on the
+    /// interface default) so the two-parameter capability bases can <c>override</c> it and interface
+    /// dispatch resolves to that override. Defaults to <c>null</c> (no profile settings).
+    /// </remarks>
+    public virtual Type? CapabilitySettingsType => null;
+
+    /// <inheritdoc />
+    public virtual AIModelSettingSupport GetSettingSupport(string modelId) => AIModelSettingSupport.Default;
+
     /// <summary>
     /// Gets the available AI models for this capability.
     /// </summary>
@@ -139,8 +199,14 @@ public abstract class AICapabilityBase(IAIProvider provider) : IAICapability
     /// <returns></returns>
     protected abstract Task<IReadOnlyList<AIModelDescriptor>> GetModelsAsync(CancellationToken cancellationToken = default);
 
-    Task<IReadOnlyList<AIModelDescriptor>> IAICapability.GetModelsAsync(object? settings, CancellationToken cancellationToken)
-        => GetModelsAsync(cancellationToken);
+    async Task<IReadOnlyList<AIModelDescriptor>> IAICapability.GetModelsAsync(object? settings, CancellationToken cancellationToken)
+    {
+        var models = await GetModelsAsync(cancellationToken).ConfigureAwait(false);
+
+        // Fold the capability's per-model setting declarations into each descriptor's metadata so the
+        // model list doubles as the applicability source for the profile editor.
+        return CapabilitySettingSupportProjection.Apply(this, models);
+    }
 }
 
 /// <summary>
@@ -159,6 +225,17 @@ public abstract class AICapabilityBase<TSettings>(IAIProvider provider) : IAICap
     /// </summary>
     public abstract AICapability Kind { get; }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// Implements the interface member as a real virtual class member (rather than relying on the
+    /// interface default) so the two-parameter capability bases can <c>override</c> it and interface
+    /// dispatch resolves to that override. Defaults to <c>null</c> (no profile settings).
+    /// </remarks>
+    public virtual Type? CapabilitySettingsType => null;
+
+    /// <inheritdoc />
+    public virtual AIModelSettingSupport GetSettingSupport(string modelId) => AIModelSettingSupport.Default;
+
     /// <summary>
     /// Gets the available AI models for this capability.
     /// </summary>
@@ -167,11 +244,16 @@ public abstract class AICapabilityBase<TSettings>(IAIProvider provider) : IAICap
     /// <returns></returns>
     protected abstract Task<IReadOnlyList<AIModelDescriptor>> GetModelsAsync(TSettings settings, CancellationToken cancellationToken = default);
 
-    Task<IReadOnlyList<AIModelDescriptor>> IAICapability.GetModelsAsync(object? settings, CancellationToken cancellationToken)
+    async Task<IReadOnlyList<AIModelDescriptor>> IAICapability.GetModelsAsync(object? settings, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(settings);
         CapabilityGuards.ThrowIfUnresolvedSettings(settings, nameof(GetModelsAsync));
-        return GetModelsAsync((TSettings)settings, cancellationToken);
+
+        var models = await GetModelsAsync((TSettings)settings, cancellationToken).ConfigureAwait(false);
+
+        // Fold the capability's per-model setting declarations into each descriptor's metadata so the
+        // model list doubles as the applicability source for the profile editor.
+        return CapabilitySettingSupportProjection.Apply(this, models);
     }
 }
 
@@ -247,6 +329,70 @@ public abstract class AIChatCapabilityBase<TSettings>(IAIProvider provider) : AI
         ArgumentNullException.ThrowIfNull(settings);
         CapabilityGuards.ThrowIfUnresolvedSettings(settings, nameof(CreateClient));
         return CreateClientAsync((TSettings)settings, modelId, cancellationToken);
+    }
+}
+
+/// <summary>
+/// Base implementation of an AI chat capability with both provider-specific connection settings and
+/// provider-declared capability settings (e.g. reasoning effort).
+/// </summary>
+/// <typeparam name="TSettings">The provider-specific connection settings type.</typeparam>
+/// <typeparam name="TCapabilitySettings">The provider-declared capability settings type (a POCO with <c>[AIField]</c> properties).</typeparam>
+/// <remarks>
+/// Derive from this (instead of <see cref="AIChatCapabilityBase{TSettings}"/>) to let a provider surface
+/// extra per-profile settings. The base exposes the schema hook (<see cref="CapabilitySettingsType"/>) and
+/// applies the resolved settings to every request's <see cref="ChatOptions"/> via <see cref="ApplyCapabilitySettings"/>;
+/// the provider implements only that typed translation.
+/// </remarks>
+public abstract class AIChatCapabilityBase<TSettings, TCapabilitySettings>(IAIProvider provider)
+    : AIChatCapabilityBase<TSettings>(provider), IAIChatCapability
+    where TSettings : class
+    where TCapabilitySettings : class, new()
+{
+    /// <inheritdoc />
+    public sealed override Type? CapabilitySettingsType => typeof(TCapabilitySettings);
+
+    /// <summary>
+    /// Applies the resolved capability settings onto a request's <see cref="ChatOptions"/>.
+    /// Called for every request. Implementations should no-op when a value is not set.
+    /// </summary>
+    /// <param name="capabilitySettings">The resolved, typed capability settings for the profile.</param>
+    /// <param name="modelId">
+    /// The model the request will run against — the caller's <see cref="ChatOptions.ModelId"/> when set,
+    /// otherwise the model the client was created for. <c>null</c> only when neither is known.
+    /// </param>
+    /// <param name="options">The chat options for the current request (safe to mutate; it is a per-request copy).</param>
+    /// <remarks>
+    /// Gate on <paramref name="modelId"/> with the same predicate used by
+    /// <see cref="IAICapability.GetSettingSupport"/>: hiding a setting in the editor does not stop a
+    /// profile saved before a model change, an alias-driven API caller, or a direct
+    /// <see cref="IChatClient"/> consumer from reaching here with a value the model rejects.
+    /// </remarks>
+    protected abstract void ApplyCapabilitySettings(
+        TCapabilitySettings capabilitySettings,
+        string? modelId,
+        ChatOptions options);
+
+    /// <inheritdoc />
+    async Task<IChatClient> IAIChatCapability.CreateClientAsync(
+        object? settings,
+        object? capabilitySettings,
+        string? modelId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        CapabilityGuards.ThrowIfUnresolvedSettings(settings, nameof(CreateClient));
+        CapabilityGuards.ThrowIfUnresolvedSettings(capabilitySettings, nameof(CreateClient));
+
+        // Build the underlying client from connection settings only (unchanged provider path).
+        var inner = await CreateClientAsync((TSettings)settings, modelId, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Wrap so the provider-declared capability settings are applied to every request. When the
+        // profile declares none (or a different capability's settings), return the client untouched.
+        return capabilitySettings is TCapabilitySettings typed
+            ? new CapabilitySettingsChatClient<TCapabilitySettings>(inner, typed, modelId, ApplyCapabilitySettings)
+            : inner;
     }
 }
 

--- a/Umbraco.AI/src/Umbraco.AI.Core/Providers/IAICapability.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Providers/IAICapability.cs
@@ -53,7 +53,7 @@ public interface IAICapability
 
     /// <summary>
     /// Declares which settings the given model does not accept. Defaults to
-    /// <see cref="AIModelSettingSupport.Default"/> — nothing declared, so every setting applies.
+    /// <see cref="AIModelSettingsSupport.Default"/> — nothing declared, so every setting applies.
     /// </summary>
     /// <param name="modelId">The model ID to describe.</param>
     /// <remarks>
@@ -66,10 +66,10 @@ public interface IAICapability
     /// <para>
     /// Must be a cheap, local, synchronous decision — it runs once per model in the list. The same
     /// predicate should also gate what the capability actually sends, since this declaration only
-    /// reaches the UI (see <see cref="AIModelSettingSupport"/>).
+    /// reaches the UI (see <see cref="AIModelSettingsSupport"/>).
     /// </para>
     /// </remarks>
-    AIModelSettingSupport GetSettingSupport(string modelId) => AIModelSettingSupport.Default;
+    AIModelSettingsSupport GetSettingsSupport(string modelId) => AIModelSettingsSupport.Default;
 
     /// <summary>
     /// Gets the available AI models for this capability.
@@ -190,7 +190,7 @@ public abstract class AICapabilityBase(IAIProvider provider) : IAICapability
     public virtual Type? CapabilitySettingsType => null;
 
     /// <inheritdoc />
-    public virtual AIModelSettingSupport GetSettingSupport(string modelId) => AIModelSettingSupport.Default;
+    public virtual AIModelSettingsSupport GetSettingsSupport(string modelId) => AIModelSettingsSupport.Default;
 
     /// <summary>
     /// Gets the available AI models for this capability.
@@ -205,7 +205,7 @@ public abstract class AICapabilityBase(IAIProvider provider) : IAICapability
 
         // Fold the capability's per-model setting declarations into each descriptor's metadata so the
         // model list doubles as the applicability source for the profile editor.
-        return CapabilitySettingSupportProjection.Apply(this, models);
+        return CapabilitySettingsSupportProjection.Apply(this, models);
     }
 }
 
@@ -234,7 +234,7 @@ public abstract class AICapabilityBase<TSettings>(IAIProvider provider) : IAICap
     public virtual Type? CapabilitySettingsType => null;
 
     /// <inheritdoc />
-    public virtual AIModelSettingSupport GetSettingSupport(string modelId) => AIModelSettingSupport.Default;
+    public virtual AIModelSettingsSupport GetSettingsSupport(string modelId) => AIModelSettingsSupport.Default;
 
     /// <summary>
     /// Gets the available AI models for this capability.
@@ -253,7 +253,7 @@ public abstract class AICapabilityBase<TSettings>(IAIProvider provider) : IAICap
 
         // Fold the capability's per-model setting declarations into each descriptor's metadata so the
         // model list doubles as the applicability source for the profile editor.
-        return CapabilitySettingSupportProjection.Apply(this, models);
+        return CapabilitySettingsSupportProjection.Apply(this, models);
     }
 }
 
@@ -364,7 +364,7 @@ public abstract class AIChatCapabilityBase<TSettings, TCapabilitySettings>(IAIPr
     /// <param name="options">The chat options for the current request (safe to mutate; it is a per-request copy).</param>
     /// <remarks>
     /// Gate on <paramref name="modelId"/> with the same predicate used by
-    /// <see cref="IAICapability.GetSettingSupport"/>: hiding a setting in the editor does not stop a
+    /// <see cref="IAICapability.GetSettingsSupport"/>: hiding a setting in the editor does not stop a
     /// profile saved before a model change, an alias-driven API caller, or a direct
     /// <see cref="IChatClient"/> consumer from reaching here with a value the model rejects.
     /// </remarks>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Providers/IAIConfiguredCapability.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Providers/IAIConfiguredCapability.cs
@@ -37,6 +37,21 @@ public interface IAIConfiguredChatCapability : IAIConfiguredCapability
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A configured chat client.</returns>
     Task<IChatClient> CreateClientAsync(string? modelId = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a chat client with the baked-in connection settings and resolved, provider-declared
+    /// profile settings (e.g. reasoning effort).
+    /// </summary>
+    /// <param name="capabilitySettings">The resolved, typed capability settings, or <c>null</c> when the profile declares none.</param>
+    /// <param name="modelId">Optional model ID to use. If null, the provider's default model is used.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A configured chat client.</returns>
+    /// <remarks>
+    /// Default implementation ignores <paramref name="capabilitySettings"/> and delegates to
+    /// <see cref="CreateClientAsync(string?, CancellationToken)"/> so existing callers/implementations keep working.
+    /// </remarks>
+    Task<IChatClient> CreateClientAsync(object? capabilitySettings, string? modelId, CancellationToken cancellationToken)
+        => CreateClientAsync(modelId, cancellationToken);
 }
 
 /// <summary>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Providers/IAIProvider.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Providers/IAIProvider.cs
@@ -35,7 +35,15 @@ public interface IAIProvider : IDiscoverable
     /// </summary>
     /// <returns>The settings schema, or null if the provider has no settings.</returns>
     AIEditableModelSchema? GetSettingsSchema();
-    
+
+    /// <summary>
+    /// Gets the schema describing the provider-declared capability settings for the given
+    /// capability (e.g. reasoning effort). Used by the UI to render extra fields on the profile editor.
+    /// </summary>
+    /// <param name="capability">The capability whose capability-settings schema is requested.</param>
+    /// <returns>The schema, or null if the capability is not supported or declares no capability settings.</returns>
+    AIEditableModelSchema? GetCapabilitySettingsSchema(AICapability capability) => null;
+
     /// <summary>
     /// Gets all capabilities supported by this provider.
     /// </summary>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Serialization/DropdownStringJsonConverter.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Serialization/DropdownStringJsonConverter.cs
@@ -1,0 +1,66 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Umbraco.AI.Core.Serialization;
+
+/// <summary>
+/// JSON converter for <see cref="string"/> properties bound to the Umbraco backoffice dropdown
+/// (<c>Umb.PropertyEditorUi.Dropdown</c>), which serialises its value as an array of strings even when
+/// configured as a single select (<c>multiple: false</c>) — so a field the model declares as a string
+/// arrives as <c>["low"]</c>. Reads the first element when the value is an array, otherwise falls back to
+/// standard string reading.
+/// </summary>
+/// <remarks>
+/// An empty array reads as <c>null</c>, which is how the dropdown represents its cleared state. Extra
+/// elements are ignored rather than rejected: cardinality is the field's own configuration, and a
+/// multi-select bound to a string property is a declaration mistake that should not fail a request at
+/// runtime.
+/// </remarks>
+public sealed class DropdownStringJsonConverter : JsonConverter<string?>
+{
+    /// <inheritdoc />
+    public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.String:
+                return reader.GetString();
+
+            case JsonTokenType.Null:
+                return null;
+
+            case JsonTokenType.StartArray:
+                using (var doc = JsonDocument.ParseValue(ref reader))
+                {
+                    foreach (var element in doc.RootElement.EnumerateArray())
+                    {
+                        return element.ValueKind switch
+                        {
+                            JsonValueKind.String => element.GetString(),
+                            JsonValueKind.Null => null,
+                            _ => throw new JsonException(
+                                $"Dropdown array element is {element.ValueKind}, not a string.")
+                        };
+                    }
+
+                    // Empty array — the dropdown's cleared state.
+                    return null;
+                }
+
+            default:
+                throw new JsonException($"Unexpected token {reader.TokenType} when reading string.");
+        }
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, string? value, JsonSerializerOptions options)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        writer.WriteStringValue(value);
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/ToolCallGrader.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tests/Graders/ToolCallGrader.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Umbraco.AI.Core.EditableModels;
+using Umbraco.AI.Core.Serialization;
 
 namespace Umbraco.AI.Core.Tests.Graders;
 
@@ -27,6 +29,7 @@ public class ToolCallGraderConfig
         EditorUiAlias = "Umb.PropertyEditorUi.Dropdown",
         EditorConfig = "[{\"alias\":\"multiple\",\"value\":false},{\"alias\":\"items\",\"value\":[\"Any\",\"All\",\"Exact\",\"None\"]}]",
         SortOrder = 2)]
+    [JsonConverter(typeof(DropdownStringJsonConverter))]
     public string ValidationMode { get; set; } = "Any";
 
     /// <summary>

--- a/Umbraco.AI/src/Umbraco.AI.Persistence.SqlServer/Migrations/20260726120000_UmbracoAI_AddProfileCapabilitySettings.Designer.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Persistence.SqlServer/Migrations/20260726120000_UmbracoAI_AddProfileCapabilitySettings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Umbraco.AI.Persistence;
 
@@ -11,9 +12,11 @@ using Umbraco.AI.Persistence;
 namespace Umbraco.AI.Persistence.SqlServer.Migrations
 {
     [DbContext(typeof(UmbracoAIDbContext))]
-    partial class UmbracoAIDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260726120000_UmbracoAI_AddProfileProviderSettings")]
+    partial class UmbracoAI_AddProfileProviderSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Umbraco.AI/src/Umbraco.AI.Persistence.SqlServer/Migrations/20260726120000_UmbracoAI_AddProfileCapabilitySettings.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Persistence.SqlServer/Migrations/20260726120000_UmbracoAI_AddProfileCapabilitySettings.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Umbraco.AI.Persistence.SqlServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class UmbracoAI_AddProfileProviderSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CapabilitySettings",
+                table: "umbracoAIProfile",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CapabilitySettings",
+                table: "umbracoAIProfile");
+        }
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Persistence.Sqlite/Migrations/20260726120010_UmbracoAI_AddProfileCapabilitySettings.Designer.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Persistence.Sqlite/Migrations/20260726120010_UmbracoAI_AddProfileCapabilitySettings.Designer.cs
@@ -2,102 +2,100 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Umbraco.AI.Persistence;
 
 #nullable disable
 
-namespace Umbraco.AI.Persistence.SqlServer.Migrations
+namespace Umbraco.AI.Persistence.Sqlite.Migrations
 {
     [DbContext(typeof(UmbracoAIDbContext))]
-    partial class UmbracoAIDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260726120010_UmbracoAI_AddProfileProviderSettings")]
+    partial class UmbracoAI_AddProfileProviderSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder
-                .HasAnnotation("ProductVersion", "10.0.0")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
-
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+            modelBuilder.HasAnnotation("ProductVersion", "10.0.0");
 
             modelBuilder.Entity("Umbraco.AI.Persistence.Analytics.Usage.AIUsageRecordEntity", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Capability")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("DurationMs")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("EntityId")
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("EntityType")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ErrorMessage")
                         .HasMaxLength(2000)
-                        .HasColumnType("nvarchar(2000)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("FeatureId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("FeatureType")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("InputTokens")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ModelId")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("OutputTokens")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ProfileAlias")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("ProfileId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ProviderId")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Status")
                         .IsRequired()
                         .HasMaxLength(20)
-                        .HasColumnType("nvarchar(20)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("Timestamp")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("TotalTokens")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("UserId")
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("UserName")
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -112,68 +110,68 @@ namespace Umbraco.AI.Persistence.SqlServer.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Capability")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("EntityType")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("FailureCount")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("FeatureType")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("InputTokens")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ModelId")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("OutputTokens")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("Period")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ProfileAlias")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("ProfileId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ProviderId")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("RequestCount")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("SuccessCount")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("TotalDurationMs")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("TotalTokens")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("UserId")
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("UserName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -186,8 +184,7 @@ namespace Umbraco.AI.Persistence.SqlServer.Migrations
                     b.HasIndex("Period", "ProviderId");
 
                     b.HasIndex("Period", "ProviderId", "ModelId", "ProfileId", "Capability", "UserId", "EntityType", "FeatureType")
-                        .IsUnique()
-                        .HasFilter("[UserId] IS NOT NULL AND [EntityType] IS NOT NULL AND [FeatureType] IS NOT NULL");
+                        .IsUnique();
 
                     b.ToTable("umbracoAIUsageStatisticsDaily", (string)null);
                 });
@@ -196,68 +193,68 @@ namespace Umbraco.AI.Persistence.SqlServer.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Capability")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("EntityType")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("FailureCount")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("FeatureType")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("InputTokens")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ModelId")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("OutputTokens")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("Period")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ProfileAlias")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("ProfileId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ProviderId")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("RequestCount")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("SuccessCount")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("TotalDurationMs")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("TotalTokens")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("UserId")
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("UserName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -270,8 +267,7 @@ namespace Umbraco.AI.Persistence.SqlServer.Migrations
                     b.HasIndex("Period", "ProviderId");
 
                     b.HasIndex("Period", "ProviderId", "ModelId", "ProfileId", "Capability", "UserId", "EntityType", "FeatureType")
-                        .IsUnique()
-                        .HasFilter("[UserId] IS NOT NULL AND [EntityType] IS NOT NULL AND [FeatureType] IS NOT NULL");
+                        .IsUnique();
 
                     b.ToTable("umbracoAIUsageStatisticsHourly", (string)null);
                 });
@@ -280,98 +276,98 @@ namespace Umbraco.AI.Persistence.SqlServer.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Capability")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime?>("EndTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("EntityId")
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("EntityType")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("ErrorCategory")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ErrorMessage")
                         .HasMaxLength(2000)
-                        .HasColumnType("nvarchar(2000)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("FeatureId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("FeatureType")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("FeatureVersion")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("InputTokens")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Metadata")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ModelId")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("OutputTokens")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<Guid?>("ParentAuditLogId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ProfileAlias")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("ProfileId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("ProfileVersion")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("PromptSnapshot")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ProviderId")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ResponseSnapshot")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("StartTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Status")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("TotalTokens")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("TraceId")
                         .HasMaxLength(32)
-                        .HasColumnType("nvarchar(32)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("UserId")
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("UserName")
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -402,44 +398,44 @@ namespace Umbraco.AI.Persistence.SqlServer.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Alias")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("CreatedByUserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateCreated")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateModified")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("IsActive")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<Guid?>("ModifiedByUserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ProviderId")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Settings")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Version")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(1);
 
                     b.HasKey("Id");
@@ -456,33 +452,33 @@ namespace Umbraco.AI.Persistence.SqlServer.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Alias")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("CreatedByUserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateCreated")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateModified")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("ModifiedByUserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Version")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(1);
 
                     b.HasKey("Id");
@@ -497,34 +493,34 @@ namespace Umbraco.AI.Persistence.SqlServer.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("ContextId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Description")
                         .HasMaxLength(1000)
-                        .HasColumnType("nvarchar(1000)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("InjectionMode")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ResourceTypeId")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Settings")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("SortOrder")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
@@ -539,33 +535,33 @@ namespace Umbraco.AI.Persistence.SqlServer.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Alias")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("CreatedByUserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateCreated")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateModified")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("ModifiedByUserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Version")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(1);
 
                     b.HasKey("Id");
@@ -580,32 +576,32 @@ namespace Umbraco.AI.Persistence.SqlServer.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Action")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Config")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("EvaluatorId")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("GuardrailId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Phase")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("SortOrder")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
@@ -620,59 +616,59 @@ namespace Umbraco.AI.Persistence.SqlServer.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Alias")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Capability")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<Guid>("ConnectionId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("CreatedByUserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateCreated")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateModified")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ModelId")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("ModifiedByUserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ProviderId")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("CapabilitySettings")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Settings")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Tags")
                         .HasMaxLength(2000)
-                        .HasColumnType("nvarchar(2000)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Version")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(1);
 
                     b.HasKey("Id");
@@ -691,28 +687,28 @@ namespace Umbraco.AI.Persistence.SqlServer.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("CreatedByUserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateCreated")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateModified")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Key")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("ModifiedByUserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Value")
                         .HasMaxLength(500)
-                        .HasColumnType("nvarchar(500)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -726,79 +722,79 @@ namespace Umbraco.AI.Persistence.SqlServer.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Alias")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("BaselineRunId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ContextIds")
                         .HasMaxLength(2000)
-                        .HasColumnType("nvarchar(2000)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("CreatedByUserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateCreated")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateModified")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Description")
                         .HasMaxLength(2000)
-                        .HasColumnType("nvarchar(2000)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("GradersJson")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("IsActive")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bit")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(true);
 
                     b.Property<Guid?>("ModifiedByUserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("ProfileId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("RunCount")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(1);
 
                     b.Property<string>("Tags")
                         .HasMaxLength(2000)
-                        .HasColumnType("nvarchar(2000)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TestFeatureConfigJson")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TestFeatureId")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("TestTargetId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("VariationsJson")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Version")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(1);
 
                     b.HasKey("Id");
@@ -817,72 +813,72 @@ namespace Umbraco.AI.Persistence.SqlServer.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("BatchId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ContextIds")
                         .HasMaxLength(2000)
-                        .HasColumnType("nvarchar(2000)");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("DurationMs")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("ExecutedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("ExecutedByUserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("ExecutionId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("GraderResultsJson")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("MetadataJson")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("OutcomeFinishReason")
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("OutcomeTokenUsageJson")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("OutcomeType")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("OutcomeValue")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("ProfileId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("RunNumber")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(1);
 
                     b.Property<int>("Status")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<Guid>("TestId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("TestVersion")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<Guid?>("TranscriptId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("VariationId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("VariationName")
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -905,26 +901,26 @@ namespace Umbraco.AI.Persistence.SqlServer.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("FinalOutputJson")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("MessagesJson")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ReasoningJson")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("RunId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TimingJson")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ToolCallsJson")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -938,32 +934,32 @@ namespace Umbraco.AI.Persistence.SqlServer.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ChangeDescription")
                         .HasMaxLength(500)
-                        .HasColumnType("nvarchar(500)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("CreatedByUserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateCreated")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("EntityId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("EntityType")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Snapshot")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Version")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 

--- a/Umbraco.AI/src/Umbraco.AI.Persistence.Sqlite/Migrations/20260726120010_UmbracoAI_AddProfileCapabilitySettings.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Persistence.Sqlite/Migrations/20260726120010_UmbracoAI_AddProfileCapabilitySettings.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Umbraco.AI.Persistence.Sqlite.Migrations
+{
+    /// <inheritdoc />
+    public partial class UmbracoAI_AddProfileProviderSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CapabilitySettings",
+                table: "umbracoAIProfile",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CapabilitySettings",
+                table: "umbracoAIProfile");
+        }
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Persistence.Sqlite/Migrations/UmbracoAIDbContextModelSnapshot.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Persistence.Sqlite/Migrations/UmbracoAIDbContextModelSnapshot.cs
@@ -653,6 +653,9 @@ namespace Umbraco.AI.Persistence.Sqlite.Migrations
                         .HasMaxLength(100)
                         .HasColumnType("TEXT");
 
+                    b.Property<string>("CapabilitySettings")
+                        .HasColumnType("TEXT");
+
                     b.Property<string>("Settings")
                         .HasColumnType("TEXT");
 

--- a/Umbraco.AI/src/Umbraco.AI.Persistence/Configuration/UmbracoBuilderExtensions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Persistence/Configuration/UmbracoBuilderExtensions.cs
@@ -56,6 +56,9 @@ public static class UmbracoBuilderExtensions
         // Connection factory for entity/domain mapping with encryption support
         builder.Services.AddSingleton<IAIConnectionFactory, AIConnectionFactory>();
 
+        // Profile factory for entity/domain mapping with provider-declared capability-settings encryption support
+        builder.Services.AddSingleton<IAIProfileFactory, AIProfileFactory>();
+
         // Context and guardrail factories for entity/domain mapping with encryption support
         builder.Services.AddSingleton<IAIContextFactory, AIContextFactory>();
         builder.Services.AddSingleton<IAIGuardrailFactory, AIGuardrailFactory>();

--- a/Umbraco.AI/src/Umbraco.AI.Persistence/Profiles/AIProfileEntity.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Persistence/Profiles/AIProfileEntity.cs
@@ -46,6 +46,13 @@ internal class AIProfileEntity
     public string? Settings { get; set; }
 
     /// <summary>
+    /// JSON-serialized, provider-declared profile-level settings (e.g. reasoning effort).
+    /// Serialized via the editable-model serializer using the provider's capability-settings schema,
+    /// so <c>[AIField(IsSensitive = true)]</c> fields are encrypted at rest.
+    /// </summary>
+    public string? CapabilitySettings { get; set; }
+
+    /// <summary>
     /// Tags array serialized as a comma-separated string.
     /// </summary>
     public string? Tags { get; set; }

--- a/Umbraco.AI/src/Umbraco.AI.Persistence/Profiles/AIProfileFactory.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Persistence/Profiles/AIProfileFactory.cs
@@ -1,21 +1,32 @@
-using System.Text.Json;
-using Umbraco.AI.Core;
+using Umbraco.AI.Core.EditableModels;
 using Umbraco.AI.Core.Models;
 using Umbraco.AI.Core.Profiles;
+using Umbraco.AI.Core.Providers;
 
 namespace Umbraco.AI.Persistence.Profiles;
 
 /// <summary>
 /// Factory for mapping between <see cref="AIProfile"/> domain models and <see cref="AIProfileEntity"/> database entities.
 /// </summary>
-internal static class AIProfileFactory
+/// <remarks>
+/// Capability-specific <see cref="AIProfile.Settings"/> continue to use the plain
+/// <see cref="AIProfileSettingsSerializer"/>. Provider-declared <see cref="AIProfile.CapabilitySettings"/>
+/// go through the editable-model serializer with the provider's capability-settings schema so sensitive
+/// fields are encrypted at rest — consistent with how connection settings are handled.
+/// </remarks>
+internal sealed class AIProfileFactory : IAIProfileFactory
 {
-    /// <summary>
-    /// Creates an <see cref="AIProfile"/> domain model from a database entity.
-    /// </summary>
-    /// <param name="entity">The database entity.</param>
-    /// <returns>The domain model.</returns>
-    public static AIProfile BuildDomain(AIProfileEntity entity)
+    private readonly IAIEditableModelSerializer _serializer;
+    private readonly AIProviderCollection _providers;
+
+    public AIProfileFactory(IAIEditableModelSerializer serializer, AIProviderCollection providers)
+    {
+        _serializer = serializer;
+        _providers = providers;
+    }
+
+    /// <inheritdoc />
+    public AIProfile BuildDomain(AIProfileEntity entity)
     {
         IReadOnlyList<string> tags = Array.Empty<string>();
         if (!string.IsNullOrEmpty(entity.Tags))
@@ -24,6 +35,14 @@ internal static class AIProfileFactory
         }
 
         var capability = (AICapability)entity.Capability;
+
+        object? capabilitySettings = null;
+        if (!string.IsNullOrEmpty(entity.CapabilitySettings))
+        {
+            // Deserialize with automatic decryption of encrypted values (returns a JsonElement bag);
+            // resolution/typing happens later at request time via IAIEditableModelResolver.
+            capabilitySettings = _serializer.Deserialize(entity.CapabilitySettings);
+        }
 
         return new AIProfile
         {
@@ -34,6 +53,7 @@ internal static class AIProfileFactory
             Model = new AIModelRef(entity.ProviderId, entity.ModelId),
             ConnectionId = entity.ConnectionId,
             Settings = AIProfileSettingsSerializer.Deserialize(capability, entity.Settings),
+            CapabilitySettings = capabilitySettings,
             Tags = tags,
             Version = entity.Version,
             DateCreated = entity.DateCreated,
@@ -43,12 +63,8 @@ internal static class AIProfileFactory
         };
     }
 
-    /// <summary>
-    /// Creates an <see cref="AIProfileEntity"/> database entity from a domain model.
-    /// </summary>
-    /// <param name="profile">The domain model.</param>
-    /// <returns>The database entity.</returns>
-    public static AIProfileEntity BuildEntity(AIProfile profile)
+    /// <inheritdoc />
+    public AIProfileEntity BuildEntity(AIProfile profile)
     {
         return new AIProfileEntity
         {
@@ -60,6 +76,7 @@ internal static class AIProfileFactory
             ModelId = profile.Model.ModelId,
             ConnectionId = profile.ConnectionId,
             Settings = AIProfileSettingsSerializer.Serialize(profile.Settings),
+            CapabilitySettings = _serializer.Serialize(profile.CapabilitySettings, GetCapabilitySettingsSchema(profile)),
             Tags = profile.Tags.Count > 0 ? string.Join(',', profile.Tags) : null,
             Version = profile.Version,
             DateCreated = profile.DateCreated,
@@ -69,12 +86,8 @@ internal static class AIProfileFactory
         };
     }
 
-    /// <summary>
-    /// Updates an existing <see cref="AIProfileEntity"/> with values from a domain model.
-    /// </summary>
-    /// <param name="entity">The entity to update.</param>
-    /// <param name="profile">The domain model with updated values.</param>
-    public static void UpdateEntity(AIProfileEntity entity, AIProfile profile)
+    /// <inheritdoc />
+    public void UpdateEntity(AIProfileEntity entity, AIProfile profile)
     {
         entity.Alias = profile.Alias;
         entity.Name = profile.Name;
@@ -83,10 +96,17 @@ internal static class AIProfileFactory
         entity.ModelId = profile.Model.ModelId;
         entity.ConnectionId = profile.ConnectionId;
         entity.Settings = AIProfileSettingsSerializer.Serialize(profile.Settings);
+        entity.CapabilitySettings = _serializer.Serialize(profile.CapabilitySettings, GetCapabilitySettingsSchema(profile));
         entity.Tags = profile.Tags.Count > 0 ? string.Join(',', profile.Tags) : null;
         entity.Version = profile.Version;
         entity.DateModified = profile.DateModified;
         entity.ModifiedByUserId = profile.ModifiedByUserId;
         // DateCreated and CreatedByUserId are intentionally not updated
+    }
+
+    private AIEditableModelSchema? GetCapabilitySettingsSchema(AIProfile profile)
+    {
+        var provider = _providers.GetById(profile.Model.ProviderId);
+        return provider?.GetCapabilitySettingsSchema(profile.Capability);
     }
 }

--- a/Umbraco.AI/src/Umbraco.AI.Persistence/Profiles/EFCoreAIProfileRepository.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Persistence/Profiles/EFCoreAIProfileRepository.cs
@@ -11,13 +11,17 @@ namespace Umbraco.AI.Persistence.Profiles;
 internal class EFCoreAIProfileRepository : IAIProfileRepository
 {
     private readonly IEFCoreScopeProvider<UmbracoAIDbContext> _scopeProvider;
+    private readonly IAIProfileFactory _factory;
 
     /// <summary>
     /// Initializes a new instance of <see cref="EFCoreAIProfileRepository"/>.
     /// </summary>
-    public EFCoreAIProfileRepository(IEFCoreScopeProvider<UmbracoAIDbContext> scopeProvider)
+    public EFCoreAIProfileRepository(
+        IEFCoreScopeProvider<UmbracoAIDbContext> scopeProvider,
+        IAIProfileFactory factory)
     {
         _scopeProvider = scopeProvider;
+        _factory = factory;
     }
 
     /// <inheritdoc />
@@ -29,7 +33,7 @@ internal class EFCoreAIProfileRepository : IAIProfileRepository
             await db.Profiles.FirstOrDefaultAsync(p => p.Id == id, cancellationToken));
 
         scope.Complete();
-        return entity is null ? null : AIProfileFactory.BuildDomain(entity);
+        return entity is null ? null : _factory.BuildDomain(entity);
     }
 
     /// <inheritdoc />
@@ -44,7 +48,7 @@ internal class EFCoreAIProfileRepository : IAIProfileRepository
                 cancellationToken));
 
         scope.Complete();
-        return entity is null ? null : AIProfileFactory.BuildDomain(entity);
+        return entity is null ? null : _factory.BuildDomain(entity);
     }
 
     /// <inheritdoc />
@@ -56,7 +60,7 @@ internal class EFCoreAIProfileRepository : IAIProfileRepository
             await db.Profiles.ToListAsync(cancellationToken));
 
         scope.Complete();
-        return entities.Select(AIProfileFactory.BuildDomain);
+        return entities.Select(_factory.BuildDomain);
     }
 
     /// <inheritdoc />
@@ -71,7 +75,7 @@ internal class EFCoreAIProfileRepository : IAIProfileRepository
                 .ToListAsync(cancellationToken));
 
         scope.Complete();
-        return entities.Select(AIProfileFactory.BuildDomain);
+        return entities.Select(_factory.BuildDomain);
     }
 
     /// <inheritdoc />
@@ -115,7 +119,7 @@ internal class EFCoreAIProfileRepository : IAIProfileRepository
         });
 
         scope.Complete();
-        return (result.items.Select(AIProfileFactory.BuildDomain), result.total);
+        return (result.items.Select(_factory.BuildDomain), result.total);
     }
 
     /// <inheritdoc />
@@ -135,7 +139,7 @@ internal class EFCoreAIProfileRepository : IAIProfileRepository
                 profile.CreatedByUserId = userId;
                 profile.ModifiedByUserId = userId;
 
-                AIProfileEntity newEntity = AIProfileFactory.BuildEntity(profile);
+                AIProfileEntity newEntity = _factory.BuildEntity(profile);
                 db.Profiles.Add(newEntity);
             }
             else
@@ -146,7 +150,7 @@ internal class EFCoreAIProfileRepository : IAIProfileRepository
                 profile.DateModified = DateTime.UtcNow;
                 profile.ModifiedByUserId = userId;
 
-                AIProfileFactory.UpdateEntity(existing, profile);
+                _factory.UpdateEntity(existing, profile);
             }
 
             await db.SaveChangesAsync(cancellationToken);

--- a/Umbraco.AI/src/Umbraco.AI.Persistence/Profiles/IAIProfileFactory.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Persistence/Profiles/IAIProfileFactory.cs
@@ -1,0 +1,34 @@
+using Umbraco.AI.Core.Profiles;
+
+namespace Umbraco.AI.Persistence.Profiles;
+
+/// <summary>
+/// Factory for mapping between <see cref="AIProfile"/> domain models and <see cref="AIProfileEntity"/> database entities.
+/// Handles serialization (and encryption of sensitive fields) of provider-declared profile settings.
+/// </summary>
+internal interface IAIProfileFactory
+{
+    /// <summary>
+    /// Creates an <see cref="AIProfile"/> domain model from a database entity.
+    /// Provider-declared profile settings are decrypted during deserialization.
+    /// </summary>
+    /// <param name="entity">The database entity.</param>
+    /// <returns>The domain model.</returns>
+    AIProfile BuildDomain(AIProfileEntity entity);
+
+    /// <summary>
+    /// Creates an <see cref="AIProfileEntity"/> database entity from a domain model.
+    /// Sensitive provider-declared profile settings are encrypted based on the provider schema.
+    /// </summary>
+    /// <param name="profile">The domain model.</param>
+    /// <returns>The database entity.</returns>
+    AIProfileEntity BuildEntity(AIProfile profile);
+
+    /// <summary>
+    /// Updates an existing <see cref="AIProfileEntity"/> with values from a domain model.
+    /// Sensitive provider-declared profile settings are encrypted based on the provider schema.
+    /// </summary>
+    /// <param name="entity">The entity to update.</param>
+    /// <param name="profile">The domain model with updated values.</param>
+    void UpdateEntity(AIProfileEntity entity, AIProfile profile);
+}

--- a/Umbraco.AI/src/Umbraco.AI.Persistence/UmbracoAIDbContext.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Persistence/UmbracoAIDbContext.cs
@@ -222,6 +222,8 @@ public class UmbracoAIDbContext : DbContext
 
             entity.Property(e => e.Settings);
 
+            entity.Property(e => e.CapabilitySettings);
+
             entity.Property(e => e.Tags)
                 .HasMaxLength(2000);
 

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/api/types.gen.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/api/types.gen.ts
@@ -227,6 +227,7 @@ export type CreateProfileRequestModel = {
     model: ModelRefModel;
     connectionId: string;
     settings?: ChatProfileSettingsModel | EmbeddingProfileSettingsModel | SpeechToTextProfileSettingsModel | ImageGenerationProfileSettingsModel | null;
+    capabilitySettings?: unknown;
     tags: Array<string>;
 };
 
@@ -497,6 +498,7 @@ export type ProfileResponseModel = {
     model?: ModelRefModel | null;
     connectionId: string;
     settings?: ChatProfileSettingsModel | EmbeddingProfileSettingsModel | SpeechToTextProfileSettingsModel | ImageGenerationProfileSettingsModel | null;
+    capabilitySettings?: unknown;
     tags: Array<string>;
     dateCreated: string;
     dateModified: string;
@@ -533,6 +535,9 @@ export type ProviderResponseModel = {
     name: string;
     capabilities: Array<string>;
     settingsSchema?: EditableModelSchemaModel | null;
+    capabilitySettingsSchemas: {
+        [key: string]: EditableModelSchemaModel;
+    };
 };
 
 export type RunTestBatchRequestModel = {
@@ -843,6 +848,7 @@ export type UpdateProfileRequestModel = {
     model: ModelRefModel;
     connectionId: string;
     settings?: ChatProfileSettingsModel | EmbeddingProfileSettingsModel | SpeechToTextProfileSettingsModel | ImageGenerationProfileSettingsModel | null;
+    capabilitySettings?: unknown;
     tags: Array<string>;
 };
 

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/core/components/model-editor/model-editor.element.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/core/components/model-editor/model-editor.element.ts
@@ -166,13 +166,49 @@ export class UaiModelEditorElement extends UmbLitElement {
         );
     }
 
-    #toPropertyConfig(config: unknown): Array<{ alias: string; value: unknown }> {
+    /**
+     * Per-field caches for the objects handed to `umb-property`, keyed by the field's own config/validation
+     * source so a cached value is only reused while its input is unchanged.
+     *
+     * Identity matters here, not just contents: `umb-property` forwards `config` to the property editor UI,
+     * and some editors rebuild derived state from scratch whenever the setter runs. The CMS dropdown, for
+     * example, adds its empty "clear the value" option in `firstUpdated` but rebuilds its options list in
+     * the `config` setter — so handing it a freshly constructed array on every render makes that option
+     * appear or disappear depending on render order.
+     */
+    #propertyConfigCache = new Map<string, { source: unknown; value: Array<{ alias: string; value: unknown }> }>();
+    #validationCache = new Map<string, { mandatory: boolean; mandatoryMessage: string | undefined }>();
+
+    #toPropertyConfig(field: UaiEditableModelFieldModel): Array<{ alias: string; value: unknown }> {
+        const cached = this.#propertyConfigCache.get(field.key);
+        if (cached && cached.source === field.editorConfig) return cached.value;
+
+        const value = this.#convertPropertyConfig(field.editorConfig);
+        this.#propertyConfigCache.set(field.key, { source: field.editorConfig, value });
+
+        return value;
+    }
+
+    #convertPropertyConfig(config: unknown): Array<{ alias: string; value: unknown }> {
         if (!config) return [];
         // If it's already an array of alias-value pairs, return as is
         if (Array.isArray(config)) return config as Array<{ alias: string; value: unknown }>;
         // If it's an object, convert its entries to alias-value pairs
         if (typeof config !== "object") return [];
         return Object.entries(config).map(([alias, value]) => ({ alias, value }));
+    }
+
+    #toValidation(field: UaiEditableModelFieldModel) {
+        const cached = this.#validationCache.get(field.key);
+        if (cached && cached.mandatory === field.isRequired) return cached;
+
+        const value = {
+            mandatory: field.isRequired,
+            mandatoryMessage: field.isRequired ? this.localize.string("This field is required") : undefined,
+        };
+        this.#validationCache.set(field.key, value);
+
+        return value;
     }
 
     /**
@@ -216,13 +252,8 @@ export class UaiModelEditorElement extends UmbLitElement {
                 description=${this.localize.string(field.description ?? "")}
                 alias=${field.key}
                 property-editor-ui-alias=${field.editorUiAlias ?? "Umb.PropertyEditorUi.TextBox"}
-                .config=${field.editorConfig ? this.#toPropertyConfig(field.editorConfig) : []}
-                .validation=${{
-                    mandatory: field.isRequired,
-                    mandatoryMessage: field.isRequired
-                        ? this.localize.string("This field is required")
-                        : undefined,
-                }}
+                .config=${this.#toPropertyConfig(field)}
+                .validation=${this.#toValidation(field)}
             >
             </umb-property>
         `;

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/core/utils/index.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/core/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./event.utils.js";
 export * from "./datetime.utils.js";
 export * from "./audio-recorder.js";
+export * from "./model-settings.utils.js";

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/core/utils/model-settings.utils.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/core/utils/model-settings.utils.ts
@@ -1,0 +1,34 @@
+/**
+ * Well-known model metadata key listing the capability settings a model rejects.
+ * @public
+ */
+export const UAI_METADATA_CAPABILITY_SETTINGS_UNSUPPORTED = "capabilitySettings.unsupported";
+
+/**
+ * Whether a provider-declared capability setting applies to a model.
+ *
+ * Support for these settings varies by model rather than by provider (reasoning effort is an
+ * o-series/GPT-5 knob; a thinking budget is rejected by the newest Claude models), so providers declare
+ * it per model and the backend folds it into the model list the editor already fetches — no extra
+ * request when the model selection changes.
+ *
+ * Returns `false` only when the provider explicitly declared that the model rejects the setting.
+ * Declarations are negative — a provider says nothing about models it has no knowledge of — so this is
+ * "not known to be rejected" rather than an affirmative claim of support.
+ *
+ * @param metadata - The selected model descriptor's metadata.
+ * @param fieldKey - The schema field key of the setting.
+ * @public
+ */
+export function isCapabilitySettingSupported(
+    metadata: Record<string, string> | undefined,
+    fieldKey: string,
+): boolean {
+    const declared = metadata?.[UAI_METADATA_CAPABILITY_SETTINGS_UNSUPPORTED];
+    if (!declared || !fieldKey) return true;
+
+    return !declared
+        .split(",")
+        .map((key) => key.trim().toLowerCase())
+        .includes(fieldKey.trim().toLowerCase());
+}

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/repository/detail/profile-detail.server.data-source.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/repository/detail/profile-detail.server.data-source.ts
@@ -35,6 +35,7 @@ export class UaiProfileDetailServerDataSource implements UmbDetailDataSource<Uai
             model: null,
             connectionId: "",
             settings,
+            capabilitySettings: null,
             tags: [],
             dateCreated: null,
             dateModified: null,

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/type-mapper.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/type-mapper.ts
@@ -29,6 +29,7 @@ export const UaiProfileTypeMapper = {
             model: response.model ? { providerId: response.model.providerId, modelId: response.model.modelId } : null,
             connectionId: response.connectionId,
             settings: this.mapResponseSettings(response),
+            capabilitySettings: (response.capabilitySettings as Record<string, unknown> | null | undefined) ?? null,
             tags: response.tags ?? [],
             dateCreated: response.dateCreated,
             dateModified: response.dateModified,
@@ -56,6 +57,7 @@ export const UaiProfileTypeMapper = {
             model: model.model!,
             connectionId: model.connectionId,
             settings: this.mapRequestSettings(model.settings),
+            capabilitySettings: model.capabilitySettings ?? undefined,
             tags: model.tags,
         };
     },
@@ -67,6 +69,7 @@ export const UaiProfileTypeMapper = {
             model: model.model!,
             connectionId: model.connectionId,
             settings: this.mapRequestSettings(model.settings),
+            capabilitySettings: model.capabilitySettings ?? undefined,
             tags: model.tags,
         };
     },

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/types.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/types.ts
@@ -66,6 +66,11 @@ export interface UaiProfileDetailModel extends UmbEntityModel {
     model: UaiModelRef | null;
     connectionId: string;
     settings: UaiProfileSettings | null;
+    /**
+     * Provider-declared, profile-level settings (e.g. reasoning effort). Shape is described by the
+     * provider's capability-settings schema for this profile's capability.
+     */
+    capabilitySettings: Record<string, unknown> | null;
     tags: string[];
     dateCreated: string | null;
     dateModified: string | null;

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/workspace/profile/views/profile-details-workspace-view.element.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/workspace/profile/views/profile-details-workspace-view.element.ts
@@ -6,10 +6,14 @@ import { umbBindToValidation } from "@umbraco-cms/backoffice/validation";
 import type { UUISelectEvent } from "@umbraco-cms/backoffice/external/uui";
 import type { UaiProfileDetailModel, UaiModelRef, UaiChatProfileSettings, UaiEmbeddingProfileSettings, UaiSpeechToTextProfileSettings, UaiImageGenerationProfileSettings } from "../../../types.js";
 import { isChatSettings, isEmbeddingSettings, isSpeechToTextSettings, isImageGenerationSettings } from "../../../types.js";
-import { UaiPartialUpdateCommand } from "../../../../core/index.js";
+import { UaiPartialUpdateCommand, isCapabilitySettingSupported } from "../../../../core/index.js";
 import { UAI_PROFILE_WORKSPACE_CONTEXT } from "../profile-workspace.context-token.js";
 import type { UaiConnectionItemModel, UaiModelDescriptorModel } from "../../../../connection/types.js";
 import { UaiConnectionCapabilityRepository, UaiConnectionModelsRepository } from "../../../../connection/repository";
+import { UaiProviderDetailRepository } from "../../../../provider/repository/detail/provider-detail.repository.js";
+import type { UaiProviderDetailModel } from "../../../../provider/types.js";
+import type { UaiEditableModelSchemaModel } from "../../../../core/types.js";
+import type { UaiModelEditorChangeEventDetail } from "../../../../core/components/exports.js";
 
 /**
  * Workspace view for Profile details.
@@ -20,9 +24,13 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
     #workspaceContext?: typeof UAI_PROFILE_WORKSPACE_CONTEXT.TYPE;
     #connectionRepository = new UaiConnectionCapabilityRepository(this);
     #connectionModelsRepository = new UaiConnectionModelsRepository(this);
+    #providerDetailRepository = new UaiProviderDetailRepository(this);
 
     @state()
     private _model?: UaiProfileDetailModel;
+
+    @state()
+    private _provider?: UaiProviderDetailModel;
 
     @state()
     private _connections: UaiConnectionItemModel[] = [];
@@ -63,11 +71,26 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
         if (data) {
             this._connections = data;
 
-            // If a connection is already selected, load its models
+            // If a connection is already selected, load its models and the provider's capability-settings schema
             if (connectionId) {
                 await this.#loadModelsForConnection(connectionId, capability);
+                await this.#loadProviderDetail(connectionId);
             }
         }
+    }
+
+    /**
+     * Loads the provider detail (for its capability-settings schema) for the selected connection's provider.
+     */
+    async #loadProviderDetail(connectionId: string | undefined) {
+        const providerId = this._connections.find((c) => c.unique === connectionId)?.providerId;
+        if (!providerId) {
+            this._provider = undefined;
+            return;
+        }
+
+        const { data } = await this.#providerDetailRepository.requestById(providerId);
+        this._provider = data;
     }
 
     async #loadModelsForConnection(connectionId: string, capability: string) {
@@ -91,14 +114,21 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
     #onConnectionChange(event: UUISelectEvent) {
         event.stopPropagation();
         const connectionId = event.target.value as string;
+        // Changing connection can change the provider, so clear any previously entered
+        // provider-specific settings to avoid carrying an incompatible bag across providers.
         this.#workspaceContext?.handleCommand(
-            new UaiPartialUpdateCommand<UaiProfileDetailModel>({ connectionId, model: null }, "connectionId"),
+            new UaiPartialUpdateCommand<UaiProfileDetailModel>(
+                { connectionId, model: null, capabilitySettings: null },
+                "connectionId",
+            ),
         );
-        // Load models for the new connection
+        // Load models and provider capability-settings schema for the new connection
         if (connectionId && this._model?.capability) {
             this.#loadModelsForConnection(connectionId, this._model.capability);
+            this.#loadProviderDetail(connectionId);
         } else {
             this._availableModels = [];
+            this._provider = undefined;
         }
     }
 
@@ -114,7 +144,37 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
 
         const [providerId, modelId] = value.split("|");
         const model: UaiModelRef = { providerId, modelId };
-        this.#workspaceContext?.handleCommand(new UaiPartialUpdateCommand<UaiProfileDetailModel>({ model }, "model"));
+        // Drop any stored provider settings the newly selected model doesn't accept. Without this they
+        // stay persisted but invisible in the editor, and still get sent on every request.
+        const capabilitySettings = this.#pruneCapabilitySettings(modelId);
+        this.#workspaceContext?.handleCommand(
+            new UaiPartialUpdateCommand<UaiProfileDetailModel>({ model, capabilitySettings }, "model"),
+        );
+    }
+
+    /**
+     * Returns the stored capability settings with the entries the given model declares unsupported
+     * removed, or `undefined` when nothing needs to change (which the partial update command skips).
+     */
+    #pruneCapabilitySettings(modelId: string): Record<string, unknown> | null | undefined {
+        const current = this._model?.capabilitySettings;
+        if (!current) return undefined;
+
+        const metadata = this.#getModelMetadata(modelId);
+        const entries = Object.entries(current).filter(([key]) => isCapabilitySettingSupported(metadata, key));
+
+        if (entries.length === Object.keys(current).length) return undefined;
+
+        return entries.length > 0 ? Object.fromEntries(entries) : null;
+    }
+
+    /**
+     * Gets the metadata for a model from the loaded model list, which carries the provider's per-model
+     * settings declarations alongside the display name.
+     */
+    #getModelMetadata(modelId: string | undefined): Record<string, string> | undefined {
+        if (!modelId) return undefined;
+        return this._availableModels.find((m) => m.model.modelId === modelId)?.metadata;
     }
 
     #onTemperatureChange(event: Event) {
@@ -272,7 +332,7 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
     /**
      * Renders capability-specific settings based on the profile's capability.
      */
-    #renderCapabilitySettings() {
+    #renderProfileSettings() {
         if (!this._model) return nothing;
 
         const capability = this._model.capability.toLowerCase();
@@ -448,6 +508,57 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
         `;
     }
 
+    /**
+     * Gets the provider-declared capability-settings schema for the current capability, if any.
+     * Keyed by capability name (e.g. "Chat"); matched case-insensitively.
+     *
+     * Fields the selected model declares unsupported are filtered out — support for these settings
+     * varies by model (reasoning effort is an o-series/GPT-5 knob; a thinking budget is rejected by the
+     * newest Claude models), and the declarations ride along on the already-loaded model list.
+     */
+    #getCapabilitySettingsSchema(): UaiEditableModelSchemaModel | undefined {
+        const capability = this._model?.capability;
+        const schemas = this._provider?.capabilitySettingsSchemas;
+        if (!capability || !schemas) return undefined;
+
+        const key = Object.keys(schemas).find((k) => k.toLowerCase() === capability.toLowerCase());
+        const schema = key ? schemas[key] : undefined;
+        if (!schema) return undefined;
+
+        const metadata = this.#getModelMetadata(this._model?.model?.modelId);
+        const fields = schema.fields.filter((field) => isCapabilitySettingSupported(metadata, field.key));
+
+        return fields.length === schema.fields.length ? schema : { ...schema, fields };
+    }
+
+    #onCapabilitySettingsChange(e: CustomEvent<UaiModelEditorChangeEventDetail>) {
+        e.stopPropagation();
+        this.#workspaceContext?.handleCommand(
+            new UaiPartialUpdateCommand<UaiProfileDetailModel>({ capabilitySettings: e.detail.model }, "capabilitySettings"),
+        );
+    }
+
+    /**
+     * Renders the provider-declared, profile-level settings (e.g. reasoning effort) using the
+     * shared schema-driven model editor. Renders nothing when the provider declares no extras.
+     */
+    #renderCapabilitySettings() {
+        const schema = this.#getCapabilitySettingsSchema();
+        if (!schema || schema.fields.length === 0) return nothing;
+
+        return html`
+            <uui-box headline="Provider settings">
+                <uai-model-editor
+                    .schema=${schema}
+                    .model=${this._model?.capabilitySettings ?? undefined}
+                    empty-message="This provider has no additional settings."
+                    @change=${this.#onCapabilitySettingsChange}
+                >
+                </uai-model-editor>
+            </uui-box>
+        `;
+    }
+
     #getCurrentModelValue(): string {
         if (!this._model?.model) return "";
         return `${this._model.model.providerId}|${this._model.model.modelId}`;
@@ -524,6 +635,7 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
                 </umb-property-layout>
             </uui-box>
 
+            ${this.#renderProfileSettings()}
             ${this.#renderCapabilitySettings()}
             ${this._model.tags.length > 0
                 ? html`

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/workspace/profile/views/profile-details-workspace-view.element.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/workspace/profile/views/profile-details-workspace-view.element.ts
@@ -541,21 +541,26 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
     /**
      * Renders the provider-declared, profile-level settings (e.g. reasoning effort) using the
      * shared schema-driven model editor. Renders nothing when the provider declares no extras.
+     *
+     * Also renders nothing until a model is selected: which of these settings apply is a per-model fact,
+     * so with no model chosen there is nothing to filter against and every field would be offered —
+     * including ones the model about to be picked rejects.
      */
     #renderCapabilitySettings() {
+        if (!this._model?.model?.modelId) return nothing;
+
         const schema = this.#getCapabilitySettingsSchema();
         if (!schema || schema.fields.length === 0) return nothing;
 
         return html`
-            <uui-box headline="Provider settings">
-                <uai-model-editor
-                    .schema=${schema}
-                    .model=${this._model?.capabilitySettings ?? undefined}
-                    empty-message="This provider has no additional settings."
-                    @change=${this.#onCapabilitySettingsChange}
-                >
-                </uai-model-editor>
-            </uui-box>
+            <uai-model-editor
+                .schema=${schema}
+                .model=${this._model?.capabilitySettings ?? undefined}
+                empty-message="This provider has no additional settings."
+                default-group="Provider settings"
+                @change=${this.#onCapabilitySettingsChange}
+            >
+            </uai-model-editor>
         `;
     }
 
@@ -621,7 +626,7 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
                     <div slot="editor">
                         ${this._loadingModels ? html`<uui-loader-bar></uui-loader-bar>` : nothing}
                         <uui-select
-                            name="model" 
+                            name="model"
                             .value=${this.#getCurrentModelValue()}
                             .options=${this.#getModelOptions()}
                             @change=${this.#onModelChange}
@@ -629,7 +634,7 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
                             ?disabled=${!this._model.connectionId || this._availableModels.length === 0}
                             required
                             ${umbBindToValidation(this, "$.model", this._model.model)}
-                            class="${this._loadingModels ? "hidden" : ""}" 
+                            class="${this._loadingModels ? "hidden" : ""}"
                         ></uui-select>
                     </div>
                 </umb-property-layout>
@@ -660,7 +665,8 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
             uui-box {
                 --uui-box-default-padding: 0 var(--uui-size-space-5);
             }
-            uui-box:not(:first-child) {
+            uui-box:not(:first-child),
+            uai-model-editor:not(:first-child) {
                 margin-top: var(--uui-size-layout-1);
             }
 

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/workspace/profile/views/profile-details-workspace-view.element.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/workspace/profile/views/profile-details-workspace-view.element.ts
@@ -363,7 +363,7 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
         const chatSettings = this.#getChatSettings();
 
         return html`
-            <uui-box headline="Settings">
+            <uui-box headline="System Settings">
                 <umb-property-layout
                     label="Temperature"
                     description="Controls randomness (0.0 = deterministic, 2.0 = very random)"
@@ -417,7 +417,7 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
         const embeddingSettings = this.#getEmbeddingSettings();
 
         return html`
-            <uui-box headline="Settings">
+            <uui-box headline="System Settings">
                 <umb-property-layout
                     label="Dimensions"
                     description="Number of dimensions for generated embeddings. Leave empty to use the model's default."
@@ -440,7 +440,7 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
         const sttSettings = this.#getSpeechToTextSettings();
 
         return html`
-            <uui-box headline="Settings">
+            <uui-box headline="System Settings">
                 <umb-property-layout
                     label="Language"
                     description="BCP-47 language hint for transcription (e.g., &quot;en&quot;, &quot;de&quot;, &quot;ja&quot;). Leave empty for auto-detection."
@@ -461,7 +461,7 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
         const imageSettings = this.#getImageGenerationSettings();
 
         return html`
-            <uui-box headline="Settings">
+            <uui-box headline="System Settings">
                 <umb-property-layout
                     label="Size"
                     description="Default image size as &quot;{width}x{height}&quot; (e.g. &quot;1024x1024&quot;). Leave empty for the provider default."
@@ -521,15 +521,34 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
         const schemas = this._provider?.capabilitySettingsSchemas;
         if (!capability || !schemas) return undefined;
 
+        const modelId = this._model?.model?.modelId;
+
+        // Filtering produces a new schema object, so the result is cached against the inputs that decide it.
+        // A fresh object on every render would push a new config into each property editor, and some rebuild
+        // derived state when that happens — the CMS dropdown loses its empty "clear the value" option.
+        const cacheKey = `${capability}|${modelId ?? ""}|${schemas === this.#cachedSchemas ? "same" : "new"}`;
+        if (this.#cachedSchemaKey === cacheKey) return this.#cachedSchema;
+
         const key = Object.keys(schemas).find((k) => k.toLowerCase() === capability.toLowerCase());
         const schema = key ? schemas[key] : undefined;
-        if (!schema) return undefined;
 
-        const metadata = this.#getModelMetadata(this._model?.model?.modelId);
-        const fields = schema.fields.filter((field) => isCapabilitySettingSupported(metadata, field.key));
+        let result: UaiEditableModelSchemaModel | undefined;
+        if (schema) {
+            const metadata = this.#getModelMetadata(modelId);
+            const fields = schema.fields.filter((field) => isCapabilitySettingSupported(metadata, field.key));
+            result = fields.length === schema.fields.length ? schema : { ...schema, fields };
+        }
 
-        return fields.length === schema.fields.length ? schema : { ...schema, fields };
+        this.#cachedSchemas = schemas;
+        this.#cachedSchemaKey = cacheKey;
+        this.#cachedSchema = result;
+
+        return result;
     }
+
+    #cachedSchemas?: Record<string, UaiEditableModelSchemaModel>;
+    #cachedSchemaKey?: string;
+    #cachedSchema?: UaiEditableModelSchemaModel;
 
     #onCapabilitySettingsChange(e: CustomEvent<UaiModelEditorChangeEventDetail>) {
         e.stopPropagation();

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/provider/type-mapper.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/provider/type-mapper.ts
@@ -1,5 +1,6 @@
 import type { ProviderItemResponseModel, ProviderResponseModel } from "../api/types.gen.js";
 import type { UaiProviderDetailModel, UaiProviderItemModel } from "./types.js";
+import type { UaiEditableModelSchemaModel } from "../core/types.js";
 import { UaiCommonTypeMapper } from "../core/type-mapper.ts";
 
 export const UaiProviderTypeMapper = {
@@ -12,11 +13,17 @@ export const UaiProviderTypeMapper = {
     },
 
     toDetailModel(response: ProviderResponseModel): UaiProviderDetailModel {
+        const capabilitySettingsSchemas: Record<string, UaiEditableModelSchemaModel> = {};
+        for (const [capability, schema] of Object.entries(response.capabilitySettingsSchemas ?? {})) {
+            capabilitySettingsSchemas[capability] = UaiCommonTypeMapper.toEditableModelSchemaModel(schema);
+        }
+
         return {
             id: response.id,
             name: response.name,
             capabilities: response.capabilities,
             settingsSchema: UaiCommonTypeMapper.toEditableModelSchemaModel(response.settingsSchema ?? { fields: [] }),
+            capabilitySettingsSchemas,
         };
     },
 };

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/provider/types.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/provider/types.ts
@@ -20,4 +20,9 @@ export interface UaiProviderDetailModel {
     name: string;
     capabilities: string[];
     settingsSchema: UaiEditableModelSchemaModel;
+    /**
+     * Provider-declared profile-level settings schemas (e.g. reasoning effort), keyed by capability
+     * name (e.g. "Chat"). Only capabilities that declare extra profile settings appear.
+     */
+    capabilitySettingsSchemas: Record<string, UaiEditableModelSchemaModel>;
 }

--- a/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/Profile/Mapping/ProfileMapDefinition.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/Profile/Mapping/ProfileMapDefinition.cs
@@ -54,6 +54,7 @@ public class ProfileMapDefinition : IMapDefinition
         target.Model = new AIModelRef(source.Model.ProviderId, source.Model.ModelId);
         target.ConnectionId = source.ConnectionId;
         target.Settings = MapSettingsFromRequest(target.Capability, source.Settings);
+        target.CapabilitySettings = source.CapabilitySettings;
         target.Tags = source.Tags;
     }
 
@@ -66,6 +67,7 @@ public class ProfileMapDefinition : IMapDefinition
         target.Model = new AIModelRef(source.Model.ProviderId, source.Model.ModelId);
         target.ConnectionId = source.ConnectionId;
         target.Settings = MapSettingsFromRequest(target.Capability, source.Settings);
+        target.CapabilitySettings = source.CapabilitySettings;
         target.Tags = source.Tags;
     }
 
@@ -79,6 +81,7 @@ public class ProfileMapDefinition : IMapDefinition
         target.Capability = source.Capability.ToString();
         target.Model = context.Map<ModelRefModel>(source.Model);
         target.Settings = MapSettingsToResponse(source);
+        target.CapabilitySettings = source.CapabilitySettings;
         target.Tags = source.Tags;
         target.DateCreated = source.DateCreated;
         target.DateModified = source.DateModified;

--- a/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/Profile/Models/CreateProfileRequestModel.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/Profile/Models/CreateProfileRequestModel.cs
@@ -44,6 +44,12 @@ public class CreateProfileRequestModel
     public ProfileSettingsModel? Settings { get; init; }
 
     /// <summary>
+    /// Provider-declared, profile-level settings (e.g. reasoning effort). Shape is described by the
+    /// provider's capability-settings schema for this profile's capability.
+    /// </summary>
+    public object? CapabilitySettings { get; init; }
+
+    /// <summary>
     /// Tags associated with the profile.
     /// </summary>
     public IReadOnlyList<string> Tags { get; init; } = Array.Empty<string>();

--- a/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/Profile/Models/ProfileResponseModel.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/Profile/Models/ProfileResponseModel.cs
@@ -49,6 +49,13 @@ public class ProfileResponseModel
     public ProfileSettingsModel? Settings { get; set; }
 
     /// <summary>
+    /// Provider-declared, profile-level settings (e.g. reasoning effort). Shape is described by the
+    /// provider's capability-settings schema for this profile's capability
+    /// (<see cref="Provider.Models.ProviderResponseModel.CapabilitySettingsSchemas"/>).
+    /// </summary>
+    public object? CapabilitySettings { get; set; }
+
+    /// <summary>
     /// Tags associated with the profile.
     /// </summary>
     public IReadOnlyList<string> Tags { get; set; } = [];

--- a/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/Profile/Models/UpdateProfileRequestModel.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/Profile/Models/UpdateProfileRequestModel.cs
@@ -38,6 +38,12 @@ public class UpdateProfileRequestModel
     public ProfileSettingsModel? Settings { get; init; }
 
     /// <summary>
+    /// Provider-declared, profile-level settings (e.g. reasoning effort). Shape is described by the
+    /// provider's capability-settings schema for this profile's capability.
+    /// </summary>
+    public object? CapabilitySettings { get; init; }
+
+    /// <summary>
     /// Tags associated with the profile.
     /// </summary>
     public IReadOnlyList<string> Tags { get; init; } = Array.Empty<string>();

--- a/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/Provider/Mapping/ProviderMapDefinition.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/Provider/Mapping/ProviderMapDefinition.cs
@@ -47,10 +47,35 @@ public class ProviderMapDefinition : IMapDefinition
         target.SettingsSchema = source.SettingsType is not null
             ? context.Map<EditableModelSchemaModel>(source.GetSettingsSchema())
             : null;
+        target.CapabilitySettingsSchemas = MapCapabilitySettingsSchemas(source, context);
     }
 
     private IEnumerable<string> MapCapabilities(IAIProvider source)
         => source.GetCapabilities()
             .Where(c => _experimentalFeatures.IsCapabilityEnabled(c.Kind))
             .Select(c => c.Kind.ToString());
+
+    private IReadOnlyDictionary<string, EditableModelSchemaModel> MapCapabilitySettingsSchemas(
+        IAIProvider source,
+        MapperContext context)
+    {
+        var schemas = new Dictionary<string, EditableModelSchemaModel>();
+        foreach (var capability in source.GetCapabilities()
+                     .Where(c => _experimentalFeatures.IsCapabilityEnabled(c.Kind)))
+        {
+            var schema = source.GetCapabilitySettingsSchema(capability.Kind);
+            if (schema is null)
+            {
+                continue;
+            }
+
+            var mapped = context.Map<EditableModelSchemaModel>(schema);
+            if (mapped is not null)
+            {
+                schemas[capability.Kind.ToString()] = mapped;
+            }
+        }
+
+        return schemas;
+    }
 }

--- a/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/Provider/Models/ProviderResponseModel.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/Provider/Models/ProviderResponseModel.cs
@@ -31,4 +31,13 @@ public class ProviderResponseModel
     /// The settings schema for this provider.
     /// </summary>
     public EditableModelSchemaModel? SettingsSchema { get; set; }
+
+    /// <summary>
+    /// The provider-declared profile-level settings schemas (e.g. reasoning effort), keyed by
+    /// capability name (e.g. "Chat"). Only capabilities that declare extra profile settings appear.
+    /// Used by the UI to render additional fields on the profile editor.
+    /// </summary>
+    [Required]
+    public IReadOnlyDictionary<string, EditableModelSchemaModel> CapabilitySettingsSchemas { get; set; }
+        = new Dictionary<string, EditableModelSchemaModel>();
 }

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Factories/AIChatClientFactoryTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Factories/AIChatClientFactoryTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.AI;
 using Umbraco.AI.Core.Chat;
 using Umbraco.AI.Core.Chat.Middleware;
 using Umbraco.AI.Core.Connections;
+using Umbraco.AI.Core.EditableModels;
 using Umbraco.AI.Core.Models;
 using Umbraco.AI.Core.Providers;
 using Umbraco.AI.Core.RuntimeContext;
@@ -15,6 +16,7 @@ public class AIChatClientFactoryTests
     private readonly Mock<IAIConnectionService> _connectionServiceMock;
     private readonly Mock<IAIRuntimeContextAccessor> _runtimeContextAccessorMock;
     private readonly Mock<IAIRuntimeContextScopeProvider> _scopeProviderMock;
+    private readonly Mock<IAIEditableModelResolver> _modelResolverMock;
     private readonly AIRuntimeContextContributorCollection _contributors;
     private readonly AIChatMiddlewareCollection _middleware;
 
@@ -23,6 +25,7 @@ public class AIChatClientFactoryTests
         _connectionServiceMock = new Mock<IAIConnectionService>();
         _runtimeContextAccessorMock = new Mock<IAIRuntimeContextAccessor>();
         _scopeProviderMock = new Mock<IAIRuntimeContextScopeProvider>();
+        _modelResolverMock = new Mock<IAIEditableModelResolver>();
         _contributors = new AIRuntimeContextContributorCollection(() => Enumerable.Empty<IAIRuntimeContextContributor>());
         _middleware = new AIChatMiddlewareCollection(() => Enumerable.Empty<IAIChatMiddleware>());
     }
@@ -34,7 +37,8 @@ public class AIChatClientFactoryTests
             _middleware,
             _runtimeContextAccessorMock.Object,
             _scopeProviderMock.Object,
-            _contributors);
+            _contributors,
+            _modelResolverMock.Object);
     }
 
     private AIChatClientFactory CreateFactory(AIChatMiddlewareCollection middleware)
@@ -44,7 +48,8 @@ public class AIChatClientFactoryTests
             middleware,
             _runtimeContextAccessorMock.Object,
             _scopeProviderMock.Object,
-            _contributors);
+            _contributors,
+            _modelResolverMock.Object);
     }
 
     private static Mock<IAIConfiguredProvider> CreateConfiguredProviderMock(
@@ -91,6 +96,8 @@ public class AIChatClientFactoryTests
         var fakeChatClient = new FakeChatClient();
         var configuredCapabilityMock = new Mock<IAIConfiguredChatCapability>();
         configuredCapabilityMock.Setup(x => x.CreateClientAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>())).ReturnsAsync(fakeChatClient);
+        // Factory calls the capability-settings-aware overload; set up both so the test is robust to how the default interface method is dispatched.
+        configuredCapabilityMock.Setup(x => x.CreateClientAsync(It.IsAny<object?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>())).ReturnsAsync(fakeChatClient);
         configuredCapabilityMock.Setup(x => x.Kind).Returns(AICapability.Chat);
 
         var fakeProvider = new FakeAIProvider("fake-provider", "Fake Provider");
@@ -347,6 +354,8 @@ public class AIChatClientFactoryTests
 
         var configuredCapabilityMock = new Mock<IAIConfiguredChatCapability>();
         configuredCapabilityMock.Setup(x => x.CreateClientAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>())).ReturnsAsync(baseChatClient);
+        // Factory calls the capability-settings-aware overload; set up both so the test is robust to how the default interface method is dispatched.
+        configuredCapabilityMock.Setup(x => x.CreateClientAsync(It.IsAny<object?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>())).ReturnsAsync(baseChatClient);
         configuredCapabilityMock.Setup(x => x.Kind).Returns(AICapability.Chat);
 
         var fakeProvider = new FakeAIProvider("fake-provider", "Fake Provider");
@@ -394,6 +403,8 @@ public class AIChatClientFactoryTests
         var baseChatClient = new FakeChatClient();
         var configuredCapabilityMock = new Mock<IAIConfiguredChatCapability>();
         configuredCapabilityMock.Setup(x => x.CreateClientAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>())).ReturnsAsync(baseChatClient);
+        // Factory calls the capability-settings-aware overload; set up both so the test is robust to how the default interface method is dispatched.
+        configuredCapabilityMock.Setup(x => x.CreateClientAsync(It.IsAny<object?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>())).ReturnsAsync(baseChatClient);
         configuredCapabilityMock.Setup(x => x.Kind).Returns(AICapability.Chat);
 
         var fakeProvider = new FakeAIProvider("fake-provider", "Fake Provider");
@@ -442,6 +453,8 @@ public class AIChatClientFactoryTests
         var fakeChatClient = new FakeChatClient();
         var configuredCapabilityMock = new Mock<IAIConfiguredChatCapability>();
         configuredCapabilityMock.Setup(x => x.CreateClientAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>())).ReturnsAsync(fakeChatClient);
+        // Factory calls the capability-settings-aware overload; set up both so the test is robust to how the default interface method is dispatched.
+        configuredCapabilityMock.Setup(x => x.CreateClientAsync(It.IsAny<object?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>())).ReturnsAsync(fakeChatClient);
         configuredCapabilityMock.Setup(x => x.Kind).Returns(AICapability.Chat);
 
         var fakeProvider = new FakeAIProvider("fake-provider", "Fake Provider");
@@ -465,8 +478,9 @@ public class AIChatClientFactoryTests
         // Assert - factory wraps with FunctionInvokingChatClient; verify inner client is accessible
         client.ShouldNotBeNull();
         client.GetService<FakeChatClient>().ShouldBe(fakeChatClient);
-        // Verify that CreateClient was called on the configured capability with the model ID from the profile
-        configuredCapabilityMock.Verify(c => c.CreateClientAsync("gpt-4", It.IsAny<CancellationToken>()), Times.Once);
+        // Verify that CreateClient was called on the configured capability with the model ID from the
+        // profile, via the capability-settings-aware overload the factory invokes.
+        configuredCapabilityMock.Verify(c => c.CreateClientAsync(It.IsAny<object?>(), "gpt-4", It.IsAny<CancellationToken>()), Times.Once);
         // Verify that GetConfiguredProviderAsync was called (which handles settings resolution)
         _connectionServiceMock.Verify(x => x.GetConfiguredProviderAsync(connectionId, It.IsAny<CancellationToken>()), Times.Once);
     }

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Factories/AIChatClientFactoryTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Factories/AIChatClientFactoryTests.cs
@@ -129,6 +129,56 @@ public class AIChatClientFactoryTests
     #region CreateClientAsync - Empty connection ID
 
     [Fact]
+    public async Task CreateClientAsync_ProfileWithNoCapabilitySettings_PassesNullThroughAndReturnsClient()
+    {
+        // Arrange — every profile saved before providers could declare settings has a null column, so this
+        // is the shape an upgraded installation resolves on its first request
+        var connectionId = Guid.NewGuid();
+        var connection = new AIConnectionBuilder()
+            .WithId(connectionId)
+            .WithProviderId("fake-provider")
+            .WithSettings(new FakeProviderSettings { ApiKey = "test-key" })
+            .IsActive(true)
+            .Build();
+
+        var profile = new AIProfileBuilder()
+            .WithConnectionId(connectionId)
+            .WithModel("fake-provider", "gpt-4")
+            .WithCapability(AICapability.Chat)
+            .Build();
+
+        profile.CapabilitySettings.ShouldBeNull();
+
+        var fakeChatClient = new FakeChatClient();
+        object? observedCapabilitySettings = "not-called";
+        var configuredCapabilityMock = new Mock<IAIConfiguredChatCapability>();
+        configuredCapabilityMock
+            .Setup(x => x.CreateClientAsync(It.IsAny<object?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Callback<object?, string?, CancellationToken>((settings, _, _) => observedCapabilitySettings = settings)
+            .ReturnsAsync(fakeChatClient);
+        configuredCapabilityMock.Setup(x => x.Kind).Returns(AICapability.Chat);
+
+        var fakeProvider = new FakeAIProvider("fake-provider", "Fake Provider");
+        var configuredProviderMock = CreateConfiguredProviderMock(fakeProvider, configuredCapabilityMock.Object);
+
+        var factory = CreateFactory();
+
+        _connectionServiceMock
+            .Setup(x => x.GetConnectionAsync(connectionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(connection);
+        _connectionServiceMock
+            .Setup(x => x.GetConfiguredProviderAsync(connectionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(configuredProviderMock.Object);
+
+        // Act
+        var client = await factory.CreateClientAsync(profile);
+
+        // Assert — resolution yields null rather than throwing, and the provider still gets a client built
+        client.ShouldNotBeNull();
+        observedCapabilitySettings.ShouldBeNull();
+    }
+
+    [Fact]
     public async Task CreateClientAsync_WithEmptyConnectionId_ThrowsInvalidOperationException()
     {
         // Arrange

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Providers/AIProviderBaseTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Providers/AIProviderBaseTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.AI;
 using Umbraco.AI.Core.Models;
 using Umbraco.AI.Core.Providers;
 using Umbraco.AI.Core.EditableModels;
@@ -269,6 +270,65 @@ public class AIProviderBaseTests
 
     #endregion
 
+    #region GetCapabilitySettingsSchema
+
+    [Fact]
+    public void GetCapabilitySettingsSchema_CapabilityWithSettingsType_BuildsFromCapabilityType()
+    {
+        // Arrange
+        var expectedSchema = new AIEditableModelSchema(
+            typeof(FakeProviderSettings),
+            new List<AIEditableModelField>
+            {
+                new() { PropertyName = "ApiKey", Key = "api-key", Label = "API Key" }
+            });
+
+        _capabilityFactoryMock
+            .Setup(x => x.Create<CapabilitySettingsChatCapability>(It.IsAny<IAIProvider>()))
+            .Returns(new CapabilitySettingsChatCapability());
+
+        _schemaBuilderMock
+            .Setup(x => x.BuildForType(typeof(FakeProviderSettings), "capability-settings-provider"))
+            .Returns(expectedSchema);
+
+        var provider = new ProviderWithCapabilitySettingsCapability(_infrastructureMock.Object);
+
+        // Act
+        var schema = provider.GetCapabilitySettingsSchema(AICapability.Chat);
+
+        // Assert
+        schema.ShouldBe(expectedSchema);
+        _schemaBuilderMock.Verify(
+            x => x.BuildForType(typeof(FakeProviderSettings), "capability-settings-provider"),
+            Times.Once);
+    }
+
+    [Fact]
+    public void GetCapabilitySettingsSchema_CapabilityWithoutSettings_ReturnsNull()
+    {
+        // Arrange
+        _capabilityFactoryMock
+            .Setup(x => x.Create<IAIChatCapability>(It.IsAny<IAIProvider>()))
+            .Returns(new FakeChatCapability());
+
+        var provider = new ProviderWithChatCapability(_infrastructureMock.Object);
+
+        // Act & Assert - FakeChatCapability declares no capability settings type
+        provider.GetCapabilitySettingsSchema(AICapability.Chat).ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetCapabilitySettingsSchema_CapabilityNotSupported_ReturnsNull()
+    {
+        // Arrange
+        var provider = new TestProvider(_infrastructureMock.Object); // no capabilities
+
+        // Act & Assert
+        provider.GetCapabilitySettingsSchema(AICapability.Chat).ShouldBeNull();
+    }
+
+    #endregion
+
     #region Test providers
 
     [AIProvider("test-provider", "Test Provider")]
@@ -314,6 +374,33 @@ public class AIProviderBaseTests
         public TypedSettingsProvider(IAIProviderInfrastructure infrastructure)
             : base(infrastructure)
         { }
+    }
+
+    [AIProvider("capability-settings-provider", "Capability Settings Provider")]
+    private class ProviderWithCapabilitySettingsCapability : AIProviderBase
+    {
+        public ProviderWithCapabilitySettingsCapability(IAIProviderInfrastructure infrastructure)
+            : base(infrastructure)
+        {
+            WithCapability<CapabilitySettingsChatCapability>();
+        }
+    }
+
+    /// <summary>
+    /// A chat capability that declares a capability-settings type (via the <see cref="IAICapability.CapabilitySettingsType"/>
+    /// hook the two-parameter base sets), used to verify schema generation without a real provider SDK.
+    /// </summary>
+    private sealed class CapabilitySettingsChatCapability : IAIChatCapability
+    {
+        public AICapability Kind => AICapability.Chat;
+
+        public Type? CapabilitySettingsType => typeof(FakeProviderSettings);
+
+        public Task<IReadOnlyList<AIModelDescriptor>> GetModelsAsync(object? settings = null, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<AIModelDescriptor>>(Array.Empty<AIModelDescriptor>());
+
+        public Task<IChatClient> CreateClientAsync(object? settings = null, string? modelId = null, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
     }
 
     #endregion

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Providers/CapabilitySettingSupportTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Providers/CapabilitySettingSupportTests.cs
@@ -1,0 +1,194 @@
+using Microsoft.Extensions.AI;
+using Umbraco.AI.Core.Models;
+using Umbraco.AI.Core.Providers;
+using Umbraco.AI.Extensions;
+using Umbraco.AI.Tests.Common.Fakes;
+
+namespace Umbraco.AI.Tests.Unit.Providers;
+
+/// <summary>
+/// Covers the per-model setting declarations: a capability names the settings a model rejects, the bases
+/// project that into the model list's metadata, and consumers read it back.
+/// </summary>
+public class CapabilitySettingSupportTests
+{
+    private static readonly FakeProviderSettings Settings = new();
+
+    #region Projection into model metadata
+
+    [Fact]
+    public async Task GetModelsAsync_ModelRejectsSetting_ProjectsDeclarationIntoMetadata()
+    {
+        // Arrange
+        IAICapability capability = new DeclaringChatCapability();
+
+        // Act
+        var models = await capability.GetModelsAsync(Settings);
+
+        // Assert
+        var plain = models.Single(m => m.Model.ModelId == "plain-model");
+        plain.Metadata[AIModelMetadataKeys.CapabilitySettingsUnsupported].ShouldBe("reasoningEffort");
+        plain.IsCapabilitySettingSupported("reasoningEffort").ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GetModelsAsync_ModelAcceptsSetting_DeclaresNothingForIt()
+    {
+        // Arrange
+        IAICapability capability = new DeclaringChatCapability();
+
+        // Act
+        var models = await capability.GetModelsAsync(Settings);
+
+        // Assert — silence, not a positive claim: the key is simply absent
+        var supporting = models.Single(m => m.Model.ModelId == "reasoning-model");
+        supporting.Metadata.ContainsKey(AIModelMetadataKeys.CapabilitySettingsUnsupported).ShouldBeFalse();
+        supporting.IsCapabilitySettingSupported("reasoningEffort").ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GetModelsAsync_ModelWithOwnMetadata_PreservesIt()
+    {
+        // Arrange — the provider already puts its own constraints on the descriptor
+        IAICapability capability = new DeclaringChatCapability();
+
+        // Act
+        var models = await capability.GetModelsAsync(Settings);
+
+        // Assert
+        var plain = models.Single(m => m.Model.ModelId == "plain-model");
+        plain.Metadata["custom.key"].ShouldBe("custom-value");
+        plain.Name.ShouldBe("Plain Model");
+    }
+
+    [Fact]
+    public async Task GetModelsAsync_CapabilityDeclaresNothing_ReturnsDescriptorsUntouched()
+    {
+        // Arrange — a capability on the base that doesn't override the declaration hook
+        var capabilityImpl = new PlainChatCapability();
+        IAICapability capability = capabilityImpl;
+
+        // Act
+        var models = await capability.GetModelsAsync(Settings);
+
+        // Assert — no declaration means no metadata is invented, and the original list is passed through
+        models.ShouldBeSameAs(capabilityImpl.Models);
+        models.ShouldAllBe(m => m.Metadata.Count == 0);
+    }
+
+    [Fact]
+    public async Task GetModelsAsync_DeclarationUsesPropertyName_NormalisesToSchemaFieldKey()
+    {
+        // Arrange — declared as nameof(...) i.e. "ReasoningEffort", read back as the camelCase field key
+        IAICapability capability = new DeclaringChatCapability();
+
+        // Act
+        var models = await capability.GetModelsAsync(Settings);
+
+        // Assert
+        var plain = models.Single(m => m.Model.ModelId == "plain-model");
+        plain.Metadata[AIModelMetadataKeys.CapabilitySettingsUnsupported].ShouldBe("reasoningEffort");
+    }
+
+    #endregion
+
+    #region Reading declarations back
+
+    [Fact]
+    public void IsCapabilitySettingSupported_NoMetadata_ReturnsTrue()
+    {
+        var model = new AIModelDescriptor(new AIModelRef("test", "some-model"), "Some Model");
+
+        model.IsCapabilitySettingSupported("reasoningEffort").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsCapabilitySettingSupported_DifferentKeyDeclared_ReturnsTrue()
+    {
+        var model = Describe("thinkingBudgetTokens");
+
+        model.IsCapabilitySettingSupported("reasoningEffort").ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("reasoningEffort")]
+    [InlineData("ReasoningEffort")]
+    [InlineData(" reasoningEffort ")]
+    public void IsCapabilitySettingSupported_DeclaredKeyRegardlessOfCasingOrWhitespace_ReturnsFalse(string fieldKey)
+    {
+        var model = Describe("verbosity, reasoningEffort");
+
+        model.IsCapabilitySettingSupported(fieldKey).ShouldBeFalse();
+    }
+
+    #endregion
+
+    private static AIModelDescriptor Describe(string unsupported)
+        => new(
+            new AIModelRef("test", "some-model"),
+            "Some Model",
+            new Dictionary<string, string> { [AIModelMetadataKeys.CapabilitySettingsUnsupported] = unsupported });
+
+    /// <summary>
+    /// A capability that rejects reasoning effort on one of its two models, exercising the projection
+    /// performed by <see cref="AICapabilityBase{TSettings}"/>.
+    /// </summary>
+    private sealed class DeclaringChatCapability()
+        : AIChatCapabilityBase<FakeProviderSettings, DeclaringChatCapability.CapabilitySettings>(
+            new FakeAIProvider())
+    {
+        public override AIModelSettingSupport GetSettingSupport(string modelId)
+            => modelId == "reasoning-model"
+                ? AIModelSettingSupport.Default
+                : new AIModelSettingSupport
+                {
+                    UnsupportedCapabilitySettings = [nameof(CapabilitySettings.ReasoningEffort)],
+                };
+
+        protected override Task<IReadOnlyList<AIModelDescriptor>> GetModelsAsync(
+            FakeProviderSettings settings,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<AIModelDescriptor>>(
+            [
+                new AIModelDescriptor(new AIModelRef("test", "reasoning-model"), "Reasoning Model"),
+                new AIModelDescriptor(
+                    new AIModelRef("test", "plain-model"),
+                    "Plain Model",
+                    new Dictionary<string, string> { ["custom.key"] = "custom-value" }),
+            ]);
+
+        protected override IChatClient CreateClient(FakeProviderSettings settings, string? modelId)
+            => throw new NotSupportedException();
+
+        protected override void ApplyCapabilitySettings(
+            CapabilitySettings capabilitySettings,
+            string? modelId,
+            ChatOptions options)
+            => throw new NotSupportedException();
+
+        internal sealed class CapabilitySettings
+        {
+            public string? ReasoningEffort { get; set; }
+        }
+    }
+
+    /// <summary>
+    /// A capability that declares nothing, so the projection must leave its descriptors alone.
+    /// </summary>
+    private sealed class PlainChatCapability()
+        : AIChatCapabilityBase<FakeProviderSettings>(new FakeAIProvider())
+    {
+        public IReadOnlyList<AIModelDescriptor> Models { get; } =
+        [
+            new AIModelDescriptor(new AIModelRef("test", "plain-model"), "Plain Model"),
+        ];
+
+        protected override Task<IReadOnlyList<AIModelDescriptor>> GetModelsAsync(
+            FakeProviderSettings settings,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(Models);
+
+        protected override IChatClient CreateClient(FakeProviderSettings settings, string? modelId)
+            => throw new NotSupportedException();
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Providers/CapabilitySettingsSupportTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Providers/CapabilitySettingsSupportTests.cs
@@ -10,7 +10,7 @@ namespace Umbraco.AI.Tests.Unit.Providers;
 /// Covers the per-model setting declarations: a capability names the settings a model rejects, the bases
 /// project that into the model list's metadata, and consumers read it back.
 /// </summary>
-public class CapabilitySettingSupportTests
+public class CapabilitySettingsSupportTests
 {
     private static readonly FakeProviderSettings Settings = new();
 
@@ -137,10 +137,10 @@ public class CapabilitySettingSupportTests
         : AIChatCapabilityBase<FakeProviderSettings, DeclaringChatCapability.CapabilitySettings>(
             new FakeAIProvider())
     {
-        public override AIModelSettingSupport GetSettingSupport(string modelId)
+        public override AIModelSettingsSupport GetSettingsSupport(string modelId)
             => modelId == "reasoning-model"
-                ? AIModelSettingSupport.Default
-                : new AIModelSettingSupport
+                ? AIModelSettingsSupport.Default
+                : new AIModelSettingsSupport
                 {
                     UnsupportedCapabilitySettings = [nameof(CapabilitySettings.ReasoningEffort)],
                 };

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Repositories/EFCoreAIProfileRepositoryTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Repositories/EFCoreAIProfileRepositoryTests.cs
@@ -1,5 +1,7 @@
+using Umbraco.AI.Core.EditableModels;
 using Umbraco.AI.Core.Models;
 using Umbraco.AI.Core.Profiles;
+using Umbraco.AI.Core.Providers;
 using Umbraco.AI.Persistence;
 using Umbraco.AI.Persistence.Connections;
 using Umbraco.AI.Persistence.Profiles;
@@ -20,7 +22,17 @@ public class EFCoreAIProfileRepositoryTests : IClassFixture<EFCoreTestFixture>
     private EFCoreAIProfileRepository CreateRepository(UmbracoAIDbContext context)
     {
         var scopeProvider = new TestEFCoreScopeProvider(() => context);
-        return new EFCoreAIProfileRepository(scopeProvider);
+        return new EFCoreAIProfileRepository(scopeProvider, CreateFactory());
+    }
+
+    // The profile mapping assertions rely on the real factory logic (Settings/Tags serialization,
+    // model-ref mapping). None of these tests exercise provider-declared CapabilitySettings, so the
+    // editable-model serializer and provider collection are stubbed/empty and never invoked.
+    private static IAIProfileFactory CreateFactory()
+    {
+        var serializer = new Mock<IAIEditableModelSerializer>().Object;
+        var providers = new AIProviderCollection(Enumerable.Empty<IAIProvider>);
+        return new AIProfileFactory(serializer, providers);
     }
 
     private async Task<Guid> EnsureConnectionExists(UmbracoAIDbContext context)

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Serialization/DropdownStringJsonConverterTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Serialization/DropdownStringJsonConverterTests.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Umbraco.AI.Core.Serialization;
+
+namespace Umbraco.AI.Tests.Unit.Serialization;
+
+public class DropdownStringJsonConverterTests
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private sealed class Container
+    {
+        [JsonConverter(typeof(DropdownStringJsonConverter))]
+        public string? Value { get; set; }
+    }
+
+    [Fact]
+    public void Read_SingleElementArray_ReturnsTheElement()
+    {
+        // The shape the backoffice dropdown actually saves, even as a single select.
+        var result = JsonSerializer.Deserialize<Container>("""{"value":["low"]}""", Options);
+
+        result.ShouldNotBeNull();
+        result!.Value.ShouldBe("low");
+    }
+
+    [Fact]
+    public void Read_PlainString_ReturnsValue()
+    {
+        // What an API caller or a normalised store sends.
+        var result = JsonSerializer.Deserialize<Container>("""{"value":"high"}""", Options);
+
+        result.ShouldNotBeNull();
+        result!.Value.ShouldBe("high");
+    }
+
+    [Fact]
+    public void Read_EmptyArray_ReturnsNull()
+    {
+        // The dropdown's cleared state.
+        var result = JsonSerializer.Deserialize<Container>("""{"value":[]}""", Options);
+
+        result.ShouldNotBeNull();
+        result!.Value.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Read_Null_ReturnsNull()
+    {
+        var result = JsonSerializer.Deserialize<Container>("""{"value":null}""", Options);
+
+        result.ShouldNotBeNull();
+        result!.Value.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Read_MultipleElements_ReturnsTheFirst()
+    {
+        // A multi-select bound to a string property is a declaration mistake; it should not fail a request.
+        var result = JsonSerializer.Deserialize<Container>("""{"value":["low","high"]}""", Options);
+
+        result.ShouldNotBeNull();
+        result!.Value.ShouldBe("low");
+    }
+
+    [Fact]
+    public void Read_NonStringArrayElement_Throws()
+    {
+        Should.Throw<JsonException>(() => JsonSerializer.Deserialize<Container>("""{"value":[7]}""", Options));
+    }
+
+    [Fact]
+    public void Read_UnexpectedToken_Throws()
+    {
+        Should.Throw<JsonException>(() => JsonSerializer.Deserialize<Container>("""{"value":7}""", Options));
+    }
+
+    [Fact]
+    public void Write_RoundTripsAsAScalar()
+    {
+        // Writing a scalar is what normalises the stored shape on the next save.
+        var json = JsonSerializer.Serialize(new Container { Value = "medium" }, Options);
+
+        json.ShouldBe("""{"value":"medium"}""");
+    }
+
+    [Fact]
+    public void Write_Null_WritesNull()
+    {
+        var json = JsonSerializer.Serialize(new Container { Value = null }, Options);
+
+        json.ShouldBe("""{"value":null}""");
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Settings/AIEditableModelResolverTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Settings/AIEditableModelResolverTests.cs
@@ -1,8 +1,10 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Umbraco.AI.Core.Models;
 using Umbraco.AI.Core.EditableModels;
+using Umbraco.AI.Core.Serialization;
 using Umbraco.AI.Tests.Common.Fakes;
 
 namespace Umbraco.AI.Tests.Unit.Settings;
@@ -536,6 +538,43 @@ public class AIEditableModelResolverTests
         result.ShouldNotBeNull();
         result.ShouldBeOfType<FakeProviderSettings>();
         ((FakeProviderSettings)result!).ApiKey.ShouldBe("provider-key");
+    }
+
+    #endregion
+
+    #region Dropdown-shaped values
+
+    [Fact]
+    public void ResolveModel_DropdownValueStoredAsArray_BindsToTheStringProperty()
+    {
+        // The backoffice dropdown saves its value as an array even as a single select, so a profile
+        // configured through the editor stores ["low"] against a string property. Without the converter
+        // on the property this threw: "The JSON value could not be converted to System.String".
+        var resolver = new AIEditableModelResolver(_configuration);
+        var data = JsonSerializer.Deserialize<JsonElement>("""{"choice":["low"]}""");
+
+        var result = resolver.ResolveModel<DropdownSettings>(data);
+
+        result.ShouldNotBeNull();
+        result!.Choice.ShouldBe("low");
+    }
+
+    [Fact]
+    public void ResolveModel_DropdownValueStoredAsEmptyArray_BindsToNull()
+    {
+        var resolver = new AIEditableModelResolver(_configuration);
+        var data = JsonSerializer.Deserialize<JsonElement>("""{"choice":[]}""");
+
+        var result = resolver.ResolveModel<DropdownSettings>(data);
+
+        result.ShouldNotBeNull();
+        result!.Choice.ShouldBeNull();
+    }
+
+    private sealed class DropdownSettings
+    {
+        [JsonConverter(typeof(DropdownStringJsonConverter))]
+        public string? Choice { get; set; }
     }
 
     #endregion


### PR DESCRIPTION
Backport of #269 to the v17 line, per the keep-active-versions-in-sync policy. Same mechanism, same reference consumers, same verification — see #269 for the full rationale.

## What this adds

A provider can declare extra, capability-specific settings that are captured on a profile and applied per request, reusing the existing editable-model pipeline (schema generation, sensitive-field encryption at rest, `$`-config resolution, validation). Profiles were the one settings consumer bypassing that pipeline.

Because support for these settings varies by **model** rather than by provider, a capability declares which settings a given model rejects via `IAICapability.GetSettingSupport(modelId)`. The capability bases project that into `AIModelDescriptor.Metadata` as the model list is built, so the profile editor filters the schema for the selected model with no extra round trip, and prunes stored values a newly selected model rejects. The same predicate gates what the provider sends, since UI suppression does not cover profiles saved before a model change, alias-driven API callers or direct `IChatClient` consumers.

Reference consumers: OpenAI `reasoning.effort` (o-series and the GPT-5 line) and Anthropic `output_config.effort` (Opus 4.5 and the 4.6 generation onwards, with `xhigh` and `max` gated separately because they reach fewer models).

## Verification on this line

- `dotnet test` clean: core 1,005, OpenAI 22, Anthropic 57 (including three wire tests asserting what actually reaches the request body).
- `dotnet ef migrations has-pending-model-changes` reports none on both SQL Server and SQLite.
- Frontend `build:core` and `tsc -p tsconfig.app.json --noEmit` clean.
- `api/types.gen.ts` was hand-patched to this line's generator shape (v17 spells the settings union out where v18 uses a named model); re-run `npm run generate-client` against a running site before release.

Not verified: no calls against real API keys, same as #269.

## Also here

The `^o4` chat-model-list fix — `OpenAIChatCapability.IsChatModel` covered `^o1` and `^o3` but not `^o4` on this line too, so `o4-mini` never appeared in the model dropdown.

## Merge order

Land #269 on `v18/dev` first so the two lines stay in step.