### PR TITLE
ci(build): Run every test project in the pipeline

### DIFF
--- a/Umbraco.AI.Agent.Deploy/Umbraco.AI.Agent.Deploy.slnx
+++ b/Umbraco.AI.Agent.Deploy/Umbraco.AI.Agent.Deploy.slnx
@@ -1,9 +1,6 @@
 <Solution>
-  <Folder Name="/Tests/" />
   <Project Path="src/Umbraco.AI.Agent.Deploy/Umbraco.AI.Agent.Deploy.csproj" />
-  <Project Path="tests/Umbraco.AI.Agent.Deploy.Tests.Unit/Umbraco.AI.Agent.Deploy.Tests.Unit.csproj">
-    <BuildType Project="?" />
-    <Platform Project="?" />
-    <Build Project="false" />
-  </Project>
+  <Folder Name="/Tests/">
+    <Project Path="tests/Umbraco.AI.Agent.Deploy.Tests.Unit/Umbraco.AI.Agent.Deploy.Tests.Unit.csproj" />
+  </Folder>
 </Solution>

--- a/Umbraco.AI.Automate/Umbraco.AI.Automate.slnx
+++ b/Umbraco.AI.Automate/Umbraco.AI.Automate.slnx
@@ -1,9 +1,6 @@
 <Solution>
-  <Folder Name="/Tests/" />
   <Project Path="src/Umbraco.AI.Automate/Umbraco.AI.Automate.csproj" />
-  <Project Path="tests/Umbraco.AI.Automate.Tests.Unit/Umbraco.AI.Automate.Tests.Unit.csproj">
-    <BuildType Project="?" />
-    <Platform Project="?" />
-    <Build Project="false" />
-  </Project>
+  <Folder Name="/Tests/">
+    <Project Path="tests/Umbraco.AI.Automate.Tests.Unit/Umbraco.AI.Automate.Tests.Unit.csproj" />
+  </Folder>
 </Solution>

--- a/Umbraco.AI.Deploy/Umbraco.AI.Deploy.slnx
+++ b/Umbraco.AI.Deploy/Umbraco.AI.Deploy.slnx
@@ -1,9 +1,6 @@
 <Solution>
-  <Folder Name="/Tests/" />
   <Project Path="src/Umbraco.AI.Deploy/Umbraco.AI.Deploy.csproj" />
-  <Project Path="tests/Umbraco.AI.Deploy.Tests.Unit/Umbraco.AI.Deploy.Tests.Unit.csproj">
-    <BuildType Project="?" />
-    <Platform Project="?" />
-    <Build Project="false" />
-  </Project>
+  <Folder Name="/Tests/">
+    <Project Path="tests/Umbraco.AI.Deploy.Tests.Unit/Umbraco.AI.Deploy.Tests.Unit.csproj" />
+  </Folder>
 </Solution>

--- a/Umbraco.AI.Prompt.Deploy/Umbraco.AI.Prompt.Deploy.slnx
+++ b/Umbraco.AI.Prompt.Deploy/Umbraco.AI.Prompt.Deploy.slnx
@@ -1,9 +1,6 @@
 <Solution>
-  <Folder Name="/Tests/" />
   <Project Path="src/Umbraco.AI.Prompt.Deploy/Umbraco.AI.Prompt.Deploy.csproj" />
-  <Project Path="tests/Umbraco.AI.Prompt.Deploy.Tests.Unit/Umbraco.AI.Prompt.Deploy.Tests.Unit.csproj">
-    <BuildType Project="?" />
-    <Platform Project="?" />
-    <Build Project="false" />
-  </Project>
+  <Folder Name="/Tests/">
+    <Project Path="tests/Umbraco.AI.Prompt.Deploy.Tests.Unit/Umbraco.AI.Prompt.Deploy.Tests.Unit.csproj" />
+  </Folder>
 </Solution>

--- a/Umbraco.AI.slnx
+++ b/Umbraco.AI.slnx
@@ -15,6 +15,7 @@
     <Project Path="Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web/Umbraco.AI.Agent.Web.csproj" />
     <Project Path="Umbraco.AI.Agent/src/Umbraco.AI.Agent/Umbraco.AI.Agent.csproj" />
     <Project Path="Umbraco.AI.Agent/src/Umbraco.AI.AGUI/Umbraco.AI.AGUI.csproj" />
+    <Project Path="Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Integration/Umbraco.AI.Agent.Tests.Integration.csproj" />
     <Project Path="Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/Umbraco.AI.Agent.Tests.Unit.csproj" />
   </Folder>
   <Folder Name="/AddOns/Copilot/">
@@ -30,6 +31,7 @@
     <Project Path="Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Umbraco.AI.Prompt.Web.StaticAssets.csproj" />
     <Project Path="Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web/Umbraco.AI.Prompt.Web.csproj" />
     <Project Path="Umbraco.AI.Prompt/src/Umbraco.AI.Prompt/Umbraco.AI.Prompt.csproj" />
+    <Project Path="Umbraco.AI.Prompt/tests/Umbraco.AI.Prompt.Tests.Unit/Umbraco.AI.Prompt.Tests.Unit.csproj" />
   </Folder>
   <Folder Name="/AddOns/Search/">
     <Project Path="Umbraco.AI.Search/src/Umbraco.AI.Search.Core/Umbraco.AI.Search.Core.csproj" />
@@ -61,6 +63,9 @@
     <Project Path="Umbraco.AI.Agent.Deploy/src/Umbraco.AI.Agent.Deploy/Umbraco.AI.Agent.Deploy.csproj" />
     <Project Path="Umbraco.AI.Deploy/src/Umbraco.AI.Deploy/Umbraco.AI.Deploy.csproj" />
     <Project Path="Umbraco.AI.Prompt.Deploy/src/Umbraco.AI.Prompt.Deploy/Umbraco.AI.Prompt.Deploy.csproj" />
+    <Project Path="Umbraco.AI.Agent.Deploy/tests/Umbraco.AI.Agent.Deploy.Tests.Unit/Umbraco.AI.Agent.Deploy.Tests.Unit.csproj" />
+    <Project Path="Umbraco.AI.Deploy/tests/Umbraco.AI.Deploy.Tests.Unit/Umbraco.AI.Deploy.Tests.Unit.csproj" />
+    <Project Path="Umbraco.AI.Prompt.Deploy/tests/Umbraco.AI.Prompt.Deploy.Tests.Unit/Umbraco.AI.Prompt.Deploy.Tests.Unit.csproj" />
   </Folder>
   <Folder Name="/Providers/" />
   <Folder Name="/Providers/Amazon/">


### PR DESCRIPTION
The pipeline runs `dotnet test Umbraco.AI.slnx`, and five test projects were absent from that solution — so **119 tests had never run in CI**.

## What was invisible

| Test project | Tests |
|---|---|
| `Umbraco.AI.Prompt.Tests.Unit` | 84 |
| `Umbraco.AI.Deploy.Tests.Unit` | 19 |
| `Umbraco.AI.Agent.Deploy.Tests.Unit` | 7 |
| `Umbraco.AI.Prompt.Deploy.Tests.Unit` | 6 |
| `Umbraco.AI.Agent.Tests.Integration` | 3 |

All five pass today, which is luck rather than evidence — nothing was checking them, so a regression in Prompt, any Deploy connector, or the Agent integration path would have merged green.

Separately, four product solutions carried `<Build Project="false" />` on their test project entry — `Umbraco.AI.Deploy`, `Umbraco.AI.Agent.Deploy`, `Umbraco.AI.Prompt.Deploy` and `Umbraco.AI.Automate`. Running `dotnet test` against any of those solutions silently ran **nothing** and exited 0, which is how I found this: the Deploy tests I added in #269 appeared to run and didn't. Those entries are now plain references inside the `Tests` folder, matching every other product.

## Verification

Ran the pipeline's own command rather than trusting the solution file:

```
dotnet test Umbraco.AI.slnx --configuration Release --no-build
→ 13 test projects, 1,533 tests, all green   (was 8 projects, 1,414 tests)
```

## Note for review

No source changes — five `.slnx` files only. Worth a second pair of eyes on whether `Umbraco.AI.slnx` is hand-maintained, because if so this class of gap will recur every time a product gains a test project. A generator or a CI check that compares test projects on disk against the solution would prevent it; I haven't added one here.

Backported to `v17/dev` as the companion PR, which also carries the sampling-parameter wire tests that #267 missed.