### PR TITLE
ci(build): Run every test project in the pipeline, and backport the sampling wire tests

### DIFF
--- a/Umbraco.AI.Agent.Deploy/Umbraco.AI.Agent.Deploy.slnx
+++ b/Umbraco.AI.Agent.Deploy/Umbraco.AI.Agent.Deploy.slnx
@@ -1,9 +1,6 @@
 <Solution>
-  <Folder Name="/Tests/" />
   <Project Path="src/Umbraco.AI.Agent.Deploy/Umbraco.AI.Agent.Deploy.csproj" />
-  <Project Path="tests/Umbraco.AI.Agent.Deploy.Tests.Unit/Umbraco.AI.Agent.Deploy.Tests.Unit.csproj">
-    <BuildType Project="?" />
-    <Platform Project="?" />
-    <Build Project="false" />
-  </Project>
+  <Folder Name="/Tests/">
+    <Project Path="tests/Umbraco.AI.Agent.Deploy.Tests.Unit/Umbraco.AI.Agent.Deploy.Tests.Unit.csproj" />
+  </Folder>
 </Solution>

--- a/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicSamplingParameterWireTests.cs
+++ b/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicSamplingParameterWireTests.cs
@@ -1,0 +1,109 @@
+using System.Net;
+using Anthropic;
+using Microsoft.Extensions.AI;
+
+namespace Umbraco.AI.Anthropic.Tests.Unit;
+
+/// <summary>
+/// End-to-end checks that the filtered sampling parameters really do not reach the API, asserted against
+/// a captured request body rather than the <see cref="ChatOptions"/> handed to the inner client.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="AnthropicSamplingParameterChatClientTests"/> covers the filter's own behaviour by recording
+/// what it passes down, which is the right shape for testing the decorator. These tests close the gap that
+/// approach leaves: the filter is only effective while the SDK's Microsoft.Extensions.AI adapter reads
+/// <see cref="ChatOptions.Temperature"/> in the first place. If a future SDK version stopped doing so —
+/// as it already does for <see cref="ChatOptions.AdditionalProperties"/>, which it drops entirely — the
+/// recording tests would still pass while the parameter quietly stopped being sent at all.
+/// </para>
+/// <para>
+/// Asserting on the serialized request keeps both halves honest: that the filter removes the parameters
+/// on a model which rejects them, and that they are genuinely sent on a model which accepts them.
+/// </para>
+/// </remarks>
+public class AnthropicSamplingParameterWireTests
+{
+    [Fact]
+    public async Task ModelRejectingSamplingParameters_TheyDoNotReachTheRequest()
+    {
+        // Arrange — Opus 5 is past the Claude 4.7 cutoff, so temperature/top_p are rejected there
+        var handler = new CapturingHandler();
+        var chatClient = CreateFilteredChatClient(handler, "claude-opus-5");
+
+        // Act
+        await SendAndIgnoreFailureAsync(chatClient, new ChatOptions { Temperature = 0.5f, TopP = 0.9f });
+
+        // Assert
+        var body = handler.RequestBodies.ShouldHaveSingleItem();
+        body.ShouldNotContain("temperature");
+        body.ShouldNotContain("top_p");
+        body.ShouldContain("hello");
+    }
+
+    [Fact]
+    public async Task ModelAcceptingSamplingParameters_TheyReachTheRequest()
+    {
+        // Arrange — Sonnet 4.6 still accepts them, so the filter must leave them alone
+        var handler = new CapturingHandler();
+        var chatClient = CreateFilteredChatClient(handler, "claude-sonnet-4-6");
+
+        // Act
+        await SendAndIgnoreFailureAsync(chatClient, new ChatOptions { Temperature = 0.5f, TopP = 0.9f });
+
+        // Assert
+        var body = handler.RequestBodies.ShouldHaveSingleItem();
+        body.ShouldContain("\"temperature\":0.5");
+        body.ShouldContain("\"top_p\":0.8999999");
+    }
+
+    private static IChatClient CreateFilteredChatClient(CapturingHandler handler, string modelId)
+    {
+        var inner = new AnthropicClient
+        {
+            ApiKey = "test-key",
+            MaxRetries = 0,
+            HttpClient = new HttpClient(handler),
+        }.Beta.AsIChatClient(modelId);
+
+        // The same wrapping the chat capability applies.
+        return new AnthropicSamplingParameterChatClient(inner, modelId, logger: null);
+    }
+
+    private static async Task SendAndIgnoreFailureAsync(IChatClient chatClient, ChatOptions options)
+    {
+        try
+        {
+            await chatClient.GetResponseAsync("hello", options);
+        }
+        catch (Exception)
+        {
+            // The capturing handler always fails the request; only the captured body matters here.
+        }
+    }
+
+    /// <summary>
+    /// Captures the body of every request and short-circuits with an error response, so the test can
+    /// assert on what would have gone over the wire without a real API call.
+    /// </summary>
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public List<string> RequestBodies { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (request.Content is not null)
+            {
+                RequestBodies.Add(await request.Content.ReadAsStringAsync(cancellationToken));
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent(
+                    """{"type":"error","error":{"type":"invalid_request_error","message":"captured"}}"""),
+            };
+        }
+    }
+}

--- a/Umbraco.AI.Automate/Umbraco.AI.Automate.slnx
+++ b/Umbraco.AI.Automate/Umbraco.AI.Automate.slnx
@@ -1,9 +1,6 @@
 <Solution>
-  <Folder Name="/Tests/" />
   <Project Path="src/Umbraco.AI.Automate/Umbraco.AI.Automate.csproj" />
-  <Project Path="tests/Umbraco.AI.Automate.Tests.Unit/Umbraco.AI.Automate.Tests.Unit.csproj">
-    <BuildType Project="?" />
-    <Platform Project="?" />
-    <Build Project="false" />
-  </Project>
+  <Folder Name="/Tests/">
+    <Project Path="tests/Umbraco.AI.Automate.Tests.Unit/Umbraco.AI.Automate.Tests.Unit.csproj" />
+  </Folder>
 </Solution>

--- a/Umbraco.AI.Deploy/Umbraco.AI.Deploy.slnx
+++ b/Umbraco.AI.Deploy/Umbraco.AI.Deploy.slnx
@@ -1,9 +1,6 @@
 <Solution>
-  <Folder Name="/Tests/" />
   <Project Path="src/Umbraco.AI.Deploy/Umbraco.AI.Deploy.csproj" />
-  <Project Path="tests/Umbraco.AI.Deploy.Tests.Unit/Umbraco.AI.Deploy.Tests.Unit.csproj">
-    <BuildType Project="?" />
-    <Platform Project="?" />
-    <Build Project="false" />
-  </Project>
+  <Folder Name="/Tests/">
+    <Project Path="tests/Umbraco.AI.Deploy.Tests.Unit/Umbraco.AI.Deploy.Tests.Unit.csproj" />
+  </Folder>
 </Solution>

--- a/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/OpenAISamplingParameterWireTests.cs
+++ b/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/OpenAISamplingParameterWireTests.cs
@@ -1,0 +1,109 @@
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Net;
+using Microsoft.Extensions.AI;
+using OpenAI;
+
+#pragma warning disable OPENAI001 // The Responses API surface is experimental in the OpenAI SDK
+
+namespace Umbraco.AI.OpenAI.Tests.Unit;
+
+/// <summary>
+/// End-to-end checks that the filtered sampling parameters really do not reach the API, asserted against
+/// a captured request body rather than the <see cref="ChatOptions"/> handed to the inner client.
+/// </summary>
+/// <remarks>
+/// <see cref="OpenAISamplingParameterChatClientTests"/> covers the filter's own behaviour by recording what
+/// it passes down, which is the right shape for testing the decorator. These tests close the gap that
+/// approach leaves: the filter is only effective while the Microsoft.Extensions.AI adapter reads
+/// <see cref="ChatOptions.Temperature"/> in the first place, and a recording test would stay green if it
+/// stopped. Asserting on the serialized request keeps both halves honest — removed on a model that rejects
+/// them, genuinely sent on a model that accepts them.
+/// </remarks>
+public class OpenAISamplingParameterWireTests
+{
+    [Fact]
+    public async Task ModelRejectingSamplingParameters_TheyDoNotReachTheRequest()
+    {
+        // Arrange — the GPT-5 line restricts the sampling parameters
+        var handler = new CapturingHandler();
+        var chatClient = CreateFilteredChatClient(handler, "gpt-5.6");
+
+        // Act
+        await SendAndIgnoreFailureAsync(chatClient, new ChatOptions { Temperature = 0.5f, TopP = 0.9f });
+
+        // Assert
+        var body = handler.RequestBodies.ShouldHaveSingleItem();
+        body.ShouldNotContain("temperature");
+        body.ShouldNotContain("top_p");
+        body.ShouldContain("hello");
+    }
+
+    [Fact]
+    public async Task ModelAcceptingSamplingParameters_TheyReachTheRequest()
+    {
+        // Arrange — gpt-4o still accepts them, so the filter must leave them alone
+        var handler = new CapturingHandler();
+        var chatClient = CreateFilteredChatClient(handler, "gpt-4o");
+
+        // Act
+        await SendAndIgnoreFailureAsync(chatClient, new ChatOptions { Temperature = 0.5f, TopP = 0.9f });
+
+        // Assert
+        var body = handler.RequestBodies.ShouldHaveSingleItem();
+        body.ShouldContain("\"temperature\":0.5");
+        body.ShouldContain("\"top_p\":0.9");
+    }
+
+    private static IChatClient CreateFilteredChatClient(CapturingHandler handler, string modelId)
+    {
+        var inner = new OpenAIClient(
+                new ApiKeyCredential("test-key"),
+                new OpenAIClientOptions
+                {
+                    Transport = new HttpClientPipelineTransport(new HttpClient(handler)),
+                    RetryPolicy = new ClientRetryPolicy(0),
+                })
+            .GetResponsesClient()
+            .AsIChatClient(modelId);
+
+        // The same wrapping the chat capability applies.
+        return new OpenAISamplingParameterChatClient(inner, modelId, logger: null);
+    }
+
+    private static async Task SendAndIgnoreFailureAsync(IChatClient chatClient, ChatOptions options)
+    {
+        try
+        {
+            await chatClient.GetResponseAsync("hello", options);
+        }
+        catch (Exception)
+        {
+            // The capturing handler always fails the request; only the captured body matters here.
+        }
+    }
+
+    /// <summary>
+    /// Captures the body of every request and short-circuits with an error response, so the test can
+    /// assert on what would have gone over the wire without a real API call.
+    /// </summary>
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public List<string> RequestBodies { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (request.Content is not null)
+            {
+                RequestBodies.Add(await request.Content.ReadAsStringAsync(cancellationToken));
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("""{"error":{"message":"captured","type":"invalid_request_error"}}"""),
+            };
+        }
+    }
+}

--- a/Umbraco.AI.Prompt.Deploy/Umbraco.AI.Prompt.Deploy.slnx
+++ b/Umbraco.AI.Prompt.Deploy/Umbraco.AI.Prompt.Deploy.slnx
@@ -1,9 +1,6 @@
 <Solution>
-  <Folder Name="/Tests/" />
   <Project Path="src/Umbraco.AI.Prompt.Deploy/Umbraco.AI.Prompt.Deploy.csproj" />
-  <Project Path="tests/Umbraco.AI.Prompt.Deploy.Tests.Unit/Umbraco.AI.Prompt.Deploy.Tests.Unit.csproj">
-    <BuildType Project="?" />
-    <Platform Project="?" />
-    <Build Project="false" />
-  </Project>
+  <Folder Name="/Tests/">
+    <Project Path="tests/Umbraco.AI.Prompt.Deploy.Tests.Unit/Umbraco.AI.Prompt.Deploy.Tests.Unit.csproj" />
+  </Folder>
 </Solution>

--- a/Umbraco.AI.slnx
+++ b/Umbraco.AI.slnx
@@ -15,6 +15,7 @@
     <Project Path="Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web/Umbraco.AI.Agent.Web.csproj" />
     <Project Path="Umbraco.AI.Agent/src/Umbraco.AI.Agent/Umbraco.AI.Agent.csproj" />
     <Project Path="Umbraco.AI.Agent/src/Umbraco.AI.AGUI/Umbraco.AI.AGUI.csproj" />
+    <Project Path="Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Integration/Umbraco.AI.Agent.Tests.Integration.csproj" />
     <Project Path="Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/Umbraco.AI.Agent.Tests.Unit.csproj" />
   </Folder>
   <Folder Name="/AddOns/Copilot/">
@@ -30,6 +31,7 @@
     <Project Path="Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Umbraco.AI.Prompt.Web.StaticAssets.csproj" />
     <Project Path="Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web/Umbraco.AI.Prompt.Web.csproj" />
     <Project Path="Umbraco.AI.Prompt/src/Umbraco.AI.Prompt/Umbraco.AI.Prompt.csproj" />
+    <Project Path="Umbraco.AI.Prompt/tests/Umbraco.AI.Prompt.Tests.Unit/Umbraco.AI.Prompt.Tests.Unit.csproj" />
   </Folder>
   <Folder Name="/AddOns/Search/">
     <Project Path="Umbraco.AI.Search/src/Umbraco.AI.Search.Core/Umbraco.AI.Search.Core.csproj" />
@@ -61,6 +63,9 @@
     <Project Path="Umbraco.AI.Agent.Deploy/src/Umbraco.AI.Agent.Deploy/Umbraco.AI.Agent.Deploy.csproj" />
     <Project Path="Umbraco.AI.Deploy/src/Umbraco.AI.Deploy/Umbraco.AI.Deploy.csproj" />
     <Project Path="Umbraco.AI.Prompt.Deploy/src/Umbraco.AI.Prompt.Deploy/Umbraco.AI.Prompt.Deploy.csproj" />
+    <Project Path="Umbraco.AI.Agent.Deploy/tests/Umbraco.AI.Agent.Deploy.Tests.Unit/Umbraco.AI.Agent.Deploy.Tests.Unit.csproj" />
+    <Project Path="Umbraco.AI.Deploy/tests/Umbraco.AI.Deploy.Tests.Unit/Umbraco.AI.Deploy.Tests.Unit.csproj" />
+    <Project Path="Umbraco.AI.Prompt.Deploy/tests/Umbraco.AI.Prompt.Deploy.Tests.Unit/Umbraco.AI.Prompt.Deploy.Tests.Unit.csproj" />
   </Folder>
   <Folder Name="/Providers/" />
   <Folder Name="/Providers/Amazon/">


### PR DESCRIPTION
Two related test-coverage fixes for this line. Companion to #271, which does the pipeline half on `v18/dev`.

## 1. Backport the sampling-parameter wire tests

`AnthropicSamplingParameterWireTests` and `OpenAISamplingParameterWireTests` landed on the v18 line with #265 but not here with #267, which was backported before they were written — so v17 has shipped the sampling-parameter filters with only recording-client coverage.

That is the gap those tests exist to close. Recording what the filter hands to an inner client stays green even if an SDK adapter stops reading `ChatOptions.Temperature` — which is exactly how a provider setting turned out to be a silent no-op on the other line (#269). These assert on the serialized request instead, for both a model that rejects the sampling parameters and one that accepts them.

Anthropic and OpenAI test counts now match v18 exactly, at 78 and 42.

## 2. Run every test project in the pipeline

Identical to #271 and the same five projects were missing from `Umbraco.AI.slnx` here: Prompt, Deploy, Prompt.Deploy, Agent.Deploy and the Agent integration suite. The same four product solutions also carried `<Build Project="false" />` on their test project, so `dotnet test` against them ran nothing and exited 0.

## Verification

```
dotnet test Umbraco.AI.slnx --configuration Release --no-build
→ 13 test projects, all green   (was 8)
```

Tests and solution files only, no source changes.