### PR TITLE
fix(core,frontend,openai,anthropic,amazon): Give temperature a real unset state [v17 backport]

### DIFF
--- a/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/AmazonChatCapability.cs
+++ b/Umbraco.AI.Amazon/src/Umbraco.AI.Amazon/AmazonChatCapability.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Umbraco.AI.Core.Models;
+using Umbraco.AI.Core.Profiles;
 using Umbraco.AI.Core.Providers;
 using Umbraco.AI.Extensions;
 using Umbraco.Cms.Core.DependencyInjection;
@@ -78,6 +79,21 @@ public class AmazonChatCapability(
                 AmazonModelUtilities.FormatDisplayName(id)))
             .ToList();
     }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Bedrock fronts other vendors' models, so it inherits their restrictions: the Claude families that
+    /// reject <c>temperature</c> reject it here too. <see cref="AmazonSamplingParameterChatClient"/>
+    /// already drops it at request time from the predicate used here, so declaring it lets the editor
+    /// account for the drop instead of leaving the profile with a value that does nothing.
+    /// </remarks>
+    public override AIModelSettingsSupport GetSettingsSupport(string modelId)
+        => AmazonModelUtilities.SupportsSamplingParameters(modelId)
+            ? AIModelSettingsSupport.Default
+            : new AIModelSettingsSupport
+            {
+                UnsupportedProfileSettings = [nameof(AIChatProfileSettings.Temperature)],
+            };
 
     /// <inheritdoc />
     protected override IChatClient CreateClient(AmazonProviderSettings settings, string? modelId)

--- a/Umbraco.AI.Amazon/tests/Umbraco.AI.Amazon.Tests.Unit/AmazonSettingsDeclarationTests.cs
+++ b/Umbraco.AI.Amazon/tests/Umbraco.AI.Amazon.Tests.Unit/AmazonSettingsDeclarationTests.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Caching.Memory;
+using Umbraco.AI.Amazon.Tests.Unit.Fakes;
+using Umbraco.AI.Core.Models;
+
+namespace Umbraco.AI.Amazon.Tests.Unit;
+
+/// <summary>
+/// What the capability declares per model, which is what the profile editor renders from. Bedrock IDs carry
+/// a region prefix and a version suffix, so the rows here pin that the declaration is made against the
+/// decorated ID the model list actually contains rather than a bare family name.
+/// </summary>
+public class AmazonSettingsDeclarationTests
+{
+    [Theory]
+    [InlineData("anthropic.claude-opus-4-8-v1:0")]
+    [InlineData("us.anthropic.claude-opus-4-7-v1:0")]
+    [InlineData("anthropic.claude-opus-5-v1:0")]
+    public void GetSettingsSupport_ModelRejectingSamplingParameters_DeclaresTemperatureUnsupported(string modelId)
+    {
+        var metadata = CreateCapability().GetSettingsSupport(modelId).ToMetadata();
+
+        metadata[AIModelMetadataKeys.ProfileSettingsUnsupported].ShouldBe("temperature");
+    }
+
+    [Theory]
+    [InlineData("anthropic.claude-3-5-sonnet-20241022-v1:0")]
+    [InlineData("eu.anthropic.claude-sonnet-4-6-v1")]
+    [InlineData("amazon.nova-lite-v1:0")]
+    public void GetSettingsSupport_ModelAcceptingSamplingParameters_DeclaresNothing(string modelId)
+    {
+        var metadata = CreateCapability().GetSettingsSupport(modelId).ToMetadata();
+
+        metadata.ShouldBeEmpty();
+    }
+
+    private static AmazonChatCapability CreateCapability()
+        => new(
+            new AmazonProvider(new FakeProviderInfrastructure(), new MemoryCache(new MemoryCacheOptions())),
+            logger: null);
+}

--- a/Umbraco.AI.Amazon/tests/Umbraco.AI.Amazon.Tests.Unit/Fakes/FakeProviderInfrastructure.cs
+++ b/Umbraco.AI.Amazon/tests/Umbraco.AI.Amazon.Tests.Unit/Fakes/FakeProviderInfrastructure.cs
@@ -1,0 +1,23 @@
+using Umbraco.AI.Core.EditableModels;
+using Umbraco.AI.Core.Providers;
+
+namespace Umbraco.AI.Amazon.Tests.Unit.Fakes;
+
+/// <summary>
+/// Minimal provider infrastructure for constructing a real provider in a test. Capabilities are created by
+/// activation, which is enough for the provider's own capability wiring.
+/// </summary>
+internal sealed class FakeProviderInfrastructure : IAIProviderInfrastructure
+{
+    public IAICapabilityFactory CapabilityFactory { get; } = new ActivatorCapabilityFactory();
+
+    public IAIEditableModelSchemaBuilder SchemaBuilder
+        => throw new NotSupportedException("Schema building is not exercised by these tests.");
+
+    private sealed class ActivatorCapabilityFactory : IAICapabilityFactory
+    {
+        public TCapability Create<TCapability>(IAIProvider provider)
+            where TCapability : class, IAICapability
+            => (TCapability)Activator.CreateInstance(typeof(TCapability), provider)!;
+    }
+}

--- a/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
+++ b/Umbraco.AI.Anthropic/src/Umbraco.AI.Anthropic/AnthropicChatCapability.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Umbraco.AI.Core.Models;
+using Umbraco.AI.Core.Profiles;
 using Umbraco.AI.Core.Providers;
 using Umbraco.AI.Extensions;
 using Umbraco.Cms.Core.DependencyInjection;
@@ -83,13 +84,31 @@ public class AnthropicChatCapability(
     /// Turns a model's reported capabilities into the settings declaration the profile editor reads,
     /// falling back to the ID-based predicate when the API reported nothing for the model.
     /// </summary>
+    /// <remarks>
+    /// The sampling half has no equivalent in the API's response, so it comes from the ID predicate that
+    /// <see cref="AnthropicSamplingParameterChatClient"/> already enforces at request time — one predicate
+    /// behind both the dropped parameter and the editor's account of it.
+    /// </remarks>
     private static AIModelSettingsSupport BuildSettingsSupport(AnthropicModelCapability model)
-        => (model.SupportsEffort ?? AnthropicModelUtilities.SupportsEffort(model.Id))
-            ? AIModelSettingsSupport.Default
-            : new AIModelSettingsSupport
-            {
-                UnsupportedCapabilitySettings = [nameof(AnthropicChatCapabilitySettings.Effort)],
-            };
+    {
+        var supportsEffort = model.SupportsEffort ?? AnthropicModelUtilities.SupportsEffort(model.Id);
+        var supportsSampling = AnthropicModelUtilities.SupportsSamplingParameters(model.Id);
+
+        if (supportsEffort && supportsSampling)
+        {
+            return AIModelSettingsSupport.Default;
+        }
+
+        return new AIModelSettingsSupport
+        {
+            UnsupportedCapabilitySettings = supportsEffort
+                ? []
+                : [nameof(AnthropicChatCapabilitySettings.Effort)],
+            UnsupportedProfileSettings = supportsSampling
+                ? []
+                : [nameof(AIChatProfileSettings.Temperature)],
+        };
+    }
 
     /// <inheritdoc />
     /// <remarks>

--- a/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicModelCapabilityTests.cs
+++ b/Umbraco.AI.Anthropic/tests/Umbraco.AI.Anthropic.Tests.Unit/AnthropicModelCapabilityTests.cs
@@ -109,6 +109,27 @@ public class AnthropicModelCapabilityTests
     }
 
     [Fact]
+    public async Task GetModelsAsync_DeclaresTemperatureUnsupportedWhereTheModelRejectsIt()
+    {
+        // Arrange
+        var (provider, settings, _) = CreateProvider(TwoModelsPage);
+        var capability = new AnthropicChatCapability(provider, logger: null);
+
+        // Act
+        var descriptors = await ((Core.Providers.IAICapability)capability).GetModelsAsync(settings);
+
+        // Assert — Opus 5 rejects the sampling parameters but reports effort support, and Haiku 4.5 is the
+        // exact inverse, so the two declarations cannot be reading each other's source
+        var opus = descriptors.Single(d => d.Model.ModelId == "claude-opus-5");
+        opus.Metadata[AIModelMetadataKeys.ProfileSettingsUnsupported].ShouldBe("temperature");
+        opus.Metadata.ContainsKey(AIModelMetadataKeys.CapabilitySettingsUnsupported).ShouldBeFalse();
+
+        var haiku = descriptors.Single(d => d.Model.ModelId == "claude-haiku-4-5-20251001");
+        haiku.Metadata.ContainsKey(AIModelMetadataKeys.ProfileSettingsUnsupported).ShouldBeFalse();
+        haiku.Metadata[AIModelMetadataKeys.CapabilitySettingsUnsupported].ShouldBe("effort");
+    }
+
+    [Fact]
     public async Task TryGetModelCapability_AfterFetch_IsReadableWithoutIo()
     {
         // Arrange — this is what lets the per-request settings hook consult reported capabilities

--- a/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIChatCapability.cs
+++ b/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIChatCapability.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OpenAI.Responses;
 using Umbraco.AI.Core.Models;
+using Umbraco.AI.Core.Profiles;
 using Umbraco.AI.Core.Providers;
 using Umbraco.AI.Extensions;
 using Umbraco.Cms.Core.DependencyInjection;
@@ -84,18 +85,38 @@ public class OpenAIChatCapability(
 
     /// <inheritdoc />
     /// <remarks>
+    /// <para>
     /// Reasoning effort applies to the o-series and GPT-5 only, so it is declared per model rather than
     /// per provider — otherwise the profile editor would offer it on a gpt-4o profile. The stable set
     /// here is the list of reasoning families, so the predicate is written as an allow-list and inverted
     /// into the declaration.
+    /// </para>
+    /// <para>
+    /// Those same reasoning models reject <c>temperature</c>, which
+    /// <see cref="OpenAISamplingParameterChatClient"/> already drops at request time. Declaring it from
+    /// the same predicate turns that silent drop into something the editor can show.
+    /// </para>
     /// </remarks>
     public override AIModelSettingsSupport GetSettingsSupport(string modelId)
-        => OpenAIModelUtilities.SupportsReasoningEffort(modelId)
-            ? AIModelSettingsSupport.Default
-            : new AIModelSettingsSupport
-            {
-                UnsupportedCapabilitySettings = [nameof(OpenAIChatCapabilitySettings.ReasoningEffort)],
-            };
+    {
+        var supportsReasoningEffort = OpenAIModelUtilities.SupportsReasoningEffort(modelId);
+        var supportsSampling = OpenAIModelUtilities.SupportsSamplingParameters(modelId);
+
+        if (supportsReasoningEffort && supportsSampling)
+        {
+            return AIModelSettingsSupport.Default;
+        }
+
+        return new AIModelSettingsSupport
+        {
+            UnsupportedCapabilitySettings = supportsReasoningEffort
+                ? []
+                : [nameof(OpenAIChatCapabilitySettings.ReasoningEffort)],
+            UnsupportedProfileSettings = supportsSampling
+                ? []
+                : [nameof(AIChatProfileSettings.Temperature)],
+        };
+    }
 
     /// <inheritdoc />
     [Experimental("OPENAI001")]

--- a/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/Fakes/FakeProviderInfrastructure.cs
+++ b/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/Fakes/FakeProviderInfrastructure.cs
@@ -1,0 +1,23 @@
+using Umbraco.AI.Core.EditableModels;
+using Umbraco.AI.Core.Providers;
+
+namespace Umbraco.AI.OpenAI.Tests.Unit.Fakes;
+
+/// <summary>
+/// Minimal provider infrastructure for constructing a real provider in a test. Capabilities are created by
+/// activation, which is enough for the provider's own capability wiring.
+/// </summary>
+internal sealed class FakeProviderInfrastructure : IAIProviderInfrastructure
+{
+    public IAICapabilityFactory CapabilityFactory { get; } = new ActivatorCapabilityFactory();
+
+    public IAIEditableModelSchemaBuilder SchemaBuilder
+        => throw new NotSupportedException("Schema building is not exercised by these tests.");
+
+    private sealed class ActivatorCapabilityFactory : IAICapabilityFactory
+    {
+        public TCapability Create<TCapability>(IAIProvider provider)
+            where TCapability : class, IAICapability
+            => (TCapability)Activator.CreateInstance(typeof(TCapability), provider)!;
+    }
+}

--- a/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/OpenAISettingsDeclarationTests.cs
+++ b/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/OpenAISettingsDeclarationTests.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.Caching.Memory;
+using Umbraco.AI.Core.Models;
+using Umbraco.AI.OpenAI.Tests.Unit.Fakes;
+
+namespace Umbraco.AI.OpenAI.Tests.Unit;
+
+/// <summary>
+/// What the capability declares per model, which is what the profile editor renders from. The predicates
+/// behind it are covered elsewhere; this pins that both of them reach the declaration, and independently —
+/// reasoning effort and temperature are supported by opposite sets of models, so a declaration that read
+/// one predicate for both answers would look plausible and be wrong on every model.
+/// </summary>
+public class OpenAISettingsDeclarationTests
+{
+    [Theory]
+    [InlineData("o3-mini")]
+    [InlineData("gpt-5.6")]
+    public void GetSettingsSupport_ReasoningModel_DeclaresTemperatureUnsupportedOnly(string modelId)
+    {
+        var metadata = CreateCapability().GetSettingsSupport(modelId).ToMetadata();
+
+        metadata[AIModelMetadataKeys.ProfileSettingsUnsupported].ShouldBe("temperature");
+        metadata.ContainsKey(AIModelMetadataKeys.CapabilitySettingsUnsupported).ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("gpt-4o")]
+    [InlineData("chatgpt-4o-latest")]
+    public void GetSettingsSupport_SamplingModel_DeclaresReasoningEffortUnsupportedOnly(string modelId)
+    {
+        var metadata = CreateCapability().GetSettingsSupport(modelId).ToMetadata();
+
+        metadata[AIModelMetadataKeys.CapabilitySettingsUnsupported].ShouldBe("reasoningEffort");
+        metadata.ContainsKey(AIModelMetadataKeys.ProfileSettingsUnsupported).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetSettingsSupport_UnknownModel_DeclaresBothUnsupported()
+    {
+        // Both predicates are allow-lists that fail safe, so a model released after this package ships
+        // hides each setting rather than offering one the model may reject.
+        var metadata = CreateCapability().GetSettingsSupport("gpt-6").ToMetadata();
+
+        metadata[AIModelMetadataKeys.CapabilitySettingsUnsupported].ShouldBe("reasoningEffort");
+        metadata[AIModelMetadataKeys.ProfileSettingsUnsupported].ShouldBe("temperature");
+    }
+
+    private static OpenAIChatCapability CreateCapability()
+        => new(
+            new OpenAIProvider(new FakeProviderInfrastructure(), new MemoryCache(new MemoryCacheOptions())),
+            logger: null);
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Extensions/AIModelDescriptorExtensions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Extensions/AIModelDescriptorExtensions.cs
@@ -19,6 +19,23 @@ public static class AIModelDescriptorExtensions
     /// this is "not known to be rejected" rather than an affirmative claim of support.
     /// </returns>
     public static bool IsCapabilitySettingSupported(this AIModelDescriptor model, string fieldKey)
+        => IsSettingSupported(model, AIModelMetadataKeys.CapabilitySettingsUnsupported, fieldKey);
+
+    /// <summary>
+    /// Whether a core profile setting (e.g. <c>temperature</c>) applies to this model, per the
+    /// capability's declaration via <see cref="Core.Providers.IAICapability.GetSettingsSupport"/>.
+    /// </summary>
+    /// <param name="model">The model descriptor.</param>
+    /// <param name="fieldKey">The field key (or property name) of the setting.</param>
+    /// <returns>
+    /// <c>false</c> only when the capability explicitly declared that this model rejects the setting.
+    /// Declarations are negative, so this is "not known to be rejected" rather than an affirmative claim
+    /// of support.
+    /// </returns>
+    public static bool IsProfileSettingSupported(this AIModelDescriptor model, string fieldKey)
+        => IsSettingSupported(model, AIModelMetadataKeys.ProfileSettingsUnsupported, fieldKey);
+
+    private static bool IsSettingSupported(AIModelDescriptor model, string metadataKey, string fieldKey)
     {
         ArgumentNullException.ThrowIfNull(model);
 
@@ -27,7 +44,7 @@ public static class AIModelDescriptorExtensions
             return true;
         }
 
-        if (!model.Metadata.TryGetValue(AIModelMetadataKeys.CapabilitySettingsUnsupported, out var declared))
+        if (!model.Metadata.TryGetValue(metadataKey, out var declared))
         {
             return true;
         }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Models/AIModelMetadataKeys.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Models/AIModelMetadataKeys.cs
@@ -16,4 +16,12 @@ public static class AIModelMetadataKeys
     /// Absent when the capability has nothing to declare for the model.
     /// </summary>
     public const string CapabilitySettingsUnsupported = "capabilitySettings.unsupported";
+
+    /// <summary>
+    /// Comma-separated field keys of the core profile settings this model rejects or ignores — the
+    /// built-in settings every provider shares (<c>temperature</c> and friends), as opposed to the
+    /// provider-declared ones in <see cref="CapabilitySettingsUnsupported"/>.
+    /// Absent when the capability has nothing to declare for the model.
+    /// </summary>
+    public const string ProfileSettingsUnsupported = "profileSettings.unsupported";
 }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Models/AIModelSettingsSupport.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Models/AIModelSettingsSupport.cs
@@ -26,7 +26,9 @@ namespace Umbraco.AI.Core.Models;
 /// list is fetched from the vendor and cannot be consulted per request, so a capability that declares a
 /// setting unsupported must also refrain from sending it (see
 /// <c>AIChatCapabilityBase&lt;TSettings, TCapabilitySettings&gt;.ApplyCapabilitySettings</c>, which receives
-/// the resolved model ID for exactly that purpose). Declare and enforce from one shared predicate.
+/// the resolved model ID for exactly that purpose). For the core settings in
+/// <see cref="UnsupportedProfileSettings"/> the enforcement already exists as the provider's own
+/// request-time filter. Either way: declare and enforce from one shared predicate.
 /// </para>
 /// <para>
 /// Entries may be given as property names (<c>nameof(MySettings.ReasoningEffort)</c>) or as schema field
@@ -47,9 +49,21 @@ public sealed class AIModelSettingsSupport
     public IReadOnlyCollection<string> UnsupportedCapabilitySettings { get; init; } = [];
 
     /// <summary>
+    /// The core profile settings this model rejects or ignores, named from the capability's own settings
+    /// type (e.g. <c>nameof(AIChatProfileSettings.Temperature)</c>).
+    /// </summary>
+    /// <remarks>
+    /// These are the built-in settings every provider shares, so a model that rejects one is the case a
+    /// user is most likely to hit: the field is a permanent fixture of the profile editor rather than
+    /// something a provider opted into rendering. Declaring it lets the editor say so instead of saving a
+    /// value that is silently dropped on every request.
+    /// </remarks>
+    public IReadOnlyCollection<string> UnsupportedProfileSettings { get; init; } = [];
+
+    /// <summary>
     /// Whether this declaration says anything at all.
     /// </summary>
-    internal bool IsEmpty => UnsupportedCapabilitySettings.Count == 0;
+    internal bool IsEmpty => UnsupportedCapabilitySettings.Count == 0 && UnsupportedProfileSettings.Count == 0;
 
     /// <summary>
     /// Projects the declaration into the metadata entries carried by <see cref="AIModelDescriptor.Metadata"/>.
@@ -61,16 +75,28 @@ public sealed class AIModelSettingsSupport
     /// its descriptors with the declaration already attached instead of implementing the hook.
     /// </remarks>
     public IReadOnlyDictionary<string, string> ToMetadata()
-        => IsEmpty
-            ? new Dictionary<string, string>()
-            : new Dictionary<string, string>
+    {
+        var metadata = new Dictionary<string, string>();
+
+        Add(AIModelMetadataKeys.CapabilitySettingsUnsupported, UnsupportedCapabilitySettings);
+        Add(AIModelMetadataKeys.ProfileSettingsUnsupported, UnsupportedProfileSettings);
+
+        return metadata;
+
+        // Normalise to the same camelCase key the schema builder derives from the property name, so a
+        // declaration written as nameof(TSettings.ReasoningEffort) matches the field key. A declaration
+        // holding only blanks is silence, not an empty list, so the key stays absent.
+        void Add(string key, IReadOnlyCollection<string> declared)
+        {
+            var keys = declared
+                .Where(k => !string.IsNullOrWhiteSpace(k))
+                .Select(k => k.Trim().ToCamelCase())
+                .ToList();
+
+            if (keys.Count > 0)
             {
-                // Normalise to the same camelCase key the schema builder derives from the property name,
-                // so a declaration written as nameof(TSettings.ReasoningEffort) matches the field key.
-                [AIModelMetadataKeys.CapabilitySettingsUnsupported] = string.Join(
-                    ',',
-                    UnsupportedCapabilitySettings
-                        .Where(k => !string.IsNullOrWhiteSpace(k))
-                        .Select(k => k.Trim().ToCamelCase())),
-            };
+                metadata[key] = string.Join(',', keys);
+            }
+        }
+    }
 }

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/core/utils/model-settings.utils.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/core/utils/model-settings.utils.ts
@@ -24,7 +24,42 @@ export function isCapabilitySettingSupported(
     metadata: Record<string, string> | undefined,
     fieldKey: string,
 ): boolean {
-    const declared = metadata?.[UAI_METADATA_CAPABILITY_SETTINGS_UNSUPPORTED];
+    return isSettingSupported(metadata, UAI_METADATA_CAPABILITY_SETTINGS_UNSUPPORTED, fieldKey);
+}
+
+/**
+ * Well-known model metadata key listing the core profile settings a model rejects.
+ * @public
+ */
+export const UAI_METADATA_PROFILE_SETTINGS_UNSUPPORTED = "profileSettings.unsupported";
+
+/**
+ * Whether a core profile setting (e.g. `temperature`) applies to a model.
+ *
+ * Same channel as {@link isCapabilitySettingSupported}, for the built-in settings every provider shares
+ * rather than the ones a provider declares. Anthropic dropped `temperature` from Claude Opus 4.7 onwards
+ * and OpenAI's reasoning models restrict it the same way, so the field is a permanent fixture of the
+ * editor that some models simply do not accept.
+ *
+ * Returns `false` only when the provider explicitly declared that the model rejects the setting.
+ *
+ * @param metadata - The selected model descriptor's metadata.
+ * @param fieldKey - The field key of the setting.
+ * @public
+ */
+export function isProfileSettingSupported(
+    metadata: Record<string, string> | undefined,
+    fieldKey: string,
+): boolean {
+    return isSettingSupported(metadata, UAI_METADATA_PROFILE_SETTINGS_UNSUPPORTED, fieldKey);
+}
+
+function isSettingSupported(
+    metadata: Record<string, string> | undefined,
+    metadataKey: string,
+    fieldKey: string,
+): boolean {
+    const declared = metadata?.[metadataKey];
     if (!declared || !fieldKey) return true;
 
     return !declared

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/workspace/profile/views/profile-details-workspace-view.element.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/workspace/profile/views/profile-details-workspace-view.element.ts
@@ -6,7 +6,7 @@ import { umbBindToValidation } from "@umbraco-cms/backoffice/validation";
 import type { UUISelectEvent } from "@umbraco-cms/backoffice/external/uui";
 import type { UaiProfileDetailModel, UaiModelRef, UaiChatProfileSettings, UaiEmbeddingProfileSettings, UaiSpeechToTextProfileSettings, UaiImageGenerationProfileSettings } from "../../../types.js";
 import { isChatSettings, isEmbeddingSettings, isSpeechToTextSettings, isImageGenerationSettings } from "../../../types.js";
-import { UaiPartialUpdateCommand, isCapabilitySettingSupported } from "../../../../core/index.js";
+import { UaiPartialUpdateCommand, isCapabilitySettingSupported, isProfileSettingSupported } from "../../../../core/index.js";
 import { UAI_PROFILE_WORKSPACE_CONTEXT } from "../profile-workspace.context-token.js";
 import type { UaiConnectionItemModel, UaiModelDescriptorModel } from "../../../../connection/types.js";
 import { UaiConnectionCapabilityRepository, UaiConnectionModelsRepository } from "../../../../connection/repository";
@@ -14,6 +14,11 @@ import { UaiProviderDetailRepository } from "../../../../provider/repository/det
 import type { UaiProviderDetailModel } from "../../../../provider/types.js";
 import type { UaiEditableModelSchemaModel } from "../../../../core/types.js";
 import type { UaiModelEditorChangeEventDetail } from "../../../../core/components/exports.js";
+
+/**
+ * Field key of the core temperature setting, as providers declare it in the model metadata.
+ */
+const UAI_TEMPERATURE_FIELD_KEY = "temperature";
 
 /**
  * Workspace view for Profile details.
@@ -41,6 +46,28 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
     @state()
     private _loadingModels = false;
 
+    #observedTemperatureEditor?: Element;
+    #observedTemperatureEditorWidth = 0;
+
+    /**
+     * Keeps the temperature slider's step markers aligned with its track.
+     *
+     * `uui-slider` measures the track once, when it first renders, and thereafter only when the window
+     * resizes — so any later width change leaves the markers spaced for the old width, running past the
+     * end of the track. A scrollbar appearing as the editor fills out is enough to trigger it. Re-firing
+     * the event the slider already listens for is the supported way to make it measure again.
+     *
+     * The container is observed rather than the slider itself: `umb-input-slider` declares no display on
+     * its host, so it is an inline element, and a ResizeObserver reports nothing for those.
+     */
+    #temperatureResizeObserver = new ResizeObserver((entries) => {
+        const width = Math.round(entries[0]?.contentRect.width ?? 0);
+        if (width === 0 || width === this.#observedTemperatureEditorWidth) return;
+
+        this.#observedTemperatureEditorWidth = width;
+        window.dispatchEvent(new Event("resize"));
+    });
+
     constructor() {
         super();
         this.consumeContext(UAI_PROFILE_WORKSPACE_CONTEXT, (context) => {
@@ -61,6 +88,26 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
                 });
             }
         });
+    }
+
+    override disconnectedCallback() {
+        this.#temperatureResizeObserver.disconnect();
+        super.disconnectedCallback();
+    }
+
+    protected override updated(changedProperties: Map<string, unknown>) {
+        super.updated(changedProperties);
+
+        const editor = this.shadowRoot?.querySelector(".temperature-editor") ?? undefined;
+        if (editor === this.#observedTemperatureEditor) return;
+
+        if (this.#observedTemperatureEditor) {
+            this.#temperatureResizeObserver.unobserve(this.#observedTemperatureEditor);
+        }
+
+        this.#observedTemperatureEditor = editor;
+        this.#observedTemperatureEditorWidth = 0;
+        if (editor) this.#temperatureResizeObserver.observe(editor);
     }
 
     /**
@@ -147,8 +194,9 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
         // Drop any stored provider settings the newly selected model doesn't accept. Without this they
         // stay persisted but invisible in the editor, and still get sent on every request.
         const capabilitySettings = this.#pruneCapabilitySettings(modelId);
+        const settings = this.#pruneProfileSettings(modelId);
         this.#workspaceContext?.handleCommand(
-            new UaiPartialUpdateCommand<UaiProfileDetailModel>({ model, capabilitySettings }, "model"),
+            new UaiPartialUpdateCommand<UaiProfileDetailModel>({ model, capabilitySettings, settings }, "model"),
         );
     }
 
@@ -169,6 +217,22 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
     }
 
     /**
+     * Returns the stored capability settings with the core settings the given model declares unsupported
+     * cleared, or `undefined` when nothing needs to change (which the partial update command skips).
+     *
+     * Same reasoning as {@link #pruneCapabilitySettings}: a temperature the model rejects would sit in the
+     * profile with no field to show it and be dropped on every request.
+     */
+    #pruneProfileSettings(modelId: string): UaiChatProfileSettings | undefined {
+        const chatSettings = this.#getChatSettings();
+        if (chatSettings?.temperature === null || chatSettings?.temperature === undefined) return undefined;
+
+        if (isProfileSettingSupported(this.#getModelMetadata(modelId), UAI_TEMPERATURE_FIELD_KEY)) return undefined;
+
+        return { ...chatSettings, temperature: null };
+    }
+
+    /**
      * Gets the metadata for a model from the loaded model list, which carries the provider's per-model
      * settings declarations alongside the display name.
      */
@@ -182,6 +246,14 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
         const target = event.target as HTMLInputElement;
         const temperature = target.value ? parseFloat(target.value) : null;
         this.#updateChatSettings({ temperature });
+    }
+
+    /**
+     * Returns temperature to unset, so the provider's own default applies again.
+     */
+    #onTemperatureClear(event: Event) {
+        event.stopPropagation();
+        this.#updateChatSettings({ temperature: null });
     }
 
     #onMaxTokensChange(event: Event) {
@@ -364,20 +436,7 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
 
         return html`
             <uui-box headline="System Settings">
-                <umb-property-layout
-                    label="Temperature"
-                    description="Controls randomness (0.0 = deterministic, 2.0 = very random)"
-                >
-                    <umb-input-slider
-                        slot="editor"
-                        label="Temperature"
-                        .valueLow=${chatSettings?.temperature ?? 1}
-                        .min=${0}
-                        .max=${2}
-                        .step=${0.1}
-                        @change=${this.#onTemperatureChange}
-                    ></umb-input-slider>
-                </umb-property-layout>
+                ${this.#renderTemperature(chatSettings)}
 
                 <umb-property-layout label="Max Tokens" description="Maximum number of tokens to generate">
                     <uui-input
@@ -410,6 +469,53 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
                 </umb-property-layout>
 
             </uui-box>
+        `;
+    }
+
+    /**
+     * Renders the temperature control, in the same two states the provider-declared settings use: absent
+     * when the selected model rejects the setting, otherwise editable.
+     *
+     * An editable slider cannot express "unset" on its own — with no value it parks at its minimum, which
+     * reads as a deliberate 0 — so an unset slider is dimmed, and the clear button beside it is how the
+     * value gets given back. Nothing is stored until the slider is moved, so an untouched profile keeps its
+     * null. Any value already stored is cleared when a model that rejects it is selected, so hiding the
+     * field never hides a value that is still being sent.
+     */
+    #renderTemperature(chatSettings: UaiChatProfileSettings | null) {
+        const metadata = this.#getModelMetadata(this._model?.model?.modelId);
+        if (!isProfileSettingSupported(metadata, UAI_TEMPERATURE_FIELD_KEY)) {
+            return nothing;
+        }
+
+        const temperature = chatSettings?.temperature ?? null;
+
+        return html`
+            <umb-property-layout
+                label="Temperature"
+                description="Controls randomness (0.0 = deterministic, 2.0 = very random). Clear it to use the provider's default."
+            >
+                <div slot="editor" class="temperature-editor">
+                    <umb-input-slider
+                        class=${temperature === null ? "unset" : ""}
+                        label="Temperature"
+                        .valueLow=${temperature ?? undefined}
+                        .min=${0}
+                        .max=${2}
+                        .step=${0.1}
+                        @change=${this.#onTemperatureChange}
+                    ></umb-input-slider>
+                    <uui-button
+                        compact
+                        look="secondary"
+                        label="Clear temperature"
+                        title="Clear temperature"
+                        @click=${this.#onTemperatureClear}
+                    >
+                        <uui-icon name="icon-trash"></uui-icon>
+                    </uui-button>
+                </div>
+            </umb-property-layout>
         `;
     }
 
@@ -696,6 +802,28 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
             uui-input,
             umb-input-slider {
                 width: 100%;
+            }
+
+            /* The clear button is taken out of flow with room reserved for it, rather than laid out as a
+               flex sibling: the slider measures its own width to decide whether the step markers fit, it
+               does that once before a flex row has settled, and only ever recomputes on a window resize —
+               so a slider sized by flex loses its markers. A plain full-width slider measures correctly. */
+            .temperature-editor {
+                position: relative;
+                padding-right: calc(30px + var(--uui-size-space-2));
+            }
+            .temperature-editor uui-button {
+                position: absolute;
+                right: 0;
+                /* Centred on the track, which sits at the top of the slider's box above the row it
+                   reserves for step labels — not on the box itself. */
+                top: 9px;
+                transform: translateY(-50%);
+            }
+            /* Dimmed while no value is stored, so the slider's resting position at its minimum doesn't
+               read as the profile's temperature. */
+            .temperature-editor umb-input-slider.unset {
+                opacity: 0.5;
             }
 
             uui-textarea {

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Providers/CapabilitySettingsSupportTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Providers/CapabilitySettingsSupportTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.AI;
 using Umbraco.AI.Core.Models;
+using Umbraco.AI.Core.Profiles;
 using Umbraco.AI.Core.Providers;
 using Umbraco.AI.Extensions;
 using Umbraco.AI.Tests.Common.Fakes;
@@ -90,6 +91,52 @@ public class CapabilitySettingsSupportTests
         plain.Metadata[AIModelMetadataKeys.CapabilitySettingsUnsupported].ShouldBe("reasoningEffort");
     }
 
+    [Fact]
+    public async Task GetModelsAsync_ModelRejectsCoreProfileSetting_ProjectsItSeparately()
+    {
+        // Arrange
+        IAICapability capability = new DeclaringChatCapability();
+
+        // Act
+        var models = await capability.GetModelsAsync(Settings);
+
+        // Assert — the two declarations travel under their own keys, so neither implies the other
+        var restricted = models.Single(m => m.Model.ModelId == "no-temperature-model");
+        restricted.Metadata[AIModelMetadataKeys.ProfileSettingsUnsupported].ShouldBe("temperature");
+        restricted.Metadata.ContainsKey(AIModelMetadataKeys.CapabilitySettingsUnsupported).ShouldBeFalse();
+        restricted.IsProfileSettingSupported("temperature").ShouldBeFalse();
+        restricted.IsCapabilitySettingSupported("reasoningEffort").ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GetModelsAsync_ModelRejectsBoth_ProjectsBothKeys()
+    {
+        // Arrange
+        IAICapability capability = new DeclaringChatCapability();
+
+        // Act
+        var models = await capability.GetModelsAsync(Settings);
+
+        // Assert
+        var restricted = models.Single(m => m.Model.ModelId == "restricted-model");
+        restricted.Metadata[AIModelMetadataKeys.CapabilitySettingsUnsupported].ShouldBe("reasoningEffort");
+        restricted.Metadata[AIModelMetadataKeys.ProfileSettingsUnsupported].ShouldBe("temperature");
+    }
+
+    [Fact]
+    public void ToMetadata_DeclarationHoldsOnlyBlanks_EmitsNoKey()
+    {
+        // A list of blanks is silence, not a claim that nothing is supported — emitting the key with an
+        // empty value would leave consumers splitting an empty string.
+        var support = new AIModelSettingsSupport
+        {
+            UnsupportedCapabilitySettings = ["  "],
+            UnsupportedProfileSettings = [""],
+        };
+
+        support.ToMetadata().ShouldBeEmpty();
+    }
+
     #endregion
 
     #region Reading declarations back
@@ -121,6 +168,30 @@ public class CapabilitySettingsSupportTests
         model.IsCapabilitySettingSupported(fieldKey).ShouldBeFalse();
     }
 
+    [Fact]
+    public void IsProfileSettingSupported_ReadsItsOwnKeyOnly()
+    {
+        // A capability-settings declaration says nothing about the core settings, and vice versa
+        var model = Describe("temperature");
+
+        model.IsCapabilitySettingSupported("temperature").ShouldBeFalse();
+        model.IsProfileSettingSupported("temperature").ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("temperature")]
+    [InlineData("Temperature")]
+    [InlineData(" temperature ")]
+    public void IsProfileSettingSupported_DeclaredKeyRegardlessOfCasingOrWhitespace_ReturnsFalse(string fieldKey)
+    {
+        var model = new AIModelDescriptor(
+            new AIModelRef("test", "some-model"),
+            "Some Model",
+            new Dictionary<string, string> { [AIModelMetadataKeys.ProfileSettingsUnsupported] = "temperature" });
+
+        model.IsProfileSettingSupported(fieldKey).ShouldBeFalse();
+    }
+
     #endregion
 
     private static AIModelDescriptor Describe(string unsupported)
@@ -130,20 +201,34 @@ public class CapabilitySettingsSupportTests
             new Dictionary<string, string> { [AIModelMetadataKeys.CapabilitySettingsUnsupported] = unsupported });
 
     /// <summary>
-    /// A capability that rejects reasoning effort on one of its two models, exercising the projection
-    /// performed by <see cref="AICapabilityBase{TSettings}"/>.
+    /// A capability whose four models cover each combination of declaration — neither setting, a
+    /// provider-declared one, a core one, and both — exercising the projection performed by
+    /// <see cref="AICapabilityBase{TSettings}"/>.
     /// </summary>
     private sealed class DeclaringChatCapability()
         : AIChatCapabilityBase<FakeProviderSettings, DeclaringChatCapability.CapabilitySettings>(
             new FakeAIProvider())
     {
         public override AIModelSettingsSupport GetSettingsSupport(string modelId)
-            => modelId == "reasoning-model"
-                ? AIModelSettingsSupport.Default
-                : new AIModelSettingsSupport
-                {
-                    UnsupportedCapabilitySettings = [nameof(CapabilitySettings.ReasoningEffort)],
-                };
+        {
+            var rejectsReasoningEffort = modelId is "plain-model" or "restricted-model";
+            var rejectsTemperature = modelId is "no-temperature-model" or "restricted-model";
+
+            if (!rejectsReasoningEffort && !rejectsTemperature)
+            {
+                return AIModelSettingsSupport.Default;
+            }
+
+            return new AIModelSettingsSupport
+            {
+                UnsupportedCapabilitySettings = rejectsReasoningEffort
+                    ? [nameof(CapabilitySettings.ReasoningEffort)]
+                    : [],
+                UnsupportedProfileSettings = rejectsTemperature
+                    ? [nameof(AIChatProfileSettings.Temperature)]
+                    : [],
+            };
+        }
 
         protected override Task<IReadOnlyList<AIModelDescriptor>> GetModelsAsync(
             FakeProviderSettings settings,
@@ -155,6 +240,8 @@ public class CapabilitySettingsSupportTests
                     new AIModelRef("test", "plain-model"),
                     "Plain Model",
                     new Dictionary<string, string> { ["custom.key"] = "custom-value" }),
+                new AIModelDescriptor(new AIModelRef("test", "no-temperature-model"), "No Temperature Model"),
+                new AIModelDescriptor(new AIModelRef("test", "restricted-model"), "Restricted Model"),
             ]);
 
         protected override IChatClient CreateClient(FakeProviderSettings settings, string? modelId)


### PR DESCRIPTION
Backport of #273 to the v17 line — item 3 of #266.

## What it fixes

The profile editor rendered the temperature slider as `.valueLow=${chatSettings?.temperature ?? 1}`, so a **null temperature displayed as 1**. A slider has no empty position, so an untouched editor looked identical to a deliberate choice, the first nudge persisted a value nobody picked, and there was no way to clear it afterwards. That is how the `temperature` 400 reported on #256 reached people who had never configured a temperature.

The editor now shows the state rather than inventing a value:

| State | Rendering |
|---|---|
| Value set | Slider at the value, trash button beside it |
| Unset | Slider dimmed at its minimum, trash button inert |
| Model rejects it | Field absent entirely |

Nothing is stored until the slider moves. A stored temperature is cleared when a model that rejects it is selected, so a hidden field never leaves a value going out on requests.

Backend side, `AIModelSettingsSupport.UnsupportedProfileSettings` extends the per-model declaration channel that #270 brought to this line — it carried only provider-declared capability settings, and temperature is a core profile setting. OpenAI, Anthropic and Amazon declare it from the same predicate their request-time sampling filter already uses.

Also fixes the slider's step markers, which are sized once at first render and re-measured only on a window `resize`, so a scrollbar appearing afterwards left them running past the end of the track.

Full rationale, the review notes on the ResizeObserver and the flex-vs-absolute layout, and what remains open on #266 are all in **#273** — this branch is a clean cherry-pick of that commit.

## Verification (this line)

Cherry-picked with no conflicts. Built and tested here:

```
Umbraco.AI            1,024   (994 unit + 30 integration)
Umbraco.AI.OpenAI        45
Umbraco.AI.Anthropic     77
Umbraco.AI.Amazon        27
```

Frontend: `npm run build:core` clean.

Counts sit below v18's for OpenAI and Anthropic because the sampling-parameter wire tests are still missing on this line — that gap is #272's, not this PR's.

The three-state behaviour was driven in the backoffice and checked against the database on the v18 branch (set a value → stored; clear → `null`; reasoning model → field and stored value gone). Not repeated here, since the source is identical and the v17-specific risk is compilation, which the suites above cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
