### PR TITLE
feat(core,providers): Extend capability settings to every capability

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Core/Embeddings/AIEmbeddingGeneratorFactory.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Embeddings/AIEmbeddingGeneratorFactory.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.AI;
 using Umbraco.AI.Core.Connections;
+using Umbraco.AI.Core.EditableModels;
 using Umbraco.AI.Core.Profiles;
 using Umbraco.AI.Core.Providers;
 using Umbraco.AI.Core.RuntimeContext;
@@ -13,19 +14,22 @@ internal sealed class AIEmbeddingGeneratorFactory : IAIEmbeddingGeneratorFactory
     private readonly IAIRuntimeContextAccessor _runtimeContextAccessor;
     private readonly IAIRuntimeContextScopeProvider _scopeProvider;
     private readonly AIRuntimeContextContributorCollection _contributors;
+    private readonly IAIEditableModelResolver _modelResolver;
 
     public AIEmbeddingGeneratorFactory(
         IAIConnectionService connectionService,
         AIEmbeddingMiddlewareCollection middleware,
         IAIRuntimeContextAccessor runtimeContextAccessor,
         IAIRuntimeContextScopeProvider scopeProvider,
-        AIRuntimeContextContributorCollection contributors)
+        AIRuntimeContextContributorCollection contributors,
+        IAIEditableModelResolver modelResolver)
     {
         _connectionService = connectionService;
         _middleware = middleware;
         _runtimeContextAccessor = runtimeContextAccessor;
         _scopeProvider = scopeProvider;
         _contributors = contributors;
+        _modelResolver = modelResolver;
     }
 
     public async Task<IEmbeddingGenerator<string, Embedding<float>>> CreateGeneratorAsync(
@@ -35,8 +39,19 @@ internal sealed class AIEmbeddingGeneratorFactory : IAIEmbeddingGeneratorFactory
         // Get configured provider with resolved settings
         var (embeddingCapability, provider) = await GetConfiguredEmbeddingCapabilityAsync(profile, cancellationToken);
 
-        // Create base generator from provider with the profile's model
-        var generator = await embeddingCapability.CreateGeneratorAsync(profile.Model.ModelId, cancellationToken);
+        // Resolve any provider-declared capability settings through the same editable-model pipeline
+        // connections use ($-config resolution + validation + typing), so the provider receives a
+        // strongly-typed, resolved object rather than a raw stored bag.
+        var resolvedCapabilitySettings = _modelResolver.ResolveCapabilitySettings(
+            provider,
+            profile.Capability,
+            profile.CapabilitySettings);
+
+        // Create base generator from provider with the profile's model and resolved capability settings
+        var generator = await embeddingCapability.CreateGeneratorAsync(
+            resolvedCapabilitySettings,
+            profile.Model.ModelId,
+            cancellationToken);
 
         // Wrap innermost so SDK exceptions are classified against the originating provider before
         // any middleware sees them.

--- a/Umbraco.AI/src/Umbraco.AI.Core/ImageGeneration/AIImageGeneratorFactory.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/ImageGeneration/AIImageGeneratorFactory.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.AI;
 using Umbraco.AI.Core.Connections;
+using Umbraco.AI.Core.EditableModels;
 using Umbraco.AI.Core.Profiles;
 using Umbraco.AI.Core.Providers;
 using Umbraco.AI.Core.RuntimeContext;
@@ -16,19 +17,22 @@ internal sealed class AIImageGeneratorFactory : IAIImageGeneratorFactory
     private readonly IAIRuntimeContextAccessor _runtimeContextAccessor;
     private readonly IAIRuntimeContextScopeProvider _scopeProvider;
     private readonly AIRuntimeContextContributorCollection _contributors;
+    private readonly IAIEditableModelResolver _modelResolver;
 
     public AIImageGeneratorFactory(
         IAIConnectionService connectionService,
         AIImageGenerationMiddlewareCollection middleware,
         IAIRuntimeContextAccessor runtimeContextAccessor,
         IAIRuntimeContextScopeProvider scopeProvider,
-        AIRuntimeContextContributorCollection contributors)
+        AIRuntimeContextContributorCollection contributors,
+        IAIEditableModelResolver modelResolver)
     {
         _connectionService = connectionService;
         _middleware = middleware;
         _runtimeContextAccessor = runtimeContextAccessor;
         _scopeProvider = scopeProvider;
         _contributors = contributors;
+        _modelResolver = modelResolver;
     }
 
     public async Task<IImageGenerator> CreateGeneratorAsync(
@@ -38,8 +42,19 @@ internal sealed class AIImageGeneratorFactory : IAIImageGeneratorFactory
         // Get configured provider with resolved settings
         var (imageGeneratorCapability, provider) = await GetConfiguredImageGeneratorCapabilityAsync(profile, cancellationToken);
 
-        // Create base generator from provider with the profile's model
-        var generator = await imageGeneratorCapability.CreateGeneratorAsync(profile.Model.ModelId, cancellationToken);
+        // Resolve any provider-declared capability settings through the same editable-model pipeline
+        // connections use ($-config resolution + validation + typing), so the provider receives a
+        // strongly-typed, resolved object rather than a raw stored bag.
+        var resolvedCapabilitySettings = _modelResolver.ResolveCapabilitySettings(
+            provider,
+            profile.Capability,
+            profile.CapabilitySettings);
+
+        // Create base generator from provider with the profile's model and resolved capability settings
+        var generator = await imageGeneratorCapability.CreateGeneratorAsync(
+            resolvedCapabilitySettings,
+            profile.Model.ModelId,
+            cancellationToken);
 
         // Wrap innermost so SDK exceptions are classified against the originating provider before
         // any middleware sees them.

--- a/Umbraco.AI/src/Umbraco.AI.Core/Providers/AIConfiguredCapability.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Providers/AIConfiguredCapability.cs
@@ -41,6 +41,13 @@ internal sealed class AIConfiguredEmbeddingCapability(IAIEmbeddingCapability inn
          => inner.CreateGeneratorAsync(settings, modelId, cancellationToken);
 
     /// <inheritdoc />
+    public Task<IEmbeddingGenerator<string, Embedding<float>>> CreateGeneratorAsync(
+        object? capabilitySettings,
+        string? modelId,
+        CancellationToken cancellationToken)
+        => inner.CreateGeneratorAsync(settings, capabilitySettings, modelId, cancellationToken);
+
+    /// <inheritdoc />
     public Task<IReadOnlyList<AIModelDescriptor>> GetModelsAsync(CancellationToken cancellationToken = default)
         => inner.GetModelsAsync(settings, cancellationToken);
 }
@@ -59,6 +66,13 @@ internal sealed class AIConfiguredSpeechToTextCapability(IAISpeechToTextCapabili
         => inner.CreateClientAsync(settings, modelId, cancellationToken);
 
     /// <inheritdoc />
+    public Task<ISpeechToTextClient> CreateClientAsync(
+        object? capabilitySettings,
+        string? modelId,
+        CancellationToken cancellationToken)
+        => inner.CreateClientAsync(settings, capabilitySettings, modelId, cancellationToken);
+
+    /// <inheritdoc />
     public Task<IReadOnlyList<AIModelDescriptor>> GetModelsAsync(CancellationToken cancellationToken = default)
         => inner.GetModelsAsync(settings, cancellationToken);
 }
@@ -75,6 +89,13 @@ internal sealed class AIConfiguredImageGeneratorCapability(IAIImageGeneratorCapa
     /// <inheritdoc />
     public Task<IImageGenerator> CreateGeneratorAsync(string? modelId = null, CancellationToken cancellationToken = default)
         => inner.CreateGeneratorAsync(settings, modelId, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<IImageGenerator> CreateGeneratorAsync(
+        object? capabilitySettings,
+        string? modelId,
+        CancellationToken cancellationToken)
+        => inner.CreateGeneratorAsync(settings, capabilitySettings, modelId, cancellationToken);
 
     /// <inheritdoc />
     public Task<IReadOnlyList<AIModelDescriptor>> GetModelsAsync(CancellationToken cancellationToken = default)

--- a/Umbraco.AI/src/Umbraco.AI.Core/Providers/CapabilitySettingsEmbeddingGenerator.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Providers/CapabilitySettingsEmbeddingGenerator.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.AI;
+
+namespace Umbraco.AI.Core.Providers;
+
+/// <summary>
+/// Embedding generator decorator that applies provider-declared capability settings onto each request's
+/// <see cref="EmbeddingGenerationOptions"/> before delegating to the inner generator.
+/// </summary>
+/// <remarks>
+/// Created by <see cref="AIEmbeddingCapabilityBase{TSettings, TCapabilitySettings}"/> with the resolved,
+/// typed capability settings baked in. The caller's <see cref="EmbeddingGenerationOptions"/> instance is
+/// never mutated; a per-request copy is used.
+/// </remarks>
+/// <typeparam name="TCapabilitySettings">The provider-declared capability settings type.</typeparam>
+internal sealed class CapabilitySettingsEmbeddingGenerator<TCapabilitySettings>
+    : DelegatingEmbeddingGenerator<string, Embedding<float>>
+    where TCapabilitySettings : class
+{
+    private readonly TCapabilitySettings _capabilitySettings;
+    private readonly string? _boundModelId;
+    private readonly Action<TCapabilitySettings, string?, EmbeddingGenerationOptions> _apply;
+
+    public CapabilitySettingsEmbeddingGenerator(
+        IEmbeddingGenerator<string, Embedding<float>> innerGenerator,
+        TCapabilitySettings capabilitySettings,
+        string? boundModelId,
+        Action<TCapabilitySettings, string?, EmbeddingGenerationOptions> apply)
+        : base(innerGenerator)
+    {
+        _capabilitySettings = capabilitySettings;
+        _boundModelId = boundModelId;
+        _apply = apply;
+    }
+
+    /// <inheritdoc />
+    public override Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(
+        IEnumerable<string> values,
+        EmbeddingGenerationOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => base.GenerateAsync(values, Apply(options), cancellationToken);
+
+    private EmbeddingGenerationOptions Apply(EmbeddingGenerationOptions? options)
+    {
+        // Clone so the caller's options instance is never mutated.
+        var effective = options?.Clone() ?? new EmbeddingGenerationOptions();
+
+        // Resolve the model the request will actually run against so the provider can gate settings the
+        // model rejects, falling back to the model the generator was created for.
+        _apply(_capabilitySettings, effective.ModelId ?? _boundModelId, effective);
+        return effective;
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Providers/CapabilitySettingsImageGenerator.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Providers/CapabilitySettingsImageGenerator.cs
@@ -1,0 +1,56 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.AI;
+using Umbraco.AI.Core.ImageGeneration;
+
+#pragma warning disable MEAI001 // IImageGenerator is experimental in M.E.AI
+
+namespace Umbraco.AI.Core.Providers;
+
+/// <summary>
+/// Image generator decorator that applies provider-declared capability settings onto each request's
+/// <see cref="ImageGenerationOptions"/> before delegating to the inner generator.
+/// </summary>
+/// <remarks>
+/// Created by <see cref="AIImageGeneratorCapabilityBase{TSettings, TCapabilitySettings}"/> with the
+/// resolved, typed capability settings baked in. The caller's <see cref="ImageGenerationOptions"/> instance
+/// is never mutated; a per-request copy is used.
+/// </remarks>
+/// <typeparam name="TCapabilitySettings">The provider-declared capability settings type.</typeparam>
+[Experimental(AIImageGenerationDiagnostics.DiagnosticId)]
+internal sealed class CapabilitySettingsImageGenerator<TCapabilitySettings> : DelegatingImageGenerator
+    where TCapabilitySettings : class
+{
+    private readonly TCapabilitySettings _capabilitySettings;
+    private readonly string? _boundModelId;
+    private readonly Action<TCapabilitySettings, string?, ImageGenerationOptions> _apply;
+
+    public CapabilitySettingsImageGenerator(
+        IImageGenerator innerGenerator,
+        TCapabilitySettings capabilitySettings,
+        string? boundModelId,
+        Action<TCapabilitySettings, string?, ImageGenerationOptions> apply)
+        : base(innerGenerator)
+    {
+        _capabilitySettings = capabilitySettings;
+        _boundModelId = boundModelId;
+        _apply = apply;
+    }
+
+    /// <inheritdoc />
+    public override Task<ImageGenerationResponse> GenerateAsync(
+        ImageGenerationRequest request,
+        ImageGenerationOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => base.GenerateAsync(request, Apply(options), cancellationToken);
+
+    private ImageGenerationOptions Apply(ImageGenerationOptions? options)
+    {
+        // Clone so the caller's options instance is never mutated.
+        var effective = options?.Clone() ?? new ImageGenerationOptions();
+
+        // Resolve the model the request will actually run against so the provider can gate settings the
+        // model rejects, falling back to the model the generator was created for.
+        _apply(_capabilitySettings, effective.ModelId ?? _boundModelId, effective);
+        return effective;
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Providers/CapabilitySettingsSpeechToTextClient.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Providers/CapabilitySettingsSpeechToTextClient.cs
@@ -1,0 +1,60 @@
+using Microsoft.Extensions.AI;
+
+#pragma warning disable MEAI001 // ISpeechToTextClient is experimental in M.E.AI
+
+namespace Umbraco.AI.Core.Providers;
+
+/// <summary>
+/// Speech-to-text client decorator that applies provider-declared capability settings onto each request's
+/// <see cref="SpeechToTextOptions"/> before delegating to the inner client.
+/// </summary>
+/// <remarks>
+/// Created by <see cref="AISpeechToTextCapabilityBase{TSettings, TCapabilitySettings}"/> with the resolved,
+/// typed capability settings baked in. The caller's <see cref="SpeechToTextOptions"/> instance is never
+/// mutated; a per-request copy is used.
+/// </remarks>
+/// <typeparam name="TCapabilitySettings">The provider-declared capability settings type.</typeparam>
+internal sealed class CapabilitySettingsSpeechToTextClient<TCapabilitySettings> : DelegatingSpeechToTextClient
+    where TCapabilitySettings : class
+{
+    private readonly TCapabilitySettings _capabilitySettings;
+    private readonly string? _boundModelId;
+    private readonly Action<TCapabilitySettings, string?, SpeechToTextOptions> _apply;
+
+    public CapabilitySettingsSpeechToTextClient(
+        ISpeechToTextClient innerClient,
+        TCapabilitySettings capabilitySettings,
+        string? boundModelId,
+        Action<TCapabilitySettings, string?, SpeechToTextOptions> apply)
+        : base(innerClient)
+    {
+        _capabilitySettings = capabilitySettings;
+        _boundModelId = boundModelId;
+        _apply = apply;
+    }
+
+    /// <inheritdoc />
+    public override Task<SpeechToTextResponse> GetTextAsync(
+        Stream audioSpeechStream,
+        SpeechToTextOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => base.GetTextAsync(audioSpeechStream, Apply(options), cancellationToken);
+
+    /// <inheritdoc />
+    public override IAsyncEnumerable<SpeechToTextResponseUpdate> GetStreamingTextAsync(
+        Stream audioSpeechStream,
+        SpeechToTextOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => base.GetStreamingTextAsync(audioSpeechStream, Apply(options), cancellationToken);
+
+    private SpeechToTextOptions Apply(SpeechToTextOptions? options)
+    {
+        // Clone so the caller's options instance is never mutated.
+        var effective = options?.Clone() ?? new SpeechToTextOptions();
+
+        // Resolve the model the request will actually run against so the provider can gate settings the
+        // model rejects, falling back to the model the client was created for.
+        _apply(_capabilitySettings, effective.ModelId ?? _boundModelId, effective);
+        return effective;
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Providers/IAICapability.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Providers/IAICapability.cs
@@ -133,6 +133,23 @@ public interface IAISpeechToTextCapability : IAICapability
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A configured speech-to-text client.</returns>
     Task<ISpeechToTextClient> CreateClientAsync(object? settings = null, string? modelId = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a speech-to-text client with the provided connection settings and resolved,
+    /// provider-declared capability settings.
+    /// </summary>
+    /// <param name="settings">Provider-specific connection settings (e.g., API key). Must be resolved (not a raw <see cref="JsonElement"/>).</param>
+    /// <param name="capabilitySettings">The resolved, typed capability settings, or <c>null</c> when the profile declares none. Must be resolved (not a raw <see cref="JsonElement"/>).</param>
+    /// <param name="modelId">Optional model ID to use. If null, the provider's default model is used.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A configured speech-to-text client.</returns>
+    /// <remarks>
+    /// Default implementation ignores <paramref name="capabilitySettings"/> and delegates to
+    /// <see cref="CreateClientAsync(object?, string?, CancellationToken)"/> so existing capabilities keep working.
+    /// The two-parameter <c>AISpeechToTextCapabilityBase&lt;TSettings, TCapabilitySettings&gt;</c> overrides this to apply them per request.
+    /// </remarks>
+    Task<ISpeechToTextClient> CreateClientAsync(object? settings, object? capabilitySettings, string? modelId, CancellationToken cancellationToken)
+        => CreateClientAsync(settings, modelId, cancellationToken);
 }
 
 /// <summary>
@@ -148,6 +165,27 @@ public interface IAIEmbeddingCapability : IAICapability
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A configured embedding generator.</returns>
     Task<IEmbeddingGenerator<string, Embedding<float>>> CreateGeneratorAsync(object? settings, string? modelId = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates an embedding generator with the provided connection settings and resolved,
+    /// provider-declared capability settings.
+    /// </summary>
+    /// <param name="settings">Provider-specific connection settings (e.g., API key). Must be resolved (not a raw <see cref="JsonElement"/>).</param>
+    /// <param name="capabilitySettings">The resolved, typed capability settings, or <c>null</c> when the profile declares none. Must be resolved (not a raw <see cref="JsonElement"/>).</param>
+    /// <param name="modelId">Optional model ID to use. If null, the provider's default model is used.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A configured embedding generator.</returns>
+    /// <remarks>
+    /// Default implementation ignores <paramref name="capabilitySettings"/> and delegates to
+    /// <see cref="CreateGeneratorAsync(object?, string?, CancellationToken)"/> so existing capabilities keep working.
+    /// The two-parameter <c>AIEmbeddingCapabilityBase&lt;TSettings, TCapabilitySettings&gt;</c> overrides this to apply them per request.
+    /// </remarks>
+    Task<IEmbeddingGenerator<string, Embedding<float>>> CreateGeneratorAsync(
+        object? settings,
+        object? capabilitySettings,
+        string? modelId,
+        CancellationToken cancellationToken)
+        => CreateGeneratorAsync(settings, modelId, cancellationToken);
 }
 
 /// <summary>
@@ -164,6 +202,27 @@ public interface IAIImageGeneratorCapability : IAICapability
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A configured image generator.</returns>
     Task<IImageGenerator> CreateGeneratorAsync(object? settings = null, string? modelId = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates an image generator with the provided connection settings and resolved, provider-declared
+    /// capability settings.
+    /// </summary>
+    /// <param name="settings">Provider-specific connection settings (e.g., API key). Must be resolved (not a raw <see cref="JsonElement"/>).</param>
+    /// <param name="capabilitySettings">The resolved, typed capability settings, or <c>null</c> when the profile declares none. Must be resolved (not a raw <see cref="JsonElement"/>).</param>
+    /// <param name="modelId">Optional model ID to use. If null, the provider's default model is used.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A configured image generator.</returns>
+    /// <remarks>
+    /// Default implementation ignores <paramref name="capabilitySettings"/> and delegates to
+    /// <see cref="CreateGeneratorAsync(object?, string?, CancellationToken)"/> so existing capabilities keep working.
+    /// The two-parameter <c>AIImageGeneratorCapabilityBase&lt;TSettings, TCapabilitySettings&gt;</c> overrides this to apply them per request.
+    /// </remarks>
+    Task<IImageGenerator> CreateGeneratorAsync(
+        object? settings,
+        object? capabilitySettings,
+        string? modelId,
+        CancellationToken cancellationToken)
+        => CreateGeneratorAsync(settings, modelId, cancellationToken);
 }
 
 /// <summary>
@@ -473,6 +532,71 @@ public abstract class AIEmbeddingCapabilityBase<TSettings>(IAIProvider provider)
 }
 
 /// <summary>
+/// Base implementation of an AI embedding capability with both provider-specific connection settings and
+/// provider-declared capability settings.
+/// </summary>
+/// <typeparam name="TSettings">The provider-specific connection settings type.</typeparam>
+/// <typeparam name="TCapabilitySettings">The provider-declared capability settings type (a POCO with <c>[AIField]</c> properties).</typeparam>
+/// <remarks>
+/// Derive from this (instead of <see cref="AIEmbeddingCapabilityBase{TSettings}"/>) to let a provider
+/// surface extra per-profile settings. The base exposes the schema hook (<see cref="CapabilitySettingsType"/>)
+/// and applies the resolved settings to every request's <see cref="EmbeddingGenerationOptions"/> via
+/// <see cref="ApplyCapabilitySettings"/>; the provider implements only that typed translation.
+/// </remarks>
+public abstract class AIEmbeddingCapabilityBase<TSettings, TCapabilitySettings>(IAIProvider provider)
+    : AIEmbeddingCapabilityBase<TSettings>(provider), IAIEmbeddingCapability
+    where TSettings : class
+    where TCapabilitySettings : class, new()
+{
+    /// <inheritdoc />
+    public sealed override Type? CapabilitySettingsType => typeof(TCapabilitySettings);
+
+    /// <summary>
+    /// Applies the resolved capability settings onto a request's <see cref="EmbeddingGenerationOptions"/>.
+    /// Called for every request. Implementations should no-op when a value is not set.
+    /// </summary>
+    /// <param name="capabilitySettings">The resolved, typed capability settings for the profile.</param>
+    /// <param name="modelId">
+    /// The model the request will run against — the caller's <see cref="EmbeddingGenerationOptions.ModelId"/>
+    /// when set, otherwise the model the generator was created for. <c>null</c> only when neither is known.
+    /// </param>
+    /// <param name="options">The options for the current request (safe to mutate; it is a per-request copy).</param>
+    /// <remarks>
+    /// Gate on <paramref name="modelId"/> with the same predicate used by
+    /// <see cref="IAICapability.GetSettingsSupport"/>: hiding a setting in the editor does not stop a
+    /// profile saved before a model change, or a direct
+    /// <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/> consumer, from reaching here with a value the
+    /// model rejects.
+    /// </remarks>
+    protected abstract void ApplyCapabilitySettings(
+        TCapabilitySettings capabilitySettings,
+        string? modelId,
+        EmbeddingGenerationOptions options);
+
+    /// <inheritdoc />
+    async Task<IEmbeddingGenerator<string, Embedding<float>>> IAIEmbeddingCapability.CreateGeneratorAsync(
+        object? settings,
+        object? capabilitySettings,
+        string? modelId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        CapabilityGuards.ThrowIfUnresolvedSettings(settings, nameof(CreateGenerator));
+        CapabilityGuards.ThrowIfUnresolvedSettings(capabilitySettings, nameof(CreateGenerator));
+
+        // Build the underlying generator from connection settings only (unchanged provider path).
+        var inner = await CreateGeneratorAsync((TSettings)settings, modelId, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Wrap so the provider-declared capability settings are applied to every request. When the
+        // profile declares none (or a different capability's settings), return the generator untouched.
+        return capabilitySettings is TCapabilitySettings typed
+            ? new CapabilitySettingsEmbeddingGenerator<TCapabilitySettings>(inner, typed, modelId, ApplyCapabilitySettings)
+            : inner;
+    }
+}
+
+/// <summary>
 /// Base implementation of an AI speech-to-text capability.
 /// </summary>
 public abstract class AISpeechToTextCapabilityBase(IAIProvider provider) : AICapabilityBase(provider), IAISpeechToTextCapability
@@ -544,6 +668,70 @@ public abstract class AISpeechToTextCapabilityBase<TSettings>(IAIProvider provid
         ArgumentNullException.ThrowIfNull(settings);
         CapabilityGuards.ThrowIfUnresolvedSettings(settings, nameof(CreateClient));
         return CreateClientAsync((TSettings)settings, modelId, cancellationToken);
+    }
+}
+
+/// <summary>
+/// Base implementation of an AI speech-to-text capability with both provider-specific connection settings
+/// and provider-declared capability settings.
+/// </summary>
+/// <typeparam name="TSettings">The provider-specific connection settings type.</typeparam>
+/// <typeparam name="TCapabilitySettings">The provider-declared capability settings type (a POCO with <c>[AIField]</c> properties).</typeparam>
+/// <remarks>
+/// Derive from this (instead of <see cref="AISpeechToTextCapabilityBase{TSettings}"/>) to let a provider
+/// surface extra per-profile settings. The base exposes the schema hook (<see cref="CapabilitySettingsType"/>)
+/// and applies the resolved settings to every request's <see cref="SpeechToTextOptions"/> via
+/// <see cref="ApplyCapabilitySettings"/>; the provider implements only that typed translation.
+/// </remarks>
+public abstract class AISpeechToTextCapabilityBase<TSettings, TCapabilitySettings>(IAIProvider provider)
+    : AISpeechToTextCapabilityBase<TSettings>(provider), IAISpeechToTextCapability
+    where TSettings : class
+    where TCapabilitySettings : class, new()
+{
+    /// <inheritdoc />
+    public sealed override Type? CapabilitySettingsType => typeof(TCapabilitySettings);
+
+    /// <summary>
+    /// Applies the resolved capability settings onto a request's <see cref="SpeechToTextOptions"/>.
+    /// Called for every request. Implementations should no-op when a value is not set.
+    /// </summary>
+    /// <param name="capabilitySettings">The resolved, typed capability settings for the profile.</param>
+    /// <param name="modelId">
+    /// The model the request will run against — the caller's <see cref="SpeechToTextOptions.ModelId"/> when
+    /// set, otherwise the model the client was created for. <c>null</c> only when neither is known.
+    /// </param>
+    /// <param name="options">The options for the current request (safe to mutate; it is a per-request copy).</param>
+    /// <remarks>
+    /// Gate on <paramref name="modelId"/> with the same predicate used by
+    /// <see cref="IAICapability.GetSettingsSupport"/>: hiding a setting in the editor does not stop a
+    /// profile saved before a model change, or a direct <see cref="ISpeechToTextClient"/> consumer, from
+    /// reaching here with a value the model rejects.
+    /// </remarks>
+    protected abstract void ApplyCapabilitySettings(
+        TCapabilitySettings capabilitySettings,
+        string? modelId,
+        SpeechToTextOptions options);
+
+    /// <inheritdoc />
+    async Task<ISpeechToTextClient> IAISpeechToTextCapability.CreateClientAsync(
+        object? settings,
+        object? capabilitySettings,
+        string? modelId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        CapabilityGuards.ThrowIfUnresolvedSettings(settings, nameof(CreateClient));
+        CapabilityGuards.ThrowIfUnresolvedSettings(capabilitySettings, nameof(CreateClient));
+
+        // Build the underlying client from connection settings only (unchanged provider path).
+        var inner = await CreateClientAsync((TSettings)settings, modelId, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Wrap so the provider-declared capability settings are applied to every request. When the
+        // profile declares none (or a different capability's settings), return the client untouched.
+        return capabilitySettings is TCapabilitySettings typed
+            ? new CapabilitySettingsSpeechToTextClient<TCapabilitySettings>(inner, typed, modelId, ApplyCapabilitySettings)
+            : inner;
     }
 }
 
@@ -621,5 +809,70 @@ public abstract class AIImageGeneratorCapabilityBase<TSettings>(IAIProvider prov
         ArgumentNullException.ThrowIfNull(settings);
         CapabilityGuards.ThrowIfUnresolvedSettings(settings, nameof(CreateGenerator));
         return CreateGeneratorAsync((TSettings)settings, modelId, cancellationToken);
+    }
+}
+
+/// <summary>
+/// Base implementation of an AI image-generation capability with both provider-specific connection
+/// settings and provider-declared capability settings (e.g. a quality or style hint).
+/// </summary>
+/// <typeparam name="TSettings">The provider-specific connection settings type.</typeparam>
+/// <typeparam name="TCapabilitySettings">The provider-declared capability settings type (a POCO with <c>[AIField]</c> properties).</typeparam>
+/// <remarks>
+/// Derive from this (instead of <see cref="AIImageGeneratorCapabilityBase{TSettings}"/>) to let a provider
+/// surface extra per-profile settings. The base exposes the schema hook (<see cref="CapabilitySettingsType"/>)
+/// and applies the resolved settings to every request's <see cref="ImageGenerationOptions"/> via
+/// <see cref="ApplyCapabilitySettings"/>; the provider implements only that typed translation.
+/// </remarks>
+[Experimental(AIImageGenerationDiagnostics.DiagnosticId)]
+public abstract class AIImageGeneratorCapabilityBase<TSettings, TCapabilitySettings>(IAIProvider provider)
+    : AIImageGeneratorCapabilityBase<TSettings>(provider), IAIImageGeneratorCapability
+    where TSettings : class
+    where TCapabilitySettings : class, new()
+{
+    /// <inheritdoc />
+    public sealed override Type? CapabilitySettingsType => typeof(TCapabilitySettings);
+
+    /// <summary>
+    /// Applies the resolved capability settings onto a request's <see cref="ImageGenerationOptions"/>.
+    /// Called for every request. Implementations should no-op when a value is not set.
+    /// </summary>
+    /// <param name="capabilitySettings">The resolved, typed capability settings for the profile.</param>
+    /// <param name="modelId">
+    /// The model the request will run against — the caller's <see cref="ImageGenerationOptions.ModelId"/>
+    /// when set, otherwise the model the generator was created for. <c>null</c> only when neither is known.
+    /// </param>
+    /// <param name="options">The options for the current request (safe to mutate; it is a per-request copy).</param>
+    /// <remarks>
+    /// Gate on <paramref name="modelId"/> with the same predicate used by
+    /// <see cref="IAICapability.GetSettingsSupport"/>: hiding a setting in the editor does not stop a
+    /// profile saved before a model change, or a direct <see cref="IImageGenerator"/> consumer, from
+    /// reaching here with a value the model rejects.
+    /// </remarks>
+    protected abstract void ApplyCapabilitySettings(
+        TCapabilitySettings capabilitySettings,
+        string? modelId,
+        ImageGenerationOptions options);
+
+    /// <inheritdoc />
+    async Task<IImageGenerator> IAIImageGeneratorCapability.CreateGeneratorAsync(
+        object? settings,
+        object? capabilitySettings,
+        string? modelId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        CapabilityGuards.ThrowIfUnresolvedSettings(settings, nameof(CreateGenerator));
+        CapabilityGuards.ThrowIfUnresolvedSettings(capabilitySettings, nameof(CreateGenerator));
+
+        // Build the underlying generator from connection settings only (unchanged provider path).
+        var inner = await CreateGeneratorAsync((TSettings)settings, modelId, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Wrap so the provider-declared capability settings are applied to every request. When the
+        // profile declares none (or a different capability's settings), return the generator untouched.
+        return capabilitySettings is TCapabilitySettings typed
+            ? new CapabilitySettingsImageGenerator<TCapabilitySettings>(inner, typed, modelId, ApplyCapabilitySettings)
+            : inner;
     }
 }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Providers/IAIConfiguredCapability.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Providers/IAIConfiguredCapability.cs
@@ -66,6 +66,24 @@ public interface IAIConfiguredEmbeddingCapability : IAIConfiguredCapability
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A configured embedding generator.</returns>
     Task<IEmbeddingGenerator<string, Embedding<float>>> CreateGeneratorAsync(string? modelId = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates an embedding generator with the baked-in connection settings and resolved,
+    /// provider-declared capability settings.
+    /// </summary>
+    /// <param name="capabilitySettings">The resolved, typed capability settings, or <c>null</c> when the profile declares none.</param>
+    /// <param name="modelId">Optional model ID to use. If null, the provider's default model is used.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A configured embedding generator.</returns>
+    /// <remarks>
+    /// Default implementation ignores <paramref name="capabilitySettings"/> and delegates to
+    /// <see cref="CreateGeneratorAsync(string?, CancellationToken)"/> so existing callers/implementations keep working.
+    /// </remarks>
+    Task<IEmbeddingGenerator<string, Embedding<float>>> CreateGeneratorAsync(
+        object? capabilitySettings,
+        string? modelId,
+        CancellationToken cancellationToken)
+        => CreateGeneratorAsync(modelId, cancellationToken);
 }
 
 /// <summary>
@@ -80,6 +98,24 @@ public interface IAIConfiguredSpeechToTextCapability : IAIConfiguredCapability
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A configured speech-to-text client.</returns>
     Task<ISpeechToTextClient> CreateClientAsync(string? modelId = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a speech-to-text client with the baked-in connection settings and resolved,
+    /// provider-declared capability settings.
+    /// </summary>
+    /// <param name="capabilitySettings">The resolved, typed capability settings, or <c>null</c> when the profile declares none.</param>
+    /// <param name="modelId">Optional model ID to use. If null, the provider's default model is used.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A configured speech-to-text client.</returns>
+    /// <remarks>
+    /// Default implementation ignores <paramref name="capabilitySettings"/> and delegates to
+    /// <see cref="CreateClientAsync(string?, CancellationToken)"/> so existing callers/implementations keep working.
+    /// </remarks>
+    Task<ISpeechToTextClient> CreateClientAsync(
+        object? capabilitySettings,
+        string? modelId,
+        CancellationToken cancellationToken)
+        => CreateClientAsync(modelId, cancellationToken);
 }
 
 /// <summary>
@@ -95,4 +131,22 @@ public interface IAIConfiguredImageGeneratorCapability : IAIConfiguredCapability
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A configured image generator.</returns>
     Task<IImageGenerator> CreateGeneratorAsync(string? modelId = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates an image generator with the baked-in connection settings and resolved, provider-declared
+    /// capability settings.
+    /// </summary>
+    /// <param name="capabilitySettings">The resolved, typed capability settings, or <c>null</c> when the profile declares none.</param>
+    /// <param name="modelId">Optional model ID to use. If null, the provider's default model is used.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A configured image generator.</returns>
+    /// <remarks>
+    /// Default implementation ignores <paramref name="capabilitySettings"/> and delegates to
+    /// <see cref="CreateGeneratorAsync(string?, CancellationToken)"/> so existing callers/implementations keep working.
+    /// </remarks>
+    Task<IImageGenerator> CreateGeneratorAsync(
+        object? capabilitySettings,
+        string? modelId,
+        CancellationToken cancellationToken)
+        => CreateGeneratorAsync(modelId, cancellationToken);
 }

--- a/Umbraco.AI/src/Umbraco.AI.Core/SpeechToText/AISpeechToTextClientFactory.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/SpeechToText/AISpeechToTextClientFactory.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.AI;
 using Umbraco.AI.Core.Connections;
+using Umbraco.AI.Core.EditableModels;
 using Umbraco.AI.Core.Profiles;
 using Umbraco.AI.Core.Providers;
 using Umbraco.AI.Core.RuntimeContext;
@@ -15,19 +16,22 @@ internal sealed class AISpeechToTextClientFactory : IAISpeechToTextClientFactory
     private readonly IAIRuntimeContextAccessor _runtimeContextAccessor;
     private readonly IAIRuntimeContextScopeProvider _scopeProvider;
     private readonly AIRuntimeContextContributorCollection _contributors;
+    private readonly IAIEditableModelResolver _modelResolver;
 
     public AISpeechToTextClientFactory(
         IAIConnectionService connectionService,
         AISpeechToTextMiddlewareCollection middleware,
         IAIRuntimeContextAccessor runtimeContextAccessor,
         IAIRuntimeContextScopeProvider scopeProvider,
-        AIRuntimeContextContributorCollection contributors)
+        AIRuntimeContextContributorCollection contributors,
+        IAIEditableModelResolver modelResolver)
     {
         _connectionService = connectionService;
         _middleware = middleware;
         _runtimeContextAccessor = runtimeContextAccessor;
         _scopeProvider = scopeProvider;
         _contributors = contributors;
+        _modelResolver = modelResolver;
     }
 
     public async Task<ISpeechToTextClient> CreateClientAsync(
@@ -37,8 +41,19 @@ internal sealed class AISpeechToTextClientFactory : IAISpeechToTextClientFactory
         // Get configured provider with resolved settings
         var (speechToTextCapability, provider) = await GetConfiguredSpeechToTextCapabilityAsync(profile, cancellationToken);
 
-        // Create base client from provider with the profile's model
-        var client = await speechToTextCapability.CreateClientAsync(profile.Model.ModelId, cancellationToken);
+        // Resolve any provider-declared capability settings through the same editable-model pipeline
+        // connections use ($-config resolution + validation + typing), so the provider receives a
+        // strongly-typed, resolved object rather than a raw stored bag.
+        var resolvedCapabilitySettings = _modelResolver.ResolveCapabilitySettings(
+            provider,
+            profile.Capability,
+            profile.CapabilitySettings);
+
+        // Create base client from provider with the profile's model and resolved capability settings
+        var client = await speechToTextCapability.CreateClientAsync(
+            resolvedCapabilitySettings,
+            profile.Model.ModelId,
+            cancellationToken);
 
         // Wrap innermost so SDK exceptions are classified against the originating provider before
         // any middleware sees them.

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Providers/CapabilitySettingsRoundTripTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Providers/CapabilitySettingsRoundTripTests.cs
@@ -1,0 +1,337 @@
+using Microsoft.Extensions.AI;
+using Moq;
+using Umbraco.AI.Core.Connections;
+using Umbraco.AI.Core.EditableModels;
+using Umbraco.AI.Core.Embeddings;
+using Umbraco.AI.Core.ImageGeneration;
+using Umbraco.AI.Core.Models;
+using Umbraco.AI.Core.Profiles;
+using Umbraco.AI.Core.Providers;
+using Umbraco.AI.Core.RuntimeContext;
+using Umbraco.AI.Core.SpeechToText;
+using Umbraco.AI.Tests.Common.Builders;
+using Umbraco.AI.Tests.Common.Fakes;
+
+#pragma warning disable MEAI001 // ISpeechToTextClient / IImageGenerator are experimental in M.E.AI
+#pragma warning disable UMBRACOAI_IMAGEGEN // Exercises the experimental image-generation capability surface
+
+namespace Umbraco.AI.Tests.Unit.Providers;
+
+/// <summary>
+/// Proves that provider-declared capability settings survive the whole trip for every capability: stored on
+/// a profile, resolved by the factory, handed to the capability, and applied to the request's options.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These are the guards that make the two-parameter capability bases a usable extension point rather than a
+/// trap. The schema, API and editor layers are capability-agnostic already, so a base published without the
+/// factory threading or the request-time decorator would give a third-party provider a rendered editor whose
+/// values are silently dropped — a failure that looks exactly like success.
+/// </para>
+/// <para>
+/// Deliberately end-to-end through the real factories, real configured-capability wrappers and real bases.
+/// Mocking any of those three would leave the test passing while the thing it exists to catch stays broken.
+/// </para>
+/// </remarks>
+public class CapabilitySettingsRoundTripTests
+{
+    private const string ProviderId = "fake-provider";
+    private const string ModelId = "fake-model-1";
+    private const string StoredValue = "from-profile";
+
+    private readonly Mock<IAIConnectionService> _connectionService = new();
+    private readonly Mock<IAIEditableModelResolver> _modelResolver = new();
+    private readonly Mock<IAIRuntimeContextAccessor> _contextAccessor = new();
+    private readonly Mock<IAIRuntimeContextScopeProvider> _scopeProvider = new();
+
+    private readonly AIRuntimeContextContributorCollection _contributors =
+        new(Enumerable.Empty<IAIRuntimeContextContributor>);
+
+    public CapabilitySettingsRoundTripTests()
+    {
+        // The outermost scoped wrapper opens a runtime-context scope per call, so give it a real context to
+        // populate. None of this is under test; without it the wrapper faults before the request runs.
+        var context = new AIRuntimeContext([]);
+        var scope = new Mock<IAIRuntimeContextScope>();
+        scope.Setup(x => x.Context).Returns(context);
+
+        _contextAccessor.Setup(x => x.Context).Returns((AIRuntimeContext?)null);
+        _scopeProvider
+            .Setup(x => x.CreateScope(It.IsAny<IEnumerable<AIRequestContextItem>>()))
+            .Returns(() =>
+            {
+                _contextAccessor.Setup(x => x.Context).Returns(context);
+                return scope.Object;
+            });
+        _scopeProvider
+            .Setup(x => x.CreateScope())
+            .Returns(() =>
+            {
+                _contextAccessor.Setup(x => x.Context).Returns(context);
+                return scope.Object;
+            });
+    }
+
+    [Fact]
+    public async Task Embedding_CapabilitySettings_ReachTheRequestOptions()
+    {
+        // Arrange
+        var recorder = new FakeEmbeddingGenerator();
+        var provider = new FakeAIProvider(ProviderId, "Fake Provider");
+        var capability = new TestEmbeddingCapability(provider, recorder);
+        provider.WithCapability<IAIEmbeddingCapability>(capability);
+
+        var profile = ArrangeProfile<IAIConfiguredEmbeddingCapability>(
+            provider,
+            AICapability.Embedding,
+            new AIConfiguredEmbeddingCapability(capability, ConnectionSettings));
+
+        var factory = new AIEmbeddingGeneratorFactory(
+            _connectionService.Object,
+            new AIEmbeddingMiddlewareCollection(Enumerable.Empty<IAIEmbeddingMiddleware>),
+            _contextAccessor.Object,
+            _scopeProvider.Object,
+            _contributors,
+            _modelResolver.Object);
+
+        // Act
+        var generator = await factory.CreateGeneratorAsync(profile);
+        await generator.GenerateAsync(["hello"]);
+
+        // Assert
+        AssertApplied(recorder.ReceivedOptions.ShouldHaveSingleItem()?.AdditionalProperties);
+    }
+
+    [Fact]
+    public async Task SpeechToText_CapabilitySettings_ReachTheRequestOptions()
+    {
+        // Arrange
+        var recorder = new FakeSpeechToTextClient();
+        var provider = new FakeAIProvider(ProviderId, "Fake Provider");
+        var capability = new TestSpeechToTextCapability(provider, recorder);
+        provider.WithCapability<IAISpeechToTextCapability>(capability);
+
+        var profile = ArrangeProfile<IAIConfiguredSpeechToTextCapability>(
+            provider,
+            AICapability.SpeechToText,
+            new AIConfiguredSpeechToTextCapability(capability, ConnectionSettings));
+
+        var factory = new AISpeechToTextClientFactory(
+            _connectionService.Object,
+            new AISpeechToTextMiddlewareCollection(Enumerable.Empty<IAISpeechToTextMiddleware>),
+            _contextAccessor.Object,
+            _scopeProvider.Object,
+            _contributors,
+            _modelResolver.Object);
+
+        // Act
+        var client = await factory.CreateClientAsync(profile);
+        await client.GetTextAsync(new MemoryStream([1, 2, 3]));
+
+        // Assert
+        AssertApplied(recorder.ReceivedOptions.ShouldHaveSingleItem()?.AdditionalProperties);
+    }
+
+    [Fact]
+    public async Task ImageGeneration_CapabilitySettings_ReachTheRequestOptions()
+    {
+        // Arrange
+        var recorder = new FakeImageGenerator();
+        var provider = new FakeAIProvider(ProviderId, "Fake Provider");
+        var capability = new TestImageGeneratorCapability(provider, recorder);
+        provider.WithCapability<IAIImageGeneratorCapability>(capability);
+
+        var profile = ArrangeProfile<IAIConfiguredImageGeneratorCapability>(
+            provider,
+            AICapability.ImageGeneration,
+            new AIConfiguredImageGeneratorCapability(capability, ConnectionSettings));
+
+        var factory = new AIImageGeneratorFactory(
+            _connectionService.Object,
+            new AIImageGenerationMiddlewareCollection(Enumerable.Empty<IAIImageGenerationMiddleware>),
+            _contextAccessor.Object,
+            _scopeProvider.Object,
+            _contributors,
+            _modelResolver.Object);
+
+        // Act
+        var generator = await factory.CreateGeneratorAsync(profile);
+        await generator.GenerateAsync(new ImageGenerationRequest { Prompt = "a cat" });
+
+        // Assert
+        AssertApplied(recorder.ReceivedOptions.ShouldHaveSingleItem()?.AdditionalProperties);
+    }
+
+    [Fact]
+    public async Task ProfileWithoutCapabilitySettings_LeavesTheRequestUntouched()
+    {
+        // Arrange — the shape every profile has before a provider declares any settings, and the shape an
+        // upgraded installation resolves on its first request
+        var recorder = new FakeEmbeddingGenerator();
+        var provider = new FakeAIProvider(ProviderId, "Fake Provider");
+        var capability = new TestEmbeddingCapability(provider, recorder);
+        provider.WithCapability<IAIEmbeddingCapability>(capability);
+
+        var profile = ArrangeProfile<IAIConfiguredEmbeddingCapability>(
+            provider,
+            AICapability.Embedding,
+            new AIConfiguredEmbeddingCapability(capability, ConnectionSettings),
+            storeCapabilitySettings: false);
+
+        var factory = new AIEmbeddingGeneratorFactory(
+            _connectionService.Object,
+            new AIEmbeddingMiddlewareCollection(Enumerable.Empty<IAIEmbeddingMiddleware>),
+            _contextAccessor.Object,
+            _scopeProvider.Object,
+            _contributors,
+            _modelResolver.Object);
+
+        // Act
+        var generator = await factory.CreateGeneratorAsync(profile);
+        await generator.GenerateAsync(["hello"]);
+
+        // Assert — no decorator, so nothing is invented on the caller's behalf
+        recorder.ReceivedOptions.ShouldHaveSingleItem().ShouldBeNull();
+    }
+
+    private static FakeProviderSettings ConnectionSettings => new() { ApiKey = "test-key" };
+
+    private static void AssertApplied(AdditionalPropertiesDictionary? additionalProperties)
+    {
+        additionalProperties.ShouldNotBeNull();
+        additionalProperties["applied"].ShouldBe(StoredValue);
+        // The model reaches the apply hook too, so a provider can gate a setting the model rejects.
+        additionalProperties["model"].ShouldBe(ModelId);
+    }
+
+    /// <summary>
+    /// Wires the connection service and resolver so the real factory reaches the given configured capability,
+    /// with a stored bag standing in for the profile's persisted column.
+    /// </summary>
+    private AIProfile ArrangeProfile<TConfigured>(
+        IAIProvider provider,
+        AICapability capability,
+        TConfigured configured,
+        bool storeCapabilitySettings = true)
+        where TConfigured : class, IAIConfiguredCapability
+    {
+        var connectionId = Guid.NewGuid();
+        var connection = new AIConnectionBuilder()
+            .WithId(connectionId)
+            .WithProviderId(ProviderId)
+            .WithSettings(ConnectionSettings)
+            .IsActive(true)
+            .Build();
+
+        var profile = new AIProfileBuilder()
+            .WithConnectionId(connectionId)
+            .WithModel(ProviderId, ModelId)
+            .WithCapability(capability)
+            .Build();
+
+        var configuredProvider = new Mock<IAIConfiguredProvider>();
+        configuredProvider.Setup(x => x.Provider).Returns(provider);
+        configuredProvider.Setup(x => x.GetCapability<TConfigured>()).Returns(configured);
+        configuredProvider.Setup(x => x.GetCapabilities()).Returns(new IAIConfiguredCapability[] { configured });
+
+        _connectionService
+            .Setup(x => x.GetConnectionAsync(connectionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(connection);
+        _connectionService
+            .Setup(x => x.GetConfiguredProviderAsync(connectionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(configuredProvider.Object);
+
+        // Stands in for the editable-model pipeline, which has its own tests. What matters here is that
+        // whatever it returns is what the capability receives.
+        _modelResolver
+            .Setup(x => x.ResolveModel(It.IsAny<Type>(), It.IsAny<object?>(), It.IsAny<AIEditableModelSchema?>()))
+            .Returns(new TestCapabilitySettings { Applied = StoredValue });
+
+        // A null column short-circuits before the resolver is consulted, which is the pre-declaration shape.
+        if (storeCapabilitySettings)
+        {
+            profile.CapabilitySettings = new Dictionary<string, object?> { ["applied"] = StoredValue };
+        }
+
+        return profile;
+    }
+
+    /// <summary>The provider-declared settings a third-party package would define.</summary>
+    private sealed class TestCapabilitySettings
+    {
+        public string? Applied { get; set; }
+    }
+
+    private sealed class TestEmbeddingCapability(
+        IAIProvider provider,
+        IEmbeddingGenerator<string, Embedding<float>> inner)
+        : AIEmbeddingCapabilityBase<FakeProviderSettings, TestCapabilitySettings>(provider)
+    {
+        protected override Task<IReadOnlyList<AIModelDescriptor>> GetModelsAsync(
+            FakeProviderSettings settings,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(Models);
+
+        protected override IEmbeddingGenerator<string, Embedding<float>> CreateGenerator(
+            FakeProviderSettings settings,
+            string? modelId)
+            => inner;
+
+        protected override void ApplyCapabilitySettings(
+            TestCapabilitySettings capabilitySettings,
+            string? modelId,
+            EmbeddingGenerationOptions options)
+            => Record(options.AdditionalProperties ??= new AdditionalPropertiesDictionary(), capabilitySettings, modelId);
+    }
+
+    private sealed class TestSpeechToTextCapability(IAIProvider provider, ISpeechToTextClient inner)
+        : AISpeechToTextCapabilityBase<FakeProviderSettings, TestCapabilitySettings>(provider)
+    {
+        protected override Task<IReadOnlyList<AIModelDescriptor>> GetModelsAsync(
+            FakeProviderSettings settings,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(Models);
+
+        protected override ISpeechToTextClient CreateClient(FakeProviderSettings settings, string? modelId)
+            => inner;
+
+        protected override void ApplyCapabilitySettings(
+            TestCapabilitySettings capabilitySettings,
+            string? modelId,
+            SpeechToTextOptions options)
+            => Record(options.AdditionalProperties ??= new AdditionalPropertiesDictionary(), capabilitySettings, modelId);
+    }
+
+    private sealed class TestImageGeneratorCapability(IAIProvider provider, IImageGenerator inner)
+        : AIImageGeneratorCapabilityBase<FakeProviderSettings, TestCapabilitySettings>(provider)
+    {
+        protected override Task<IReadOnlyList<AIModelDescriptor>> GetModelsAsync(
+            FakeProviderSettings settings,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(Models);
+
+        protected override IImageGenerator CreateGenerator(FakeProviderSettings settings, string? modelId)
+            => inner;
+
+        protected override void ApplyCapabilitySettings(
+            TestCapabilitySettings capabilitySettings,
+            string? modelId,
+            ImageGenerationOptions options)
+            => Record(options.AdditionalProperties ??= new AdditionalPropertiesDictionary(), capabilitySettings, modelId);
+    }
+
+    private static IReadOnlyList<AIModelDescriptor> Models =>
+        [new AIModelDescriptor(new AIModelRef(ProviderId, ModelId), "Fake Model 1")];
+
+    /// <summary>
+    /// What a real provider's apply hook would do to the request, reduced to something observable.
+    /// </summary>
+    private static void Record(
+        AdditionalPropertiesDictionary additionalProperties,
+        TestCapabilitySettings capabilitySettings,
+        string? modelId)
+    {
+        additionalProperties["applied"] = capabilitySettings.Applied;
+        additionalProperties["model"] = modelId;
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Providers/CapabilitySettingsSurfaceTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Providers/CapabilitySettingsSurfaceTests.cs
@@ -1,0 +1,101 @@
+using System.Reflection;
+using Umbraco.AI.Core.Providers;
+
+namespace Umbraco.AI.Tests.Unit.Providers;
+
+/// <summary>
+/// Guards the shape of the provider extension points rather than any behaviour: every capability a provider
+/// can implement must offer the same way to declare its own settings.
+/// </summary>
+/// <remarks>
+/// Written structurally, over whatever capability interfaces the assembly happens to contain, so adding a
+/// capability fails this test until its settings surface exists. A hand-maintained list would simply be
+/// updated in the same commit that forgot the surface.
+/// <para>
+/// Driven from the interfaces rather than the <c>AICapability</c> enum on purpose: the enum carries reserved
+/// values (<c>Media</c>, <c>Moderation</c>) that no provider can implement yet, and a guard that fails on
+/// planned-but-absent capabilities would have to be suppressed to stay green.
+/// </para>
+/// </remarks>
+public class CapabilitySettingsSurfaceTests
+{
+    private static readonly Assembly CoreAssembly = typeof(IAICapability).Assembly;
+
+    public static TheoryData<Type> CapabilityInterfaces()
+    {
+        var data = new TheoryData<Type>();
+        foreach (var type in CoreAssembly.GetTypes()
+            .Where(t => t.IsInterface
+                && t.IsPublic
+                && !t.IsGenericType
+                && t != typeof(IAICapability)
+                && typeof(IAICapability).IsAssignableFrom(t))
+            .OrderBy(t => t.Name))
+        {
+            data.Add(type);
+        }
+
+        return data;
+    }
+
+    [Fact]
+    public void CapabilityInterfaces_AreDiscovered()
+    {
+        // A reflection query that silently matches nothing would make every other test here vacuous.
+        CapabilityInterfaces().Count.ShouldBeGreaterThanOrEqualTo(4);
+    }
+
+    [Theory]
+    [MemberData(nameof(CapabilityInterfaces))]
+    public void EveryCapability_HasATwoParameterBase(Type capabilityInterface)
+    {
+        var twoParameterBase = FindTwoParameterBase(capabilityInterface);
+
+        twoParameterBase.ShouldNotBeNull(
+            $"{capabilityInterface.Name} has no two-parameter base, so a provider cannot declare capability "
+            + "settings for it. Add AI...CapabilityBase<TSettings, TCapabilitySettings> mirroring the chat one.");
+    }
+
+    [Theory]
+    [MemberData(nameof(CapabilityInterfaces))]
+    public void EveryTwoParameterBase_DeclaresItsSettingsType(Type capabilityInterface)
+    {
+        var twoParameterBase = FindTwoParameterBase(capabilityInterface).ShouldNotBeNull();
+
+        // Sealed, so a derived provider cannot report a settings type that differs from the one the base
+        // applies — which is what keeps the generated schema and the applied values in agreement.
+        var property = twoParameterBase.GetProperty(nameof(IAICapability.CapabilitySettingsType));
+        property.ShouldNotBeNull();
+        property.GetMethod!.IsFinal.ShouldBeTrue(
+            $"{twoParameterBase.Name} should seal CapabilitySettingsType.");
+    }
+
+    [Theory]
+    [MemberData(nameof(CapabilityInterfaces))]
+    public void EveryTwoParameterBase_HasAnApplyHook(Type capabilityInterface)
+    {
+        var twoParameterBase = FindTwoParameterBase(capabilityInterface).ShouldNotBeNull();
+
+        // The hook is the whole point: without it the settings would be resolved and then dropped, which is
+        // the failure mode CapabilitySettingsRoundTripTests covers behaviourally.
+        var apply = twoParameterBase
+            .GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .SingleOrDefault(m => m.Name == "ApplyCapabilitySettings");
+
+        apply.ShouldNotBeNull($"{twoParameterBase.Name} should declare an ApplyCapabilitySettings hook.");
+        apply.IsAbstract.ShouldBeTrue("The hook should be abstract, so implementing it is not optional.");
+
+        // (settings, modelId, options) — the model is what lets a provider gate a setting it cannot send.
+        var parameters = apply.GetParameters();
+        parameters.Length.ShouldBe(3);
+        parameters[1].ParameterType.ShouldBe(typeof(string));
+    }
+
+    private static Type? FindTwoParameterBase(Type capabilityInterface)
+        => CoreAssembly.GetTypes()
+            .SingleOrDefault(t => t.IsAbstract
+                && t.IsPublic
+                && t.IsGenericTypeDefinition
+                && t.GetGenericArguments().Length == 2
+                && t.GetInterfaces().Contains(capabilityInterface));
+}


### PR DESCRIPTION
First of six PRs from `plan-capability-settings-consistency.md`. Makes the provider-declared capability-settings mechanism from #269 available to **every** capability, not just chat.

## Why this first

The plan's later phases (the OpenAI image port, embedding dimensions) build on this, and it is the piece third-party provider packages build against — so it leads, and it ships with its guards rather than after them.

## What was actually missing

Everything **above** the SDK was already capability-agnostic, which is why this is smaller than it sounds:

| Layer | State before |
|---|---|
| `AIProviderBase.GetCapabilitySettingsSchema(AICapability)` | Generic — no chat branch |
| `IAIEditableModelResolver.ResolveCapabilitySettings(provider, capability, bag)` | Generic — takes the capability |
| Management API `capabilitySettingsSchemas` | Keyed by capability |
| Profile editor | Renders + per-model-filters any schema it is given |
| **Two-parameter base** | **Chat only** |
| **Configured-capability overload carrying the bag** | **Chat only** |
| **Per-request apply hook** | **Chat only** |

So an embedding capability that declared a settings type would already have got a schema, an API payload and a rendered editor. What it could not get is the settings themselves. No API or frontend changes in this PR.

## Changes

- **Bases**: `AIEmbeddingCapabilityBase<TSettings, TCapabilitySettings>`, `AISpeechToTextCapabilityBase<,>`, `AIImageGeneratorCapabilityBase<,>`. Each mirrors the chat base exactly — sealed `CapabilitySettingsType`, abstract `ApplyCapabilitySettings(settings, modelId, options)` over that capability's own options type. Copied rather than reinvented, deliberately.
- **Interfaces**: the bag-carrying overload on both `IAI*Capability` and `IAIConfigured*Capability`, as default interface methods that ignore it. Existing implementations and callers compile and behave identically.
- **Decorators**: `CapabilitySettingsEmbeddingGenerator`, `CapabilitySettingsSpeechToTextClient`, `CapabilitySettingsImageGenerator`. Each clones the per-request options so the caller's instance is never mutated, and resolves `options.ModelId ?? boundModelId` so a provider can gate a setting the model rejects — the same load-bearing fallback the chat client has for callers that build options without a model.
- **Factories**: embedding, speech-to-text and image resolve the stored bag through the editable-model pipeline and pass it, exactly as `AIChatClientFactory` does.

## Why all three pieces had to land together

A base class on its own would have been **worse than nothing**. Given the layers in the table above, publishing one without the factory threading or the decorator would give a third-party provider a generated schema, an API payload and a rendered editor whose values are silently dropped — a failure that looks exactly like success from the outside.

That is the reasoning behind both guards, and it is why they are in this PR rather than a follow-up.

## Guards

**`CapabilitySettingsRoundTripTests`** (4 tests) — per capability: store a bag on a profile, create the client through the **real** factory, **real** configured-capability wrapper and **real** base, then assert the value and the resolved model arrive in the request options. Mocking any of those three would leave the test green while the thing it exists to catch stays broken.

I confirmed it actually catches the failure mode rather than assuming it does — removing the bag from the embedding factory's call gives:

```
Failed Embedding_CapabilitySettings_ReachTheRequestOptions
  Shouldly.ShouldAssertException : additionalProperties should not be null but was
```

Plus a fourth case pinning that a profile with no capability settings gets no decorator, so nothing is invented on the caller's behalf — the shape every profile has today and after an upgrade.

**`CapabilitySettingsSurfaceTests`** (13 tests) — reflects over the capability interfaces the assembly contains and requires each to have a two-parameter base with a sealed settings type and an abstract three-parameter apply hook. A new capability then cannot ship without the surface.

Driven from the interfaces rather than the `AICapability` enum on purpose: the enum carries reserved `Media` and `Moderation` values that no provider can implement yet, and a guard failing on planned-but-absent capabilities would have to be suppressed to stay green. It also asserts the reflection query matches something, so the other cases cannot go vacuous.

## Verification

```
Umbraco.AI                    1,038  (1,008 unit + 30 integration)
Provider packages                10  all build (OpenAI, Anthropic, Amazon, Google, Mistral,
                                     DeepSeek, MicrosoftFoundry, HuggingFace, FireworksAI, TogetherAI)
Agent 175 · Prompt 84 · Search 47 · Deploy 19 · Automate 40 · Agent.Deploy 7 · Prompt.Deploy 6
```

Core interfaces changed, so every dependent product was built and tested rather than just core.

## Notes for review

- **No first-party provider uses this yet.** It is the extension point, not a feature. That was a deliberate call: these are what provider packages build against, and a vendor with a transcription or embedding knob we have never heard of should not wait for us to want one.
- The public API additions are all default interface methods and new types, so nothing existing breaks. They are surface we then have to support — accepted, and mitigated by copying the chat implementation exactly rather than inventing three variations.
- Next in the plan: the image-hint wire test (independent), then the metadata/size work (independent), then the OpenAI image port which depends on this.

v17 backport to follow once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
