### PR TITLE
fix(openai,imagegeneration): Send the image quality and style hints [v17 backport]

### DIFF
--- a/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIImageGeneratorCapability.cs
+++ b/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIImageGeneratorCapability.cs
@@ -4,7 +4,10 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using OpenAI;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.AI.Core.ImageGeneration;
 using Umbraco.AI.Core.Models;
 using Umbraco.AI.Core.Providers;
@@ -22,9 +25,25 @@ namespace Umbraco.AI.OpenAI;
 /// provider-native client for masked outpainting (Tier 3) while picking their own model/size at call time.
 /// </remarks>
 [Experimental(AIImageGenerationDiagnostics.DiagnosticId)]
-public class OpenAIImageGeneratorCapability(OpenAIProvider provider)
+public class OpenAIImageGeneratorCapability(
+    OpenAIProvider provider,
+    ILogger<OpenAIImageGeneratorCapability>? logger)
     : AIImageGeneratorCapabilityBase<OpenAIProviderSettings>(provider)
 {
+    /// <summary>
+    /// Initializes a new instance without a logger.
+    /// </summary>
+    /// <remarks>
+    /// Retained for construction paths that pass only the provider (the capability factory resolves the rest
+    /// from DI, but plain activation does not). The logger is resolved through the service locator, following
+    /// the same approach as the chat capability, so those paths still get real logging rather than none.
+    /// Null-conditional because the locator is unset before startup and in unit tests.
+    /// </remarks>
+    public OpenAIImageGeneratorCapability(OpenAIProvider provider)
+        : this(provider, StaticServiceProvider.Instance?.GetService<ILogger<OpenAIImageGeneratorCapability>>())
+    {
+    }
+
     private const string DefaultImageModel = "gpt-image-1";
 
     private new OpenAIProvider Provider => (OpenAIProvider)base.Provider;
@@ -62,7 +81,11 @@ public class OpenAIImageGeneratorCapability(OpenAIProvider provider)
 
         // Wrap so consumers can also resolve the un-bound OpenAIClient (the stock adapter only exposes the
         // bound ImageClient), enabling provider-native masked outpainting via GetService.
-        return new OpenAIImageGenerator(inner, client);
+        var generator = new OpenAIImageGenerator(inner, client);
+
+        // Wrapped outside that, so the quality/style hints are translated no matter which caller assembled
+        // the options — the adapter ignores them otherwise. See OpenAIImageHintGenerator.
+        return new OpenAIImageHintGenerator(generator, logger);
     }
 
     private static bool IsImageModel(string modelId)

--- a/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIImageHintGenerator.cs
+++ b/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIImageHintGenerator.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+#pragma warning disable MEAI001 // IImageGenerator is experimental in M.E.AI
+
+namespace Umbraco.AI.OpenAI;
+
+/// <summary>
+/// Image generator decorator that turns the provider-specific <c>quality</c> and <c>style</c> hints into the
+/// OpenAI SDK options the request is actually built from.
+/// </summary>
+/// <remarks>
+/// Wrapped outside the M.E.AI adapter but inside everything else, so the hints are translated no matter which
+/// caller assembled the <see cref="ImageGenerationOptions"/> — the profile's own settings, or a direct
+/// <see cref="IImageGenerator"/> consumer. Without it the hints are silently dropped; see
+/// <see cref="OpenAIImageHints"/>.
+/// </remarks>
+internal sealed class OpenAIImageHintGenerator(IImageGenerator innerGenerator, ILogger? logger)
+    : DelegatingImageGenerator(innerGenerator)
+{
+    /// <inheritdoc />
+    public override Task<ImageGenerationResponse> GenerateAsync(
+        ImageGenerationRequest request,
+        ImageGenerationOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => base.GenerateAsync(request, OpenAIImageHints.Apply(options, logger), cancellationToken);
+}

--- a/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIImageHints.cs
+++ b/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIImageHints.cs
@@ -1,0 +1,126 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using SdkImageGenerationOptions = OpenAI.Images.ImageGenerationOptions;
+
+#pragma warning disable MEAI001 // ImageGenerationOptions is experimental in M.E.AI
+
+namespace Umbraco.AI.OpenAI;
+
+/// <summary>
+/// Translates the provider-specific image hints (<c>quality</c>, <c>style</c>) into the OpenAI SDK's own
+/// options, which is the only channel that reaches the request.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The hints travel as <see cref="ImageGenerationOptions.AdditionalProperties"/> because
+/// Microsoft.Extensions.AI has no first-class property for either. The OpenAI adapter ignores that
+/// dictionary entirely — <c>OpenAIImageOptionsWireTests</c> pins both halves of that: the hints are absent
+/// from the body when passed as additional properties, and present when passed as a raw representation.
+/// </para>
+/// <para>
+/// Kept separate from the decorator that calls it so the same translation can be reused when these hints
+/// move to provider-declared capability settings, where the value arrives typed instead of as a loose
+/// dictionary entry.
+/// </para>
+/// </remarks>
+internal static class OpenAIImageHints
+{
+    internal const string QualityKey = "quality";
+    internal const string StyleKey = "style";
+
+    /// <summary>
+    /// The wire values the SDK understands. Which subset a given model accepts differs (<c>hd</c> and
+    /// <c>standard</c> are DALL·E 3; <c>low</c>, <c>medium</c>, <c>high</c> and <c>auto</c> are gpt-image),
+    /// so this is a spelling check rather than a support check — the API rejects a valid value sent to the
+    /// wrong model, and says so clearly.
+    /// </summary>
+    private static readonly HashSet<string> KnownQualities =
+        new(StringComparer.OrdinalIgnoreCase) { "hd", "standard", "low", "medium", "high", "auto" };
+
+    private static readonly HashSet<string> KnownStyles =
+        new(StringComparer.OrdinalIgnoreCase) { "vivid", "natural" };
+
+    /// <summary>
+    /// Returns options carrying the hints as a raw representation, or the options unchanged when there is
+    /// nothing to translate.
+    /// </summary>
+    /// <param name="options">The caller's options. Never mutated.</param>
+    /// <param name="logger">Optional logger, used when a hint is skipped.</param>
+    public static ImageGenerationOptions? Apply(ImageGenerationOptions? options, ILogger? logger)
+    {
+        if (options?.AdditionalProperties is null)
+        {
+            return options;
+        }
+
+        var quality = Read(options.AdditionalProperties, QualityKey, KnownQualities, logger);
+        var style = Read(options.AdditionalProperties, StyleKey, KnownStyles, logger);
+
+        if (quality is null && style is null)
+        {
+            return options;
+        }
+
+        if (options.RawRepresentationFactory is not null)
+        {
+            // A caller that has gone to the trouble of building the SDK options itself is more specific than
+            // a profile-level hint, and overwriting it would silently drop whatever else it set.
+            logger?.LogDebug(
+                "Image quality/style hints were ignored because the caller supplied its own raw representation.");
+            return options;
+        }
+
+        // Clone so the caller's instance is never mutated, then hand the SDK its own options type. The
+        // adapter fills everything the representation leaves empty (model, n, output format).
+        var effective = options.Clone();
+        effective.RawRepresentationFactory = _ =>
+        {
+            var raw = new SdkImageGenerationOptions();
+
+            if (quality is not null)
+            {
+                raw.Quality = new global::OpenAI.Images.GeneratedImageQuality(quality);
+            }
+
+            if (style is not null)
+            {
+                raw.Style = new global::OpenAI.Images.GeneratedImageStyle(style);
+            }
+
+            return raw;
+        };
+
+        return effective;
+    }
+
+    private static string? Read(
+        AdditionalPropertiesDictionary additionalProperties,
+        string key,
+        HashSet<string> known,
+        ILogger? logger)
+    {
+        if (!additionalProperties.TryGetValue(key, out var raw))
+        {
+            return null;
+        }
+
+        var value = (raw as string)?.Trim();
+        if (string.IsNullOrEmpty(value))
+        {
+            return null;
+        }
+
+        if (!known.Contains(value))
+        {
+            // Skipped rather than sent: an unrecognised spelling would fail the request outright, and a
+            // profile that has been saved with one should still be able to generate an image.
+            logger?.LogDebug(
+                "Ignoring unrecognised image {Hint} value '{Value}'.",
+                key,
+                value);
+            return null;
+        }
+
+        return value.ToLowerInvariant();
+    }
+}

--- a/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/OpenAIImageOptionsWireTests.cs
+++ b/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/OpenAIImageOptionsWireTests.cs
@@ -1,0 +1,191 @@
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using Microsoft.Extensions.AI;
+using OpenAI;
+using Umbraco.AI.OpenAI.Tests.Unit.Fakes;
+
+#pragma warning disable MEAI001 // IImageGenerator / ImageGenerationOptions are experimental in M.E.AI
+
+namespace Umbraco.AI.OpenAI.Tests.Unit;
+
+/// <summary>
+/// Pins down which image-generation options actually reach the OpenAI wire, asserted against a captured
+/// request body rather than a recording generator.
+/// </summary>
+/// <remarks>
+/// A recording generator only proves what we handed the adapter, and stays green when the adapter drops a
+/// value — which is exactly how the quality and style hints turned out to be silent no-ops. These tests hold
+/// both halves of that finding: what the adapter ignores, and what it honours.
+/// </remarks>
+public class OpenAIImageOptionsWireTests
+{
+    [Fact]
+    public async Task AdditionalProperties_QualityAndStyle_NeverReachTheRequest()
+    {
+        // The reason OpenAIImageHints exists. M.E.AI has no first-class property for either hint, so they
+        // travel as additional properties — which the OpenAI adapter does not read.
+        var handler = new CapturingHttpMessageHandler();
+        var generator = CreateImageGenerator(handler, "dall-e-3");
+
+        var options = new ImageGenerationOptions
+        {
+            AdditionalProperties = new AdditionalPropertiesDictionary
+            {
+                ["quality"] = "hd",
+                ["style"] = "vivid",
+            },
+        };
+
+        await SendAndIgnoreFailureAsync(generator, options);
+
+        var body = handler.RequestBodies.ShouldHaveSingleItem();
+        body.ShouldNotContain("quality");
+        body.ShouldNotContain("style");
+    }
+
+    [Fact]
+    public async Task RawRepresentation_QualityAndStyle_ReachTheRequestWithoutLosingAdapterOptions()
+    {
+        var handler = new CapturingHttpMessageHandler();
+        var generator = CreateImageGenerator(handler, "dall-e-3");
+
+        var options = new ImageGenerationOptions
+        {
+            Count = 1,
+            MediaType = "image/png",
+            RawRepresentationFactory = _ => new global::OpenAI.Images.ImageGenerationOptions
+            {
+                Quality = new global::OpenAI.Images.GeneratedImageQuality("hd"),
+                Style = new global::OpenAI.Images.GeneratedImageStyle("vivid"),
+            },
+        };
+
+        await SendAndIgnoreFailureAsync(generator, options);
+
+        var body = handler.RequestBodies.ShouldHaveSingleItem();
+        body.ShouldContain("\"quality\":\"hd\"");
+        body.ShouldContain("\"style\":\"vivid\"");
+        // Load-bearing: the adapter must still fill everything the representation left empty, or translating
+        // the hints this way would silently drop the rest of the request.
+        body.ShouldContain("\"model\":\"dall-e-3\"");
+        body.ShouldContain("\"n\":1");
+        body.ShouldContain("\"output_format\":\"png\"");
+    }
+
+    [Fact]
+    public async Task HintGenerator_TranslatesAdditionalProperties_SoTheHintsReachTheRequest()
+    {
+        // End to end through the decorator the capability installs: hints in as additional properties, out
+        // on the wire.
+        var handler = new CapturingHttpMessageHandler();
+        var generator = new OpenAIImageHintGenerator(CreateImageGenerator(handler, "dall-e-3"), logger: null);
+
+        var options = new ImageGenerationOptions
+        {
+            AdditionalProperties = new AdditionalPropertiesDictionary
+            {
+                ["quality"] = "hd",
+                ["style"] = "vivid",
+            },
+        };
+
+        await SendAndIgnoreFailureAsync(generator, options);
+
+        var body = handler.RequestBodies.ShouldHaveSingleItem();
+        body.ShouldContain("\"quality\":\"hd\"");
+        body.ShouldContain("\"style\":\"vivid\"");
+    }
+
+    [Fact]
+    public async Task HintGenerator_GptImageQualityVocabulary_ReachesTheRequestVerbatim()
+    {
+        // gpt-image accepts low/medium/high where DALL·E 3 accepts standard/hd, and the hint is passed
+        // through rather than mapped, so both vocabularies work without a per-model table.
+        var handler = new CapturingHttpMessageHandler();
+        var generator = new OpenAIImageHintGenerator(CreateImageGenerator(handler, "gpt-image-1"), logger: null);
+
+        var options = new ImageGenerationOptions
+        {
+            AdditionalProperties = new AdditionalPropertiesDictionary { ["quality"] = "high" },
+        };
+
+        await SendAndIgnoreFailureAsync(generator, options);
+
+        handler.RequestBodies.ShouldHaveSingleItem().ShouldContain("\"quality\":\"high\"");
+    }
+
+    [Fact]
+    public async Task HintGenerator_UnrecognisedQuality_IsSkippedRatherThanSent()
+    {
+        // Sending it would fail the request outright; a profile saved with a typo should still generate.
+        var handler = new CapturingHttpMessageHandler();
+        var generator = new OpenAIImageHintGenerator(CreateImageGenerator(handler, "gpt-image-1"), logger: null);
+
+        var options = new ImageGenerationOptions
+        {
+            AdditionalProperties = new AdditionalPropertiesDictionary { ["quality"] = "ultra" },
+        };
+
+        await SendAndIgnoreFailureAsync(generator, options);
+
+        handler.RequestBodies.ShouldHaveSingleItem().ShouldNotContain("quality");
+    }
+
+    [Fact]
+    public async Task HintGenerator_CallerSuppliedRawRepresentation_Wins()
+    {
+        // A caller that built the SDK options itself is more specific than a profile-level hint, and
+        // overwriting its factory would drop whatever else it set.
+        var handler = new CapturingHttpMessageHandler();
+        var generator = new OpenAIImageHintGenerator(CreateImageGenerator(handler, "dall-e-3"), logger: null);
+
+        var options = new ImageGenerationOptions
+        {
+            AdditionalProperties = new AdditionalPropertiesDictionary { ["quality"] = "hd" },
+            RawRepresentationFactory = _ => new global::OpenAI.Images.ImageGenerationOptions
+            {
+                Quality = new global::OpenAI.Images.GeneratedImageQuality("standard"),
+            },
+        };
+
+        await SendAndIgnoreFailureAsync(generator, options);
+
+        handler.RequestBodies.ShouldHaveSingleItem().ShouldContain("\"quality\":\"standard\"");
+    }
+
+    [Fact]
+    public async Task HintGenerator_NoHints_LeavesTheOptionsAlone()
+    {
+        var handler = new CapturingHttpMessageHandler();
+        var generator = new OpenAIImageHintGenerator(CreateImageGenerator(handler, "dall-e-3"), logger: null);
+
+        await SendAndIgnoreFailureAsync(generator, new ImageGenerationOptions { MediaType = "image/png" });
+
+        var body = handler.RequestBodies.ShouldHaveSingleItem();
+        body.ShouldContain("\"output_format\":\"png\"");
+        body.ShouldNotContain("quality");
+    }
+
+    private static IImageGenerator CreateImageGenerator(CapturingHttpMessageHandler handler, string modelId)
+        => new OpenAIClient(
+                new ApiKeyCredential("test-key"),
+                new OpenAIClientOptions
+                {
+                    Transport = new HttpClientPipelineTransport(new HttpClient(handler)),
+                    RetryPolicy = new ClientRetryPolicy(0),
+                })
+            .GetImageClient(modelId)
+            .AsIImageGenerator();
+
+    private static async Task SendAndIgnoreFailureAsync(IImageGenerator generator, ImageGenerationOptions options)
+    {
+        try
+        {
+            await generator.GenerateAsync(new ImageGenerationRequest { Prompt = "a cat" }, options);
+        }
+        catch (Exception)
+        {
+            // The capturing handler always fails the request; only the captured body matters here.
+        }
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/ImageGeneration/AIImageGenerationServiceTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/ImageGeneration/AIImageGenerationServiceTests.cs
@@ -122,6 +122,35 @@ public class AIImageGenerationServiceTests
     }
 
     [Fact]
+    public async Task GenerateImagesAsync_ForwardsProfileHintsUnderTheKeysProvidersRead()
+    {
+        // Quality and style have no first-class option property, so they cross into the provider as
+        // additional properties. That makes the key names a contract: the OpenAI provider reads exactly
+        // these to translate them into its SDK options, and a rename on either side would put the hints
+        // back to silently doing nothing — which is what they did before that translation existed.
+        var generator = new FakeImageGenerator();
+        var profile = new AIProfileBuilder()
+            .WithCapability(AICapability.ImageGeneration)
+            .WithModel("fake-provider", "dall-e-3")
+            .WithSettings(new AIImageGenerationProfileSettings { Quality = "hd", Style = "vivid" })
+            .Build();
+
+        _profileServiceMock
+            .Setup(x => x.GetDefaultProfileAsync(AICapability.ImageGeneration, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(profile);
+        _factoryMock
+            .Setup(x => x.CreateGeneratorAsync(profile, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(generator);
+
+        await _service.GenerateImagesAsync(b => b.WithAlias("hints"), "a cat");
+
+        var options = generator.ReceivedOptions.ShouldHaveSingleItem();
+        options!.AdditionalProperties.ShouldNotBeNull();
+        options.AdditionalProperties["quality"].ShouldBe("hd");
+        options.AdditionalProperties["style"].ShouldBe("vivid");
+    }
+
+    [Fact]
     public async Task GenerateImagesAsync_WithOriginalImages_FlowsThroughToGenerator()
     {
         var generator = new FakeImageGenerator();


### PR DESCRIPTION
Backport of #277 to the v17 line. Clean cherry-pick, no conflicts.

## The bug it fixes

The image-generation profile settings `Quality` and `Style` never reached OpenAI on this line either. Core forwards them as `ImageGenerationOptions.AdditionalProperties`, and the OpenAI adapter does not read that dictionary — so a profile saved with a quality of `hd` sent a request without it, silently:

```json
{"prompt":"a cat","model":"dall-e-3","n":1,"output_format":"png"}
```

`OpenAIImageHints` now translates the hints into the SDK's own options via `RawRepresentationFactory`, applied per request by `OpenAIImageHintGenerator` wrapped outside the M.E.AI adapter. Values pass through verbatim after a spelling check, so both model vocabularies work; an unrecognised spelling is skipped rather than sent, and a caller's own raw representation wins.

Full reasoning, the captured-body evidence and the test matrix are in **#277**.

## Verification on this line

```
Umbraco.AI          1,042  (1,012 unit + 30 integration)
Umbraco.AI.OpenAI      54
```

Includes the core guard pinning that the hints are forwarded under the `quality` and `style` keys the provider reads, since that contract is what made the original failure invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
