### PR TITLE
feat(core,frontend,openai): Drive the image size field from the model's declared sizes

### DIFF
--- a/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIImageGeneratorCapability.cs
+++ b/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIImageGeneratorCapability.cs
@@ -103,10 +103,10 @@ public class OpenAIImageGeneratorCapability(
         {
             return new Dictionary<string, string>
             {
-                ["image.supportedSizes"] = "1024x1024,1024x1536,1536x1024",
-                ["image.maxEdge"] = "1536",
-                ["image.supportsEdit"] = "true",
-                ["image.supportsMask"] = "true",
+                [AIModelMetadataKeys.ImageSupportedSizes] = "1024x1024,1024x1536,1536x1024",
+                [AIModelMetadataKeys.ImageMaxEdge] = "1536",
+                [AIModelMetadataKeys.ImageSupportsEdit] = "true",
+                [AIModelMetadataKeys.ImageSupportsMask] = "true",
             };
         }
 
@@ -114,10 +114,10 @@ public class OpenAIImageGeneratorCapability(
         {
             return new Dictionary<string, string>
             {
-                ["image.supportedSizes"] = "1024x1024,1792x1024,1024x1792",
-                ["image.maxEdge"] = "1792",
-                ["image.supportsEdit"] = "false",
-                ["image.supportsMask"] = "false",
+                [AIModelMetadataKeys.ImageSupportedSizes] = "1024x1024,1792x1024,1024x1792",
+                [AIModelMetadataKeys.ImageMaxEdge] = "1792",
+                [AIModelMetadataKeys.ImageSupportsEdit] = "false",
+                [AIModelMetadataKeys.ImageSupportsMask] = "false",
             };
         }
 
@@ -125,10 +125,10 @@ public class OpenAIImageGeneratorCapability(
         {
             return new Dictionary<string, string>
             {
-                ["image.supportedSizes"] = "256x256,512x512,1024x1024",
-                ["image.maxEdge"] = "1024",
-                ["image.supportsEdit"] = "true",
-                ["image.supportsMask"] = "true",
+                [AIModelMetadataKeys.ImageSupportedSizes] = "256x256,512x512,1024x1024",
+                [AIModelMetadataKeys.ImageMaxEdge] = "1024",
+                [AIModelMetadataKeys.ImageSupportsEdit] = "true",
+                [AIModelMetadataKeys.ImageSupportsMask] = "true",
             };
         }
 

--- a/Umbraco.AI/src/Umbraco.AI.Core/Extensions/AIModelDescriptorExtensions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Extensions/AIModelDescriptorExtensions.cs
@@ -35,6 +35,74 @@ public static class AIModelDescriptorExtensions
     public static bool IsProfileSettingSupported(this AIModelDescriptor model, string fieldKey)
         => IsSettingSupported(model, AIModelMetadataKeys.ProfileSettingsUnsupported, fieldKey);
 
+    /// <summary>
+    /// The image sizes this model accepts, each as <c>"{width}x{height}"</c>.
+    /// </summary>
+    /// <param name="model">The model descriptor.</param>
+    /// <returns>
+    /// The declared sizes, or an empty list when the capability declared none. Empty means "unknown", not
+    /// "none supported" — a consumer should keep accepting a free-typed size rather than blocking one.
+    /// </returns>
+    public static IReadOnlyList<string> GetSupportedImageSizes(this AIModelDescriptor model)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+
+        if (!model.Metadata.TryGetValue(AIModelMetadataKeys.ImageSupportedSizes, out var declared))
+        {
+            return [];
+        }
+
+        return declared
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToList();
+    }
+
+    /// <summary>
+    /// The longest edge, in pixels, this model will produce, or <c>null</c> when not declared.
+    /// </summary>
+    /// <param name="model">The model descriptor.</param>
+    public static int? GetImageMaxEdge(this AIModelDescriptor model)
+        => ReadInt(model, AIModelMetadataKeys.ImageMaxEdge);
+
+    /// <summary>
+    /// Whether this model supports editing a supplied image, or <c>null</c> when not declared.
+    /// </summary>
+    /// <param name="model">The model descriptor.</param>
+    /// <remarks>
+    /// Nullable on purpose: an absent declaration is silence, which is not the same as an explicit
+    /// <c>false</c>. A consumer that treats the two alike will hide a feature on every model a provider
+    /// happens not to describe.
+    /// </remarks>
+    public static bool? SupportsImageEdit(this AIModelDescriptor model)
+        => ReadBool(model, AIModelMetadataKeys.ImageSupportsEdit);
+
+    /// <summary>
+    /// Whether this model supports a mask when editing, or <c>null</c> when not declared.
+    /// </summary>
+    /// <param name="model">The model descriptor.</param>
+    public static bool? SupportsImageMask(this AIModelDescriptor model)
+        => ReadBool(model, AIModelMetadataKeys.ImageSupportsMask);
+
+    private static int? ReadInt(AIModelDescriptor model, string metadataKey)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+
+        return model.Metadata.TryGetValue(metadataKey, out var raw)
+            && int.TryParse(raw.Trim(), out var value)
+                ? value
+                : null;
+    }
+
+    private static bool? ReadBool(AIModelDescriptor model, string metadataKey)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+
+        return model.Metadata.TryGetValue(metadataKey, out var raw)
+            && bool.TryParse(raw.Trim(), out var value)
+                ? value
+                : null;
+    }
+
     private static bool IsSettingSupported(AIModelDescriptor model, string metadataKey, string fieldKey)
     {
         ArgumentNullException.ThrowIfNull(model);

--- a/Umbraco.AI/src/Umbraco.AI.Core/Models/AIModelMetadataKeys.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Models/AIModelMetadataKeys.cs
@@ -4,10 +4,14 @@ namespace Umbraco.AI.Core.Models;
 /// Well-known keys used in <see cref="AIModelDescriptor.Metadata"/>.
 /// </summary>
 /// <remarks>
-/// Metadata is a string dictionary so it can travel to the backoffice with the model list. This
-/// constant (plus <see cref="AIModelSettingsSupport"/> for writing and the
-/// <c>IsCapabilitySettingSupported</c> extension for reading) keeps the convention in one place
+/// Metadata is a string dictionary so it can travel to the backoffice with the model list. These
+/// constants (plus <see cref="AIModelSettingsSupport"/> for writing and the extensions on
+/// <see cref="Extensions.AIModelDescriptorExtensions"/> for reading) keep the convention in one place
 /// rather than repeated as literals across provider packages and the frontend.
+/// <para>
+/// Every key here should have a reader alongside it. A key written by a provider and read by nobody is
+/// how the image constraints spent their first release doing nothing at all.
+/// </para>
 /// </remarks>
 public static class AIModelMetadataKeys
 {
@@ -24,4 +28,25 @@ public static class AIModelMetadataKeys
     /// Absent when the capability has nothing to declare for the model.
     /// </summary>
     public const string ProfileSettingsUnsupported = "profileSettings.unsupported";
+
+    /// <summary>
+    /// Comma-separated image sizes the model accepts, each as <c>"{width}x{height}"</c>.
+    /// Absent when the capability declares no size constraint.
+    /// </summary>
+    public const string ImageSupportedSizes = "image.supportedSizes";
+
+    /// <summary>
+    /// The longest edge, in pixels, the model will produce.
+    /// </summary>
+    public const string ImageMaxEdge = "image.maxEdge";
+
+    /// <summary>
+    /// Whether the model supports editing a supplied image (<c>true</c> or <c>false</c>).
+    /// </summary>
+    public const string ImageSupportsEdit = "image.supportsEdit";
+
+    /// <summary>
+    /// Whether the model supports a mask when editing (<c>true</c> or <c>false</c>).
+    /// </summary>
+    public const string ImageSupportsMask = "image.supportsMask";
 }

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/core/utils/model-settings.utils.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/core/utils/model-settings.utils.ts
@@ -54,6 +54,32 @@ export function isProfileSettingSupported(
     return isSettingSupported(metadata, UAI_METADATA_PROFILE_SETTINGS_UNSUPPORTED, fieldKey);
 }
 
+/**
+ * Well-known model metadata key listing the image sizes a model accepts.
+ * @public
+ */
+export const UAI_METADATA_IMAGE_SUPPORTED_SIZES = "image.supportedSizes";
+
+/**
+ * The image sizes a model accepts, each as `"{width}x{height}"`.
+ *
+ * Returns an empty array when the provider declared none, which means "unknown" rather than "none
+ * supported" — a caller should keep accepting a free-typed size rather than blocking every model a provider
+ * happens not to describe.
+ *
+ * @param metadata - The selected model descriptor's metadata.
+ * @public
+ */
+export function getSupportedImageSizes(metadata: Record<string, string> | undefined): string[] {
+    const declared = metadata?.[UAI_METADATA_IMAGE_SUPPORTED_SIZES];
+    if (!declared) return [];
+
+    return declared
+        .split(",")
+        .map((size) => size.trim())
+        .filter((size) => size.length > 0);
+}
+
 function isSettingSupported(
     metadata: Record<string, string> | undefined,
     metadataKey: string,

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/workspace/profile/views/profile-details-workspace-view.element.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/workspace/profile/views/profile-details-workspace-view.element.ts
@@ -6,7 +6,12 @@ import { umbBindToValidation } from "@umbraco-cms/backoffice/validation";
 import type { UUISelectEvent } from "@umbraco-cms/backoffice/external/uui";
 import type { UaiProfileDetailModel, UaiModelRef, UaiChatProfileSettings, UaiEmbeddingProfileSettings, UaiSpeechToTextProfileSettings, UaiImageGenerationProfileSettings } from "../../../types.js";
 import { isChatSettings, isEmbeddingSettings, isSpeechToTextSettings, isImageGenerationSettings } from "../../../types.js";
-import { UaiPartialUpdateCommand, isCapabilitySettingSupported, isProfileSettingSupported } from "../../../../core/index.js";
+import {
+    UaiPartialUpdateCommand,
+    isCapabilitySettingSupported,
+    isProfileSettingSupported,
+    getSupportedImageSizes,
+} from "../../../../core/index.js";
 import { UAI_PROFILE_WORKSPACE_CONTEXT } from "../profile-workspace.context-token.js";
 import type { UaiConnectionItemModel, UaiModelDescriptorModel } from "../../../../connection/types.js";
 import { UaiConnectionCapabilityRepository, UaiConnectionModelsRepository } from "../../../../connection/repository";
@@ -217,19 +222,33 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
     }
 
     /**
-     * Returns the stored capability settings with the core settings the given model declares unsupported
-     * cleared, or `undefined` when nothing needs to change (which the partial update command skips).
+     * Returns the stored core profile settings with anything the given model cannot accept cleared, or
+     * `undefined` when nothing needs to change (which the partial update command skips).
      *
-     * Same reasoning as {@link #pruneCapabilitySettings}: a temperature the model rejects would sit in the
-     * profile with no field to show it and be dropped on every request.
+     * Same reasoning as {@link #pruneCapabilitySettings}: a value the model rejects would otherwise sit in
+     * the profile with no field showing it, and be dropped or rejected on every request.
      */
-    #pruneProfileSettings(modelId: string): UaiChatProfileSettings | undefined {
+    #pruneProfileSettings(modelId: string): UaiChatProfileSettings | UaiImageGenerationProfileSettings | undefined {
+        const metadata = this.#getModelMetadata(modelId);
+
         const chatSettings = this.#getChatSettings();
-        if (chatSettings?.temperature === null || chatSettings?.temperature === undefined) return undefined;
+        if (chatSettings?.temperature !== null && chatSettings?.temperature !== undefined) {
+            return isProfileSettingSupported(metadata, UAI_TEMPERATURE_FIELD_KEY)
+                ? undefined
+                : { ...chatSettings, temperature: null };
+        }
 
-        if (isProfileSettingSupported(this.#getModelMetadata(modelId), UAI_TEMPERATURE_FIELD_KEY)) return undefined;
+        const imageSettings = this.#getImageGenerationSettings();
+        if (imageSettings?.size) {
+            // Only prune against a model that actually declares its sizes. An empty list is silence, and
+            // clearing a deliberate size because a provider described nothing would be worse than keeping it.
+            const sizes = getSupportedImageSizes(metadata);
+            return sizes.length === 0 || sizes.includes(imageSettings.size)
+                ? undefined
+                : { ...imageSettings, size: null };
+        }
 
-        return { ...chatSettings, temperature: null };
+        return undefined;
     }
 
     /**
@@ -361,6 +380,81 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
         const target = event.target as HTMLInputElement;
         this.#updateImageGenerationSettings({ size: target.value || null });
     }
+
+    /**
+     * Renders the image size as a dropdown of the sizes the selected model declares, falling back to free
+     * text when it declares none.
+     *
+     * The sizes have been travelling on the model list since image generation shipped, with nothing reading
+     * them, so a size the model rejects saved cleanly and failed at generation time. The fallback matters as
+     * much as the dropdown: declarations are negative, so a model a provider says nothing about must stay
+     * typeable rather than being restricted to an empty list.
+     */
+    #renderImageSize(imageSettings: UaiImageGenerationProfileSettings | null) {
+        const sizes = getSupportedImageSizes(this.#getModelMetadata(this._model?.model?.modelId));
+        const size = imageSettings?.size ?? "";
+
+        return html`
+            <umb-property-layout
+                label="Size"
+                description=${sizes.length > 0
+                    ? "Default image size. Leave empty for the provider default."
+                    : 'Default image size as "{width}x{height}" (e.g. "1024x1024"). Leave empty for the provider default.'}
+            >
+                ${sizes.length > 0
+                    ? html`
+                        <uui-select
+                            slot="editor"
+                            .options=${this.#getImageSizeOptions(sizes, size)}
+                            @change=${this.#onImageSizeChange}
+                        ></uui-select>
+                    `
+                    : html`
+                        <uui-input
+                            slot="editor"
+                            type="text"
+                            .value=${size}
+                            @input=${this.#onImageSizeChange}
+                            placeholder="Provider default"
+                        ></uui-input>
+                    `}
+            </umb-property-layout>
+        `;
+    }
+
+    /**
+     * Builds the size options, cached against the inputs that decide them.
+     *
+     * A fresh array on every render pushes a new config into the CMS dropdown, which rebuilds its derived
+     * state and loses the empty "provider default" entry — the same trap the capability-settings schema
+     * works around.
+     */
+    #getImageSizeOptions(sizes: string[], selected: string): Array<{ name: string; value: string; selected?: boolean }> {
+        const cacheKey = `${sizes.join(",")}|${selected}`;
+        if (this.#cachedImageSizeOptionsKey === cacheKey) return this.#cachedImageSizeOptions!;
+
+        // A model that declares sizes can still be left unset, so the profile falls back to the provider's
+        // own default — the same three-state thinking as temperature.
+        const options = [
+            { name: "Provider default", value: "", selected: selected === "" },
+            ...sizes.map((s) => ({ name: s, value: s, selected: s === selected })),
+        ];
+
+        // A stored size the model doesn't list would otherwise vanish from the dropdown and read as unset.
+        // Pruning on model change handles the normal path; this covers a value saved before a declaration
+        // existed, or one a provider has since dropped.
+        if (selected !== "" && !sizes.includes(selected)) {
+            options.push({ name: `${selected} (not listed for this model)`, value: selected, selected: true });
+        }
+
+        this.#cachedImageSizeOptionsKey = cacheKey;
+        this.#cachedImageSizeOptions = options;
+
+        return options;
+    }
+
+    #cachedImageSizeOptionsKey?: string;
+    #cachedImageSizeOptions?: Array<{ name: string; value: string; selected?: boolean }>;
 
     #onImageQualityChange(event: Event) {
         event.stopPropagation();
@@ -568,18 +662,7 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
 
         return html`
             <uui-box headline="System Settings">
-                <umb-property-layout
-                    label="Size"
-                    description="Default image size as &quot;{width}x{height}&quot; (e.g. &quot;1024x1024&quot;). Leave empty for the provider default."
-                >
-                    <uui-input
-                        slot="editor"
-                        type="text"
-                        .value=${imageSettings?.size ?? ""}
-                        @input=${this.#onImageSizeChange}
-                        placeholder="Provider default"
-                    ></uui-input>
-                </umb-property-layout>
+                ${this.#renderImageSize(imageSettings)}
 
                 <umb-property-layout label="Media Type" description="Output image encoding (e.g. &quot;image/png&quot;, &quot;image/jpeg&quot;, &quot;image/webp&quot;). Supported values vary by model.">
                     <uui-input

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Common/Fakes/FakeImageGeneratorCapability.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Common/Fakes/FakeImageGeneratorCapability.cs
@@ -25,8 +25,8 @@ public class FakeImageGeneratorCapability : IAIImageGeneratorCapability
                 "GPT Image 1",
                 new Dictionary<string, string>
                 {
-                    ["image.supportedSizes"] = "1024x1024,1024x1536,1536x1024",
-                    ["image.maxEdge"] = "1536",
+                    [AIModelMetadataKeys.ImageSupportedSizes] = "1024x1024,1024x1536,1536x1024",
+                    [AIModelMetadataKeys.ImageMaxEdge] = "1536",
                 }),
         };
     }

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/ImageGeneration/AIImageGenerationServiceTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/ImageGeneration/AIImageGenerationServiceTests.cs
@@ -266,7 +266,7 @@ public class AIImageGenerationServiceTests
             .ReturnsAsync(new List<AIModelDescriptor>
             {
                 new(new AIModelRef("fake-provider", "gpt-image-1"), "GPT Image 1",
-                    new Dictionary<string, string> { ["image.supportedSizes"] = "1024x1024" }),
+                    new Dictionary<string, string> { [AIModelMetadataKeys.ImageSupportedSizes] = "1024x1024" }),
             });
 
         var configuredProvider = new Mock<IAIConfiguredProvider>();
@@ -284,6 +284,8 @@ public class AIImageGenerationServiceTests
 
         result.ModelId.ShouldBe("gpt-image-1");
         result.Models.Count.ShouldBe(1);
+        // Deliberately the literal rather than the constant: this is the key that travels to the backoffice,
+        // so a change to the constant's value should fail here rather than silently rename the contract.
         result.Models[0].Metadata.ContainsKey("image.supportedSizes").ShouldBeTrue();
     }
 }

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Providers/ImageModelMetadataTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Providers/ImageModelMetadataTests.cs
@@ -1,0 +1,89 @@
+using Umbraco.AI.Core.Models;
+using Umbraco.AI.Extensions;
+
+namespace Umbraco.AI.Tests.Unit.Providers;
+
+/// <summary>
+/// Reading the per-model image constraints a capability declares.
+/// </summary>
+/// <remarks>
+/// These keys shipped with image generation and had no reader at all: providers wrote them, the backoffice
+/// received them, and nothing consumed them — so a size the model rejects saved cleanly and failed only at
+/// generation time. The readers exist so there is one place that knows the format, and these tests pin what
+/// an absent or malformed declaration means.
+/// </remarks>
+public class ImageModelMetadataTests
+{
+    [Fact]
+    public void GetSupportedImageSizes_Declared_ReturnsThemInOrder()
+    {
+        var model = Describe(new() { [AIModelMetadataKeys.ImageSupportedSizes] = "1024x1024,1024x1536,1536x1024" });
+
+        model.GetSupportedImageSizes().ShouldBe(["1024x1024", "1024x1536", "1536x1024"]);
+    }
+
+    [Fact]
+    public void GetSupportedImageSizes_Whitespace_IsTrimmed()
+    {
+        var model = Describe(new() { [AIModelMetadataKeys.ImageSupportedSizes] = " 1024x1024 , 512x512 ,, " });
+
+        model.GetSupportedImageSizes().ShouldBe(["1024x1024", "512x512"]);
+    }
+
+    [Fact]
+    public void GetSupportedImageSizes_NotDeclared_ReturnsEmpty()
+    {
+        // Empty means "unknown", not "none supported" — the editor keeps accepting a typed size, rather than
+        // restricting every model a provider happens not to describe to an empty dropdown.
+        Describe(new()).GetSupportedImageSizes().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetImageMaxEdge_Declared_IsParsed()
+    {
+        Describe(new() { [AIModelMetadataKeys.ImageMaxEdge] = "1536" }).GetImageMaxEdge().ShouldBe(1536);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("wide")]
+    public void GetImageMaxEdge_Unparseable_ReturnsNull(string value)
+    {
+        // Metadata is a string dictionary, so a provider can put anything in it. Reading it as null beats
+        // throwing on a model list the user only wanted to browse.
+        Describe(new() { [AIModelMetadataKeys.ImageMaxEdge] = value }).GetImageMaxEdge().ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("false", false)]
+    [InlineData("True", true)]
+    public void SupportsImageEdit_Declared_IsParsed(string value, bool expected)
+    {
+        Describe(new() { [AIModelMetadataKeys.ImageSupportsEdit] = value }).SupportsImageEdit().ShouldBe(expected);
+    }
+
+    [Fact]
+    public void SupportsImageEdit_NotDeclared_ReturnsNull()
+    {
+        // Null rather than false: silence is not a denial, and a consumer that conflates them hides the
+        // feature on every model nobody has described yet.
+        Describe(new()).SupportsImageEdit().ShouldBeNull();
+    }
+
+    [Fact]
+    public void SupportsImageMask_ReadsItsOwnKey()
+    {
+        var model = Describe(new()
+        {
+            [AIModelMetadataKeys.ImageSupportsEdit] = "true",
+            [AIModelMetadataKeys.ImageSupportsMask] = "false",
+        });
+
+        model.SupportsImageEdit().ShouldBe(true);
+        model.SupportsImageMask().ShouldBe(false);
+    }
+
+    private static AIModelDescriptor Describe(Dictionary<string, string> metadata)
+        => new(new AIModelRef("test", "some-image-model"), "Some Image Model", metadata);
+}


### PR DESCRIPTION
PR 3 of `plan-capability-settings-consistency.md`. Makes the per-model image constraints actually do something, and brings their keys onto the convention the rest of the model metadata follows.

## The gap

`image.supportedSizes`, `image.maxEdge`, `image.supportsEdit` and `image.supportsMask` have been on the model list since image generation shipped, and **nothing read any of them** — not the frontend, not `AIImageGenerationService`, nowhere. The only other references were two test fakes mirroring the literals.

So the Size field was free text: `1792x1024` saved cleanly on a gpt-image-1 profile (which accepts three sizes, none of them that) and failed at generation time, while the correct values sat unused on the wire. Issue #266 cited image generation as the *precedent* for per-model declarations; it was in fact the one capability whose declarations went nowhere.

## Changes

**Core**

- `AIModelMetadataKeys` gains the four image keys, with the same wire strings, so anything already reading the raw dictionary is unaffected.
- Typed readers next to them: `GetSupportedImageSizes`, `GetImageMaxEdge`, `SupportsImageEdit`, `SupportsImageMask`. One place now knows the format instead of each consumer re-parsing.
- The two boolean readers return `bool?`, not `bool`. An absent declaration is silence, and a consumer that folds that into `false` hides a feature on every model a provider happens not to describe.
- OpenAI and the test fakes reference the constants rather than repeating literals. One assertion deliberately keeps the literal `"image.supportedSizes"`, with a comment saying why: it pins the key that travels to the backoffice, so changing the constant's *value* should fail rather than silently rename the contract.

**Editor**

- Size becomes a dropdown of the sizes the selected model declares, with an explicit "Provider default" entry, so the field keeps the same three-state shape temperature got in #273.
- **A model that declares no sizes keeps the free-text input.** Declarations are negative, so a model a provider says nothing about must stay typeable rather than be restricted to an empty list.
- A stored size the newly selected model does not list is pruned, extending the `#pruneProfileSettings` clause temperature added.
- A stored size that predates a declaration is kept as an option labelled "not listed for this model", so it neither disappears nor reads as unset.
- Options are cached against the inputs that decide them — a fresh array per render makes the CMS dropdown rebuild derived state and lose the empty entry, the same trap the capability-settings schema already works around.

## Verification

Driven in the backoffice against the database, not just the DOM. Needed the experimental flag and a real image profile, so I created one:

| Check | Result |
|---|---|
| Size chosen from the dropdown, saved | DB: `{"size":"1024x1536","quality":null,"style":null,"mediaType":null}` |
| Reload | Dropdown shows `1024x1536` selected |
| Switch to a model declaring `256x256,512x512` | Stored size cleared to `null`, dropdown offers that model's two sizes |
| Model declaring no sizes | Falls back to the free-text input with the original description |

Two of those needed simulating, and I would rather say so than imply otherwise: this OpenAI account exposes only `gpt-image-*` models, and the provider declares identical sizes for all of them, so I patched the loaded model list to give one model a different declaration and another none at all. Everything else is the real path.

```
Umbraco.AI          1,050  (1,020 unit + 30 integration)
Umbraco.AI.OpenAI      54
```

New `ImageModelMetadataTests` covers the readers: declared, whitespace, absent, unparseable `maxEdge`, and `bool?` semantics.

## Worth a look while reviewing

`GetImageConstraints` matches on `id.StartsWith("gpt-image")`, so **every future gpt-image model inherits gpt-image-1's declared sizes**. Harmless while nothing read the declaration; now that the dropdown acts on it, an over-broad prefix could restrict a newer model to the wrong list. My account already lists `gpt-image-1.5`, `gpt-image-2` and `gpt-image-2-2026-04-21`, all currently claiming gpt-image-1's three sizes.

I have left that alone here — it is a provider-side judgement, not something this PR should quietly change — but it wants a decision. The free-text fallback only helps models that declare *nothing*, which these do not.

## Not in scope

Quality and Style are still free text; PR 4 moves them to provider-declared capability settings with their own dropdowns. `maxEdge`, `supportsEdit` and `supportsMask` now have readers but no consumer yet — the readers exist so the next consumer does not invent a fifth parsing style.

v17 backport to follow once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
