### PR TITLE
feat(core,frontend,openai)!: Move image quality and style to capability settings

### DIFF
--- a/Umbraco.AI.Deploy/tests/Umbraco.AI.Deploy.Tests.Unit/Connectors/ServiceConnectors/UmbracoAIProfileServiceConnectorTests.cs
+++ b/Umbraco.AI.Deploy/tests/Umbraco.AI.Deploy.Tests.Unit/Connectors/ServiceConnectors/UmbracoAIProfileServiceConnectorTests.cs
@@ -157,8 +157,6 @@ public class UmbracoAIProfileServiceConnectorTests
             Settings = new AIImageGenerationProfileSettings
             {
                 Size = "1024x1024",
-                Quality = "hd",
-                Style = "vivid",
                 MediaType = "image/png"
             }
         };
@@ -192,8 +190,6 @@ public class UmbracoAIProfileServiceConnectorTests
         savedProfile.ShouldNotBeNull();
         var settings = savedProfile.Settings.ShouldBeOfType<AIImageGenerationProfileSettings>();
         settings.Size.ShouldBe("1024x1024");
-        settings.Quality.ShouldBe("hd");
-        settings.Style.ShouldBe("vivid");
         settings.MediaType.ShouldBe("image/png");
     }
 

--- a/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIImageCapabilitySettings.cs
+++ b/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIImageCapabilitySettings.cs
@@ -1,0 +1,48 @@
+using System.Text.Json.Serialization;
+using Umbraco.AI.Core.EditableModels;
+using Umbraco.AI.Core.Serialization;
+
+namespace Umbraco.AI.OpenAI;
+
+/// <summary>
+/// Provider-declared, profile-level image-generation settings for OpenAI (surfaced on the profile editor
+/// and applied to each request).
+/// </summary>
+/// <remarks>
+/// Quality and style live here rather than in the core profile settings because Microsoft.Extensions.AI
+/// models neither as a first-class option — they exist only as provider hints, and their accepted values
+/// differ per model. Size and media type stay core, where M.E.AI does model them.
+/// </remarks>
+public class OpenAIImageCapabilitySettings
+{
+    /// <summary>
+    /// The rendering quality. Leave empty for the model default.
+    /// </summary>
+    /// <remarks>
+    /// One field covering two vocabularies: DALL·E 3 accepts <c>standard</c> and <c>hd</c>, gpt-image
+    /// accepts <c>low</c>, <c>medium</c>, <c>high</c> and <c>auto</c>. A value the selected model's family
+    /// does not accept is dropped rather than sent, so a profile carried across models degrades instead of
+    /// failing. Per-model option lists would need a declaration channel the metadata does not have yet.
+    /// </remarks>
+    [AIField(
+        Label = "Quality",
+        Description = "Rendering quality. DALL·E 3 accepts standard and hd; gpt-image accepts low, medium, high and auto. Leave empty for the model default.",
+        EditorUiAlias = "Umb.PropertyEditorUi.Dropdown",
+        EditorConfig = "[{\"alias\":\"multiple\",\"value\":false},{\"alias\":\"items\",\"value\":[\"auto\",\"low\",\"medium\",\"high\",\"standard\",\"hd\"]}]",
+        SortOrder = 1)]
+    [JsonConverter(typeof(DropdownStringJsonConverter))]
+    public string? Quality { get; set; }
+
+    /// <summary>
+    /// The rendering style. DALL·E 3 only — declared unsupported on every other model, so the field does
+    /// not render for them.
+    /// </summary>
+    [AIField(
+        Label = "Style",
+        Description = "Rendering style, supported by DALL·E 3 only. Leave empty for the model default.",
+        EditorUiAlias = "Umb.PropertyEditorUi.Dropdown",
+        EditorConfig = "[{\"alias\":\"multiple\",\"value\":false},{\"alias\":\"items\",\"value\":[\"vivid\",\"natural\"]}]",
+        SortOrder = 2)]
+    [JsonConverter(typeof(DropdownStringJsonConverter))]
+    public string? Style { get; set; }
+}

--- a/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIImageGeneratorCapability.cs
+++ b/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIImageGeneratorCapability.cs
@@ -28,7 +28,7 @@ namespace Umbraco.AI.OpenAI;
 public class OpenAIImageGeneratorCapability(
     OpenAIProvider provider,
     ILogger<OpenAIImageGeneratorCapability>? logger)
-    : AIImageGeneratorCapabilityBase<OpenAIProviderSettings>(provider)
+    : AIImageGeneratorCapabilityBase<OpenAIProviderSettings, OpenAIImageCapabilitySettings>(provider)
 {
     /// <summary>
     /// Initializes a new instance without a logger.
@@ -83,9 +83,54 @@ public class OpenAIImageGeneratorCapability(
         // bound ImageClient), enabling provider-native masked outpainting via GetService.
         var generator = new OpenAIImageGenerator(inner, client);
 
-        // Wrapped outside that, so the quality/style hints are translated no matter which caller assembled
-        // the options — the adapter ignores them otherwise. See OpenAIImageHintGenerator.
-        return new OpenAIImageHintGenerator(generator, logger);
+        // Wrapped outside that, so hints passed as additional properties by a direct consumer are still
+        // translated — the adapter ignores them otherwise. A profile's own settings arrive typed through
+        // ApplyCapabilitySettings instead. See OpenAIImageHintGenerator.
+        return new OpenAIImageHintGenerator(generator, modelId ?? DefaultImageModel, logger);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Style is DALL·E 3 only, so it is declared unsupported elsewhere and the profile editor drops the
+    /// field. Quality applies to every family but with different vocabularies, which
+    /// <see cref="ApplyCapabilitySettings"/> gates per request — a per-model list of allowed *values* would
+    /// need a declaration channel the model metadata does not have yet.
+    /// </remarks>
+    public override AIModelSettingsSupport GetSettingsSupport(string modelId)
+        => OpenAIImageHints.SupportsStyle(modelId)
+            ? AIModelSettingsSupport.Default
+            : new AIModelSettingsSupport
+            {
+                UnsupportedCapabilitySettings = [nameof(OpenAIImageCapabilitySettings.Style)],
+            };
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Translates the profile's hints into the SDK's own options, which is the only channel the adapter
+    /// reads. Gated with the same predicates that drive <see cref="GetSettingsSupport"/>, so a profile
+    /// carrying a value the selected model rejects degrades rather than failing the request.
+    /// </remarks>
+    protected override void ApplyCapabilitySettings(
+        OpenAIImageCapabilitySettings capabilitySettings,
+        string? modelId,
+        ImageGenerationOptions options)
+    {
+        if (options.RawRepresentationFactory is not null)
+        {
+            // A caller that built the SDK options itself is more specific than a profile-level default.
+            return;
+        }
+
+        var factory = OpenAIImageHints.CreateRawFactory(
+            capabilitySettings.Quality,
+            capabilitySettings.Style,
+            modelId ?? DefaultImageModel,
+            logger);
+
+        if (factory is not null)
+        {
+            options.RawRepresentationFactory = factory;
+        }
     }
 
     private static bool IsImageModel(string modelId)

--- a/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIImageHintGenerator.cs
+++ b/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIImageHintGenerator.cs
@@ -10,12 +10,15 @@ namespace Umbraco.AI.OpenAI;
 /// OpenAI SDK options the request is actually built from.
 /// </summary>
 /// <remarks>
-/// Wrapped outside the M.E.AI adapter but inside everything else, so the hints are translated no matter which
-/// caller assembled the <see cref="ImageGenerationOptions"/> — the profile's own settings, or a direct
-/// <see cref="IImageGenerator"/> consumer. Without it the hints are silently dropped; see
-/// <see cref="OpenAIImageHints"/>.
+/// Covers a direct <see cref="IImageGenerator"/> consumer that passes hints as additional properties, which
+/// the adapter ignores. A profile's own settings arrive typed through the capability's
+/// <c>ApplyCapabilitySettings</c> hook and are already a raw representation by the time they reach here, so
+/// this leaves them alone. See <see cref="OpenAIImageHints"/>.
 /// </remarks>
-internal sealed class OpenAIImageHintGenerator(IImageGenerator innerGenerator, ILogger? logger)
+internal sealed class OpenAIImageHintGenerator(
+    IImageGenerator innerGenerator,
+    string? boundModelId,
+    ILogger? logger)
     : DelegatingImageGenerator(innerGenerator)
 {
     /// <inheritdoc />
@@ -23,5 +26,5 @@ internal sealed class OpenAIImageHintGenerator(IImageGenerator innerGenerator, I
         ImageGenerationRequest request,
         ImageGenerationOptions? options = null,
         CancellationToken cancellationToken = default)
-        => base.GenerateAsync(request, OpenAIImageHints.Apply(options, logger), cancellationToken);
+        => base.GenerateAsync(request, OpenAIImageHints.Apply(options, boundModelId, logger), cancellationToken);
 }

--- a/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIImageHints.cs
+++ b/Umbraco.AI.OpenAI/src/Umbraco.AI.OpenAI/OpenAIImageHints.cs
@@ -7,20 +7,20 @@ using SdkImageGenerationOptions = OpenAI.Images.ImageGenerationOptions;
 namespace Umbraco.AI.OpenAI;
 
 /// <summary>
-/// Translates the provider-specific image hints (<c>quality</c>, <c>style</c>) into the OpenAI SDK's own
-/// options, which is the only channel that reaches the request.
+/// Translates the provider-specific image hints (quality, style) into the OpenAI SDK's own options, which
+/// is the only channel that reaches the request, and holds which models accept which values.
 /// </summary>
 /// <remarks>
 /// <para>
-/// The hints travel as <see cref="ImageGenerationOptions.AdditionalProperties"/> because
-/// Microsoft.Extensions.AI has no first-class property for either. The OpenAI adapter ignores that
-/// dictionary entirely — <c>OpenAIImageOptionsWireTests</c> pins both halves of that: the hints are absent
-/// from the body when passed as additional properties, and present when passed as a raw representation.
+/// Microsoft.Extensions.AI has no first-class property for either hint, and the OpenAI adapter ignores
+/// <see cref="ImageGenerationOptions.AdditionalProperties"/> entirely —
+/// <c>OpenAIImageOptionsWireTests</c> pins both halves of that. So the hints have to be handed over as a
+/// raw representation.
 /// </para>
 /// <para>
-/// Kept separate from the decorator that calls it so the same translation can be reused when these hints
-/// move to provider-declared capability settings, where the value arrives typed instead of as a loose
-/// dictionary entry.
+/// Two callers share this. The profile's capability settings arrive typed and gated per model; a direct
+/// <c>IImageGenerator</c> consumer can still pass them as additional properties, handled by
+/// <see cref="OpenAIImageHintGenerator"/>. One translation, so the two cannot drift.
 /// </para>
 /// </remarks>
 internal static class OpenAIImageHints
@@ -29,98 +29,167 @@ internal static class OpenAIImageHints
     internal const string StyleKey = "style";
 
     /// <summary>
-    /// The wire values the SDK understands. Which subset a given model accepts differs (<c>hd</c> and
-    /// <c>standard</c> are DALL·E 3; <c>low</c>, <c>medium</c>, <c>high</c> and <c>auto</c> are gpt-image),
-    /// so this is a spelling check rather than a support check — the API rejects a valid value sent to the
-    /// wrong model, and says so clearly.
+    /// Quality vocabularies by model family. DALL·E 2 accepts only <c>standard</c>, DALL·E 3 adds
+    /// <c>hd</c>, and gpt-image uses a different scale entirely.
     /// </summary>
-    private static readonly HashSet<string> KnownQualities =
-        new(StringComparer.OrdinalIgnoreCase) { "hd", "standard", "low", "medium", "high", "auto" };
+    private static readonly Dictionary<string, HashSet<string>> QualitiesByFamily =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["gpt-image"] = new(StringComparer.OrdinalIgnoreCase) { "auto", "low", "medium", "high" },
+            ["dall-e-3"] = new(StringComparer.OrdinalIgnoreCase) { "standard", "hd" },
+            ["dall-e-2"] = new(StringComparer.OrdinalIgnoreCase) { "standard" },
+        };
+
+    /// <summary>
+    /// Every value any known family accepts, used when the model itself is unrecognised — we cannot know
+    /// what it takes, so a deliberate value is passed through rather than dropped.
+    /// </summary>
+    private static readonly HashSet<string> AllKnownQualities =
+        new(QualitiesByFamily.Values.SelectMany(v => v), StringComparer.OrdinalIgnoreCase);
 
     private static readonly HashSet<string> KnownStyles =
         new(StringComparer.OrdinalIgnoreCase) { "vivid", "natural" };
 
     /// <summary>
-    /// Returns options carrying the hints as a raw representation, or the options unchanged when there is
-    /// nothing to translate.
+    /// Whether the model supports a style hint. DALL·E 3 only.
+    /// </summary>
+    /// <remarks>
+    /// Drives both the per-model declaration the editor reads and the request-time gate, so the field the
+    /// user sees and the value actually sent cannot disagree.
+    /// </remarks>
+    public static bool SupportsStyle(string? modelId)
+        => modelId?.StartsWith("dall-e-3", StringComparison.OrdinalIgnoreCase) == true;
+
+    /// <summary>
+    /// Builds a raw-representation factory carrying the given hints, or <c>null</c> when neither survives
+    /// gating.
+    /// </summary>
+    /// <param name="quality">The requested quality, or <c>null</c>.</param>
+    /// <param name="style">The requested style, or <c>null</c>.</param>
+    /// <param name="modelId">The model the request will run against, used to gate the values.</param>
+    /// <param name="logger">Optional logger, used when a hint is dropped.</param>
+    public static Func<IImageGenerator, object?>? CreateRawFactory(
+        string? quality,
+        string? style,
+        string? modelId,
+        ILogger? logger)
+    {
+        var resolvedQuality = ResolveQuality(quality, modelId, logger);
+        var resolvedStyle = ResolveStyle(style, modelId, logger);
+
+        if (resolvedQuality is null && resolvedStyle is null)
+        {
+            return null;
+        }
+
+        return _ =>
+        {
+            var raw = new SdkImageGenerationOptions();
+
+            if (resolvedQuality is not null)
+            {
+                raw.Quality = new global::OpenAI.Images.GeneratedImageQuality(resolvedQuality);
+            }
+
+            if (resolvedStyle is not null)
+            {
+                raw.Style = new global::OpenAI.Images.GeneratedImageStyle(resolvedStyle);
+            }
+
+            return raw;
+        };
+    }
+
+    /// <summary>
+    /// Returns options carrying any hints found in <see cref="ImageGenerationOptions.AdditionalProperties"/>
+    /// as a raw representation, or the options unchanged when there is nothing to translate.
     /// </summary>
     /// <param name="options">The caller's options. Never mutated.</param>
-    /// <param name="logger">Optional logger, used when a hint is skipped.</param>
-    public static ImageGenerationOptions? Apply(ImageGenerationOptions? options, ILogger? logger)
+    /// <param name="boundModelId">The model the generator was created for.</param>
+    /// <param name="logger">Optional logger, used when a hint is dropped.</param>
+    public static ImageGenerationOptions? Apply(
+        ImageGenerationOptions? options,
+        string? boundModelId,
+        ILogger? logger)
     {
         if (options?.AdditionalProperties is null)
         {
             return options;
         }
 
-        var quality = Read(options.AdditionalProperties, QualityKey, KnownQualities, logger);
-        var style = Read(options.AdditionalProperties, StyleKey, KnownStyles, logger);
-
-        if (quality is null && style is null)
-        {
-            return options;
-        }
-
         if (options.RawRepresentationFactory is not null)
         {
-            // A caller that has gone to the trouble of building the SDK options itself is more specific than
-            // a profile-level hint, and overwriting it would silently drop whatever else it set.
+            // Whoever built the SDK options — a caller directly, or the profile's capability settings
+            // upstream of here — is more specific than a loose dictionary entry, and overwriting the factory
+            // would drop whatever else it set.
             logger?.LogDebug(
-                "Image quality/style hints were ignored because the caller supplied its own raw representation.");
+                "Image hints in additional properties were ignored because a raw representation is already set.");
             return options;
         }
 
-        // Clone so the caller's instance is never mutated, then hand the SDK its own options type. The
-        // adapter fills everything the representation leaves empty (model, n, output format).
-        var effective = options.Clone();
-        effective.RawRepresentationFactory = _ =>
+        var factory = CreateRawFactory(
+            Read(options.AdditionalProperties, QualityKey),
+            Read(options.AdditionalProperties, StyleKey),
+            options.ModelId ?? boundModelId,
+            logger);
+
+        if (factory is null)
         {
-            var raw = new SdkImageGenerationOptions();
+            return options;
+        }
 
-            if (quality is not null)
-            {
-                raw.Quality = new global::OpenAI.Images.GeneratedImageQuality(quality);
-            }
-
-            if (style is not null)
-            {
-                raw.Style = new global::OpenAI.Images.GeneratedImageStyle(style);
-            }
-
-            return raw;
-        };
-
+        // Clone so the caller's instance is never mutated.
+        var effective = options.Clone();
+        effective.RawRepresentationFactory = factory;
         return effective;
     }
 
-    private static string? Read(
-        AdditionalPropertiesDictionary additionalProperties,
-        string key,
-        HashSet<string> known,
-        ILogger? logger)
+    private static string? ResolveQuality(string? value, string? modelId, ILogger? logger)
     {
-        if (!additionalProperties.TryGetValue(key, out var raw))
+        var quality = value?.Trim();
+        if (string.IsNullOrEmpty(quality))
         {
             return null;
         }
 
-        var value = (raw as string)?.Trim();
-        if (string.IsNullOrEmpty(value))
-        {
-            return null;
-        }
+        var family = QualitiesByFamily
+            .FirstOrDefault(f => modelId?.StartsWith(f.Key, StringComparison.OrdinalIgnoreCase) == true);
+        var accepted = family.Value ?? AllKnownQualities;
 
-        if (!known.Contains(value))
+        if (!accepted.Contains(quality))
         {
-            // Skipped rather than sent: an unrecognised spelling would fail the request outright, and a
-            // profile that has been saved with one should still be able to generate an image.
+            // Dropped rather than sent: the API rejects the whole request for a quality the model does not
+            // know, and a profile carried across models should degrade instead of failing outright.
             logger?.LogDebug(
-                "Ignoring unrecognised image {Hint} value '{Value}'.",
-                key,
-                value);
+                "Ignoring image quality '{Quality}', which model '{ModelId}' does not accept.",
+                quality,
+                modelId);
             return null;
         }
 
-        return value.ToLowerInvariant();
+        return quality.ToLowerInvariant();
     }
+
+    private static string? ResolveStyle(string? value, string? modelId, ILogger? logger)
+    {
+        var style = value?.Trim();
+        if (string.IsNullOrEmpty(style))
+        {
+            return null;
+        }
+
+        if (!KnownStyles.Contains(style) || !SupportsStyle(modelId))
+        {
+            logger?.LogDebug(
+                "Ignoring image style '{Style}' for model '{ModelId}'.",
+                style,
+                modelId);
+            return null;
+        }
+
+        return style.ToLowerInvariant();
+    }
+
+    private static string? Read(AdditionalPropertiesDictionary additionalProperties, string key)
+        => additionalProperties.TryGetValue(key, out var raw) ? raw as string : null;
 }

--- a/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/OpenAIImageOptionsWireTests.cs
+++ b/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/OpenAIImageOptionsWireTests.cs
@@ -78,7 +78,7 @@ public class OpenAIImageOptionsWireTests
         // End to end through the decorator the capability installs: hints in as additional properties, out
         // on the wire.
         var handler = new CapturingHttpMessageHandler();
-        var generator = new OpenAIImageHintGenerator(CreateImageGenerator(handler, "dall-e-3"), logger: null);
+        var generator = new OpenAIImageHintGenerator(CreateImageGenerator(handler, "dall-e-3"), "dall-e-3", logger: null);
 
         var options = new ImageGenerationOptions
         {
@@ -102,7 +102,7 @@ public class OpenAIImageOptionsWireTests
         // gpt-image accepts low/medium/high where DALL·E 3 accepts standard/hd, and the hint is passed
         // through rather than mapped, so both vocabularies work without a per-model table.
         var handler = new CapturingHttpMessageHandler();
-        var generator = new OpenAIImageHintGenerator(CreateImageGenerator(handler, "gpt-image-1"), logger: null);
+        var generator = new OpenAIImageHintGenerator(CreateImageGenerator(handler, "gpt-image-1"), "gpt-image-1", logger: null);
 
         var options = new ImageGenerationOptions
         {
@@ -119,7 +119,7 @@ public class OpenAIImageOptionsWireTests
     {
         // Sending it would fail the request outright; a profile saved with a typo should still generate.
         var handler = new CapturingHttpMessageHandler();
-        var generator = new OpenAIImageHintGenerator(CreateImageGenerator(handler, "gpt-image-1"), logger: null);
+        var generator = new OpenAIImageHintGenerator(CreateImageGenerator(handler, "gpt-image-1"), "gpt-image-1", logger: null);
 
         var options = new ImageGenerationOptions
         {
@@ -137,7 +137,7 @@ public class OpenAIImageOptionsWireTests
         // A caller that built the SDK options itself is more specific than a profile-level hint, and
         // overwriting its factory would drop whatever else it set.
         var handler = new CapturingHttpMessageHandler();
-        var generator = new OpenAIImageHintGenerator(CreateImageGenerator(handler, "dall-e-3"), logger: null);
+        var generator = new OpenAIImageHintGenerator(CreateImageGenerator(handler, "dall-e-3"), "dall-e-3", logger: null);
 
         var options = new ImageGenerationOptions
         {
@@ -157,13 +157,77 @@ public class OpenAIImageOptionsWireTests
     public async Task HintGenerator_NoHints_LeavesTheOptionsAlone()
     {
         var handler = new CapturingHttpMessageHandler();
-        var generator = new OpenAIImageHintGenerator(CreateImageGenerator(handler, "dall-e-3"), logger: null);
+        var generator = new OpenAIImageHintGenerator(CreateImageGenerator(handler, "dall-e-3"), "dall-e-3", logger: null);
 
         await SendAndIgnoreFailureAsync(generator, new ImageGenerationOptions { MediaType = "image/png" });
 
         var body = handler.RequestBodies.ShouldHaveSingleItem();
         body.ShouldContain("\"output_format\":\"png\"");
         body.ShouldNotContain("quality");
+    }
+
+    [Theory]
+    [InlineData("dall-e-3", "hd", true)]
+    [InlineData("dall-e-3", "high", false)]
+    [InlineData("gpt-image-1", "high", true)]
+    [InlineData("gpt-image-1", "hd", false)]
+    [InlineData("dall-e-2", "standard", true)]
+    [InlineData("dall-e-2", "hd", false)]
+    public async Task CapabilitySettings_Quality_IsGatedByModelVocabulary(
+        string modelId,
+        string quality,
+        bool expectedOnTheWire)
+    {
+        // One field, two vocabularies: DALL·E takes standard/hd, gpt-image takes low/medium/high/auto. A
+        // value the selected model does not know is dropped rather than sent, because the API rejects the
+        // whole request for it and a profile carried across models should degrade instead of failing.
+        var handler = new CapturingHttpMessageHandler();
+        var options = new ImageGenerationOptions
+        {
+            RawRepresentationFactory = OpenAIImageHints.CreateRawFactory(quality, style: null, modelId, logger: null),
+        };
+
+        await SendAndIgnoreFailureAsync(CreateImageGenerator(handler, modelId), options);
+
+        var body = handler.RequestBodies.ShouldHaveSingleItem();
+        if (expectedOnTheWire)
+        {
+            body.ShouldContain($"\"quality\":\"{quality}\"");
+        }
+        else
+        {
+            body.ShouldNotContain("quality");
+        }
+    }
+
+    [Fact]
+    public void CapabilitySettings_UnknownModel_PassesQualityThrough()
+    {
+        // We cannot know what an unrecognised model accepts, so a deliberate value goes out rather than
+        // being dropped on a guess.
+        OpenAIImageHints
+            .CreateRawFactory("hd", style: null, "some-future-image-model", logger: null)
+            .ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task CapabilitySettings_Style_OnlyReachesDallE3()
+    {
+        var handler = new CapturingHttpMessageHandler();
+        var options = new ImageGenerationOptions
+        {
+            RawRepresentationFactory = OpenAIImageHints.CreateRawFactory(
+                quality: null,
+                style: "vivid",
+                "gpt-image-1",
+                logger: null),
+        };
+
+        await SendAndIgnoreFailureAsync(CreateImageGenerator(handler, "gpt-image-1"), options);
+
+        // The editor hides the field on gpt-image via GetSettingsSupport, but a profile saved before the
+        // model changed still reaches here, so the gate is enforced rather than assumed.
+        handler.RequestBodies.ShouldHaveSingleItem().ShouldNotContain("style");
     }
 
     private static IImageGenerator CreateImageGenerator(CapturingHttpMessageHandler handler, string modelId)

--- a/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/OpenAISettingsDeclarationTests.cs
+++ b/Umbraco.AI.OpenAI/tests/Umbraco.AI.OpenAI.Tests.Unit/OpenAISettingsDeclarationTests.cs
@@ -2,6 +2,8 @@ using Microsoft.Extensions.Caching.Memory;
 using Umbraco.AI.Core.Models;
 using Umbraco.AI.OpenAI.Tests.Unit.Fakes;
 
+#pragma warning disable UMBRACOAI_IMAGEGEN // Covers the experimental image capability's declarations
+
 namespace Umbraco.AI.OpenAI.Tests.Unit;
 
 /// <summary>
@@ -45,7 +47,33 @@ public class OpenAISettingsDeclarationTests
         metadata[AIModelMetadataKeys.ProfileSettingsUnsupported].ShouldBe("temperature");
     }
 
+    [Fact]
+    public void ImageGetSettingsSupport_DallE3_DeclaresNothing()
+    {
+        // Style is a DALL·E 3 feature, so it is the one family where the field should render.
+        CreateImageCapability().GetSettingsSupport("dall-e-3").ToMetadata().ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("gpt-image-1")]
+    [InlineData("dall-e-2")]
+    [InlineData("some-future-image-model")]
+    public void ImageGetSettingsSupport_ModelWithoutStyle_DeclaresStyleUnsupported(string modelId)
+    {
+        var metadata = CreateImageCapability().GetSettingsSupport(modelId).ToMetadata();
+
+        metadata[AIModelMetadataKeys.CapabilitySettingsUnsupported].ShouldBe("style");
+        // Quality applies to every family, just with different values, so it is never declared unsupported —
+        // the per-request gate handles the vocabulary difference.
+        metadata[AIModelMetadataKeys.CapabilitySettingsUnsupported].ShouldNotContain("quality");
+    }
+
     private static OpenAIChatCapability CreateCapability()
+        => new(
+            new OpenAIProvider(new FakeProviderInfrastructure(), new MemoryCache(new MemoryCacheOptions())),
+            logger: null);
+
+    private static OpenAIImageGeneratorCapability CreateImageCapability()
         => new(
             new OpenAIProvider(new FakeProviderInfrastructure(), new MemoryCache(new MemoryCacheOptions())),
             logger: null);

--- a/Umbraco.AI/src/Umbraco.AI.Core/ImageGeneration/AIImageGenerationService.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/ImageGeneration/AIImageGenerationService.cs
@@ -333,19 +333,6 @@ internal sealed class AIImageGenerationService : IAIImageGenerationService
             options.MediaType = settings.MediaType;
         }
 
-        // Forward provider-specific hints for adapters that read them.
-        if (!string.IsNullOrWhiteSpace(settings?.Quality))
-        {
-            options.AdditionalProperties ??= new AdditionalPropertiesDictionary();
-            options.AdditionalProperties["quality"] = settings.Quality;
-        }
-
-        if (!string.IsNullOrWhiteSpace(settings?.Style))
-        {
-            options.AdditionalProperties ??= new AdditionalPropertiesDictionary();
-            options.AdditionalProperties["style"] = settings.Style;
-        }
-
         return options;
     }
 

--- a/Umbraco.AI/src/Umbraco.AI.Core/Profiles/AIImageGenerationProfileSettings.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Profiles/AIImageGenerationProfileSettings.cs
@@ -4,9 +4,16 @@ namespace Umbraco.AI.Core.Profiles;
 /// Profile settings specific to the image-generation capability.
 /// </summary>
 /// <remarks>
+/// <para>
 /// These are use-case <em>policy</em> defaults ("house style") for a profile, overridable per call.
 /// Request mechanics such as image count and response format are intentionally <em>not</em> here — they
 /// are passed at generation time (e.g. via the builder options or the REST request).
+/// </para>
+/// <para>
+/// Only settings Microsoft.Extensions.AI models as first-class options live here. Provider-specific hints
+/// such as quality and style are declared by the provider as capability settings instead, so their values
+/// can be offered per model rather than typed blind.
+/// </para>
 /// </remarks>
 public sealed class AIImageGenerationProfileSettings : IAIProfileSettings
 {
@@ -14,18 +21,6 @@ public sealed class AIImageGenerationProfileSettings : IAIProfileSettings
     /// Default image size as <c>"{width}x{height}"</c> (e.g. <c>"1024x1024"</c>).
     /// </summary>
     public string? Size { get; init; }
-
-    /// <summary>
-    /// Provider-specific quality hint (e.g. <c>"hd"</c> for DALL·E 3, <c>"high"</c> for gpt-image-1).
-    /// Supported values vary by model.
-    /// </summary>
-    public string? Quality { get; init; }
-
-    /// <summary>
-    /// Provider-specific style hint (e.g. <c>"vivid"</c>, <c>"natural"</c> for DALL·E 3).
-    /// Supported values vary by model.
-    /// </summary>
-    public string? Style { get; init; }
 
     /// <summary>
     /// Default output media type (MIME type) of the generated images, e.g. <c>"image/png"</c>,

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/type-mapper.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/type-mapper.ts
@@ -115,8 +115,6 @@ export const UaiProfileTypeMapper = {
             return {
                 $type: "imageGeneration",
                 size: img.size ?? null,
-                quality: img.quality ?? null,
-                style: img.style ?? null,
                 mediaType: img.mediaType ?? null,
             } as UaiImageGenerationProfileSettings;
         }
@@ -166,8 +164,6 @@ export const UaiProfileTypeMapper = {
             return {
                 $type: "imageGeneration",
                 size: settings.size,
-                quality: settings.quality,
-                style: settings.style,
                 mediaType: settings.mediaType,
             } as ImageGenerationProfileSettingsModel;
         }

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/types.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/types.ts
@@ -49,8 +49,6 @@ export interface UaiSpeechToTextProfileSettings extends UaiProfileSettings {
 export interface UaiImageGenerationProfileSettings extends UaiProfileSettings {
     $type: "imageGeneration";
     size: string | null;
-    quality: string | null;
-    style: string | null;
     mediaType: string | null;
 }
 

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/workspace/profile/views/profile-details-workspace-view.element.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/workspace/profile/views/profile-details-workspace-view.element.ts
@@ -456,18 +456,6 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
     #cachedImageSizeOptionsKey?: string;
     #cachedImageSizeOptions?: Array<{ name: string; value: string; selected?: boolean }>;
 
-    #onImageQualityChange(event: Event) {
-        event.stopPropagation();
-        const target = event.target as HTMLInputElement;
-        this.#updateImageGenerationSettings({ quality: target.value || null });
-    }
-
-    #onImageStyleChange(event: Event) {
-        event.stopPropagation();
-        const target = event.target as HTMLInputElement;
-        this.#updateImageGenerationSettings({ style: target.value || null });
-    }
-
     #onImageMediaTypeChange(event: Event) {
         event.stopPropagation();
         const target = event.target as HTMLInputElement;
@@ -481,8 +469,6 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
             : {
                 $type: "imageGeneration",
                 size: updates.size ?? null,
-                quality: updates.quality ?? null,
-                style: updates.style ?? null,
                 mediaType: updates.mediaType ?? null,
             };
 
@@ -670,26 +656,6 @@ export class UaiProfileDetailsWorkspaceViewElement extends UmbLitElement {
                         type="text"
                         .value=${imageSettings?.mediaType ?? ""}
                         @input=${this.#onImageMediaTypeChange}
-                        placeholder="Provider default"
-                    ></uui-input>
-                </umb-property-layout>
-
-                <umb-property-layout label="Quality" description="Provider-specific quality hint (e.g. &quot;hd&quot; for DALL·E 3, &quot;high&quot; for gpt-image-1). Values vary by model.">
-                    <uui-input
-                        slot="editor"
-                        type="text"
-                        .value=${imageSettings?.quality ?? ""}
-                        @input=${this.#onImageQualityChange}
-                        placeholder="Provider default"
-                    ></uui-input>
-                </umb-property-layout>
-
-                <umb-property-layout label="Style" description="Provider-specific style hint (e.g. &quot;vivid&quot;, &quot;natural&quot; for DALL·E 3). Values vary by model.">
-                    <uui-input
-                        slot="editor"
-                        type="text"
-                        .value=${imageSettings?.style ?? ""}
-                        @input=${this.#onImageStyleChange}
                         placeholder="Provider default"
                     ></uui-input>
                 </umb-property-layout>

--- a/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/Profile/Mapping/ProfileMapDefinition.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/Profile/Mapping/ProfileMapDefinition.cs
@@ -123,8 +123,6 @@ public class ProfileMapDefinition : IMapDefinition
             AIImageGenerationProfileSettings imageGeneration => new ImageGenerationProfileSettingsModel
             {
                 Size = imageGeneration.Size,
-                Quality = imageGeneration.Quality,
-                Style = imageGeneration.Style,
                 MediaType = imageGeneration.MediaType
             },
             _ => null
@@ -157,8 +155,6 @@ public class ProfileMapDefinition : IMapDefinition
             AICapability.ImageGeneration when settings is ImageGenerationProfileSettingsModel imageGeneration => new AIImageGenerationProfileSettings
             {
                 Size = imageGeneration.Size,
-                Quality = imageGeneration.Quality,
-                Style = imageGeneration.Style,
                 MediaType = imageGeneration.MediaType
             },
             AICapability.ImageGeneration => new AIImageGenerationProfileSettings(),

--- a/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/Profile/Models/ProfileSettingsModels.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/Profile/Models/ProfileSettingsModels.cs
@@ -79,15 +79,7 @@ public class ImageGenerationProfileSettingsModel : ProfileSettingsModel
     /// </summary>
     public string? Size { get; init; }
 
-    /// <summary>
-    /// Provider-specific quality hint (e.g. "hd", "high"). Varies by model.
-    /// </summary>
-    public string? Quality { get; init; }
 
-    /// <summary>
-    /// Provider-specific style hint (e.g. "vivid", "natural"). Varies by model.
-    /// </summary>
-    public string? Style { get; init; }
 
     /// <summary>
     /// Default output media type (MIME) of the generated images (e.g. "image/png"). Varies by model.

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/ImageGeneration/AIImageGenerationServiceTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/ImageGeneration/AIImageGenerationServiceTests.cs
@@ -122,17 +122,17 @@ public class AIImageGenerationServiceTests
     }
 
     [Fact]
-    public async Task GenerateImagesAsync_ForwardsProfileHintsUnderTheKeysProvidersRead()
+    public async Task GenerateImagesAsync_DoesNotInventProviderHints()
     {
-        // Quality and style have no first-class option property, so they cross into the provider as
-        // additional properties. That makes the key names a contract: the OpenAI provider reads exactly
-        // these to translate them into its SDK options, and a rename on either side would put the hints
-        // back to silently doing nothing — which is what they did before that translation existed.
+        // Quality and style used to travel from here as additional properties, which the OpenAI adapter
+        // ignored — so they did nothing at all. They are now provider-declared capability settings, applied
+        // by the provider itself. This holds the core side of that move: nothing here fabricates a hint,
+        // so there is only ever one place those values come from.
         var generator = new FakeImageGenerator();
         var profile = new AIProfileBuilder()
             .WithCapability(AICapability.ImageGeneration)
             .WithModel("fake-provider", "dall-e-3")
-            .WithSettings(new AIImageGenerationProfileSettings { Quality = "hd", Style = "vivid" })
+            .WithSettings(new AIImageGenerationProfileSettings { Size = "1024x1024", MediaType = "image/png" })
             .Build();
 
         _profileServiceMock
@@ -145,9 +145,11 @@ public class AIImageGenerationServiceTests
         await _service.GenerateImagesAsync(b => b.WithAlias("hints"), "a cat");
 
         var options = generator.ReceivedOptions.ShouldHaveSingleItem();
-        options!.AdditionalProperties.ShouldNotBeNull();
-        options.AdditionalProperties["quality"].ShouldBe("hd");
-        options.AdditionalProperties["style"].ShouldBe("vivid");
+        // The first-class settings still flow, because M.E.AI models them.
+        options!.ImageSize.ShouldNotBeNull();
+        options.MediaType.ShouldBe("image/png");
+        options.AdditionalProperties?.ContainsKey("quality").ShouldNotBe(true);
+        options.AdditionalProperties?.ContainsKey("style").ShouldNotBe(true);
     }
 
     [Fact]


### PR DESCRIPTION
PR 4 of `plan-capability-settings-consistency.md`, and the one the earlier PRs were building toward. **Breaking, deliberately** — see the upgrade note at the end.

## Why move them

Quality and Style were core profile settings holding provider-specific strings. M.E.AI models neither as a first-class option, so core could only offer a free-text box, and the accepted values differ per model:

| Model family | Quality | Style |
|---|---|---|
| DALL·E 3 | `standard`, `hd` | `vivid`, `natural` |
| DALL·E 2 | `standard` | — |
| gpt-image | `low`, `medium`, `high`, `auto` | — |

Typed blind, with no clue which set applied. That is exactly the shape the plan's rule assigns to provider-declared capability settings, and #275 made that mechanism available to image generation.

## What changed

- **`OpenAIImageCapabilitySettings`** with Quality and Style as dropdowns, rendered by the existing schema-driven editor and filtered per model — no new UI code.
- **`OpenAIImageGeneratorCapability`** now derives from the two-parameter base, declares `Style` unsupported on anything but DALL·E 3, and applies both hints through `ApplyCapabilitySettings`.
- **Quality is gated per request** against the selected model's vocabulary. A value the model does not know is dropped rather than sent: the API rejects the whole request for it, and a profile carried across models should degrade instead of failing. An unrecognised *model* passes the value through, since we cannot know what it accepts.
- **One predicate drives the declaration and the gate**, so the field a user sees and the value actually sent cannot disagree. That was the rule #269 set and it holds here.
- `OpenAIImageHints` still translates hints passed as additional properties, which remains the route for a direct `IImageGenerator` consumer. A raw representation already on the options wins, so profile settings beat a loose dictionary entry.

## Verification

Backoffice against the database, on a gpt-image-1 profile:

```
settings           = {"size":null,"mediaType":null}     ← Quality/Style gone from core
capabilitySettings = {"quality":"high"}                 ← provider's own bag
```

System Settings now lists only Connection, Model, Size and Media Type. The provider's schema on that model contains **only** `quality` — Style is filtered out by the declaration, which is the per-model filtering doing its job rather than a hand-written branch.

Wire-level gating, asserted on captured request bodies:

| Model | Quality | On the wire |
|---|---|---|
| dall-e-3 | `hd` | yes |
| dall-e-3 | `high` | no |
| gpt-image-1 | `high` | yes |
| gpt-image-1 | `hd` | no |
| dall-e-2 | `standard` | yes |
| dall-e-2 | `hd` | no |

Plus: style never reaches a non-DALL·E-3 model even when stored, and an unknown model passes a quality through.

```
Umbraco.AI 1,050 · OpenAI 66 · Agent 175 · Prompt 84 · Search 47
Deploy 19 · Automate 40 · Agent.Deploy 7 · Prompt.Deploy 6
```

Every dependent product built and tested, since a core public type lost members. Deploy had a profile round-trip test asserting the two properties; updated.

## Upgrade note (breaking)

`AIImageGenerationProfileSettings.Quality` and `.Style` are **removed**, along with their API model properties and editor fields. Values stored under the old shape are ignored and need re-entering under the provider's settings on the profile editor.

Shipped without an obsolete shim because image generation is experimental — gated by `UMBRACOAI_IMAGEGEN` and the `Umbraco:AI:Experimental:ImageGeneration` flag — and confirmed as breakable.

**No data migration, on purpose.** The target keys belong to a provider's schema, so a core migration writing them would put vendor knowledge in core — the exact coupling this design exists to avoid. Worth noting the values never reached OpenAI at all until #277, so nothing that previously *worked* stops working; the affected case is a value that was already doing nothing.

## Remaining in the plan

PR 5 (embedding `Dimensions` declared per model) and PR 6 (the remaining metadata guards). Also still open from the earlier review: `maxEdge`, `supportsEdit` and `supportsMask` have readers but no consumer.

v17 backport to follow once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
