### PR TITLE
fix(frontend): Import the setting rules' helper directly rather than via the barrel

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/workspace/profile/views/settings/declared-settings.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/profile/workspace/profile/views/settings/declared-settings.ts
@@ -1,4 +1,8 @@
-import { isProfileSettingSupported } from "../../../../../core/index.js";
+// Imported from the module rather than the core barrel: this file holds pure functions, and reaching
+// through the barrel pulls the whole component library (and therefore uui) into anything that imports it,
+// including the tests. On the v17 line that broke the suite outright, because the uui version resolved
+// there has a directory import Node cannot resolve — this line passes only by luck of its resolved version.
+import { isProfileSettingSupported } from "../../../../../core/utils/model-settings.utils.js";
 import type { UaiProfileSettings } from "../../../../types.js";
 
 /**


### PR DESCRIPTION
Ports the one v17-specific commit from #284 back to this line, so the two are identical.

## Why

`declared-settings.ts` holds pure functions, but imported one of them through the **core barrel**, which pulls the entire component library — and therefore `uui` — into everything that imports the module, tests included.

On v17 that broke outright: the `uui` version resolved there has a directory import Node cannot resolve, so the new vitest suite failed to load with `Tests: no tests`. This line passes only by luck of the version it happens to resolve, which leaves the two lines one dependency bump apart from diverging.

Narrowed to the module that defines the helper.

## Verification

```
Frontend: build clean · vitest 13 passed
```

One import line; no behaviour to test beyond the suite that exposed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
