### PR TITLE
fix(microsoft-foundry): Declare per-model setting support

### DIFF
--- a/Umbraco.AI.MicrosoftFoundry/CLAUDE.md
+++ b/Umbraco.AI.MicrosoftFoundry/CLAUDE.md
@@ -20,11 +20,10 @@ Umbraco.AI.MicrosoftFoundry is a provider plugin for Umbraco.AI that enables int
 
 ### Project Structure
 
-This provider uses a simplified structure (single project):
-
-| Project                       | Purpose                                             |
-| ----------------------------- | --------------------------------------------------- |
-| `Umbraco.AI.MicrosoftFoundry` | Provider implementation, capabilities, and settings |
+| Project                                  | Purpose                                             |
+| ---------------------------------------- | --------------------------------------------------- |
+| `Umbraco.AI.MicrosoftFoundry`            | Provider implementation, capabilities, and settings |
+| `Umbraco.AI.MicrosoftFoundry.Tests.Unit` | Unit tests                                          |
 
 ### Provider Implementation
 
@@ -73,6 +72,46 @@ Authentication is determined at runtime based on which settings fields are popul
 - Lists embedding models from the models/deployments API
 - Default model: `text-embedding-3-small`
 
+### Per-Model Setting Support
+
+Foundry is a **gateway**: it fronts other vendors' models and inherits their per-model restrictions without
+owning any of them. Both capabilities override `GetSettingsSupport`, which the core capability bases both
+project into the model list (so the profile editor hides what does not apply) and enforce per request (so a
+stale profile cannot send it). `MicrosoftFoundryModelUtilities` holds the predicates behind it.
+
+The gateway shape makes these predicates deliberately **different from the first-party provider packages**,
+and the difference is easy to get wrong:
+
+- **Unknown models are treated as supported**, the opposite of the allow-lists in `Umbraco.AI.OpenAI` and
+  `Umbraco.AI.Anthropic`. Those packages each own a closed set of models with a known restriction, so an
+  allow-list means an unrecognised model degrades rather than fails. Foundry's catalogue is mostly Mistral,
+  Llama, Cohere, Phi and Nova, almost none of which restrict anything, so the same allow-list would stop
+  sending a temperature that most of the catalogue honours today.
+- **Within a vendor known to restrict, allow-list semantics still apply.** A name that reads as OpenAI's or
+  Anthropic's but is unrecognised (a future `gpt-6`, a `claude-opus-4-9`) is treated as restricted, so the
+  fail-safe behaviour is kept exactly where it is warranted.
+- **A reported publisher can only rule a restriction out, never in** — a Llama deployment named `o3-llama`
+  must not inherit o3's restriction, but knowing only that a vendor is OpenAI is not enough to infer that a
+  given deployment is restricted.
+- **Azure spells GPT-3.5 without the dot** (`gpt-35-turbo`), because an Azure model name cannot contain one.
+  OpenAI's own `^gpt-3\.5` pattern never has to match that, so the undotted form is listed here separately.
+
+The family patterns duplicate a small part of `OpenAIModelUtilities` and `AnthropicModelUtilities`. That is
+intentional — sharing them would couple independently released packages, and lifting them into core would put
+vendor knowledge where it does not belong — so **a change to a vendor's restrictions needs the same edit in
+every package naming that vendor's families**.
+
+### Deployment Metadata
+
+The deployments API reports `modelName`, `modelVersion` and `modelPublisher` alongside the deployment name.
+This matters because **a deployment name is user-chosen and can say nothing about the model behind it**: a
+deployment called `prod-chat` may front `o3`. The provider carries all three onto `MicrosoftFoundryModelInfo`
+and caches each entry under its own key, so `TryGetModelInfo` can read them synchronously at request time.
+Both capabilities prefetch the (cached) model list when creating a client so that lookup is warm.
+
+They are `null` on the models API path, which reports only an ID, so every consumer has to cope with not
+knowing — that case falls back to reasoning from the ID, which keeps today's behaviour rather than guessing.
+
 ### Settings System
 
 Settings use the `[AIField]` attribute with groups for UI organization:
@@ -109,7 +148,7 @@ Values prefixed with `$` are resolved from `IConfiguration` (e.g., `"$Umbraco:AI
 ### Model Listing Strategy
 
 - **API Key auth**: Calls `GET {endpoint}/openai/models?api-version=2024-10-21` — returns all models available in the catalog.
-- **Entra ID auth (with ProjectName)**: Calls `GET {endpoint}/api/projects/{ProjectName}/deployments?api-version=v1` using `https://ai.azure.com/.default` scope — returns only deployed models. Falls back to the models API if the deployments call fails. Requires `Azure AI Developer` RBAC role.
+- **Entra ID auth (with ProjectName)**: Calls `GET {endpoint}/api/projects/{ProjectName}/deployments?api-version=v1` using `https://ai.azure.com/.default` scope — returns only deployed models, and the only path that reports what each deployment fronts (see Deployment Metadata). Falls back to the models API if the deployments call fails. Requires `Azure AI Developer` RBAC role.
 - **Entra ID auth (without ProjectName)**: Falls back to the models API using `https://cognitiveservices.azure.com/.default` scope.
 
 ## Key Namespaces

--- a/Umbraco.AI.MicrosoftFoundry/Umbraco.AI.MicrosoftFoundry.slnx
+++ b/Umbraco.AI.MicrosoftFoundry/Umbraco.AI.MicrosoftFoundry.slnx
@@ -7,5 +7,8 @@
   <Folder Name="/src/">
     <Project Path="src/Umbraco.AI.MicrosoftFoundry/Umbraco.AI.MicrosoftFoundry.csproj" />
   </Folder>
+  <Folder Name="/Tests/">
+    <Project Path="tests/Umbraco.AI.MicrosoftFoundry.Tests.Unit/Umbraco.AI.MicrosoftFoundry.Tests.Unit.csproj" />
+  </Folder>
   <Project Path="../Umbraco.AI/src/Umbraco.AI.Core/Umbraco.AI.Core.csproj" />
 </Solution>

--- a/Umbraco.AI.MicrosoftFoundry/src/Umbraco.AI.MicrosoftFoundry/MicrosoftFoundryChatCapability.cs
+++ b/Umbraco.AI.MicrosoftFoundry/src/Umbraco.AI.MicrosoftFoundry/MicrosoftFoundryChatCapability.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Umbraco.AI.Core.Models;
 using Umbraco.AI.Core.Providers;
+using Umbraco.AI.Extensions;
 
 namespace Umbraco.AI.MicrosoftFoundry;
 
@@ -20,6 +21,10 @@ public class MicrosoftFoundryChatCapability(MicrosoftFoundryProvider provider, I
     private new MicrosoftFoundryProvider Provider => (MicrosoftFoundryProvider)base.Provider;
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Declarations are attached here from the same predicate <see cref="GetSettingsSupport"/> uses, with
+    /// each model's listing entry passed in directly rather than read back from the provider's cache.
+    /// </remarks>
     protected override async Task<IReadOnlyList<AIModelDescriptor>> GetModelsAsync(
         MicrosoftFoundryProviderSettings settings,
         CancellationToken cancellationToken = default)
@@ -30,16 +35,74 @@ public class MicrosoftFoundryChatCapability(MicrosoftFoundryProvider provider, I
             .Where(IsChatModel)
             .Select(m => new AIModelDescriptor(
                 new AIModelRef(Provider.Id, m.Id),
-                m.Id))
+                MicrosoftFoundryModelUtilities.FormatDisplayName(m.Id, m.ModelName, m.ModelVersion),
+                BuildSettingsSupport(m.Id, m).ToMetadata()))
             .ToList();
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Foundry fronts other vendors' models, so it inherits their restrictions: an o-series or GPT-5
+    /// deployment rejects the sampling parameters exactly as it would on OpenAI directly, and a Claude 4.7+
+    /// deployment as it would on Anthropic. The base enforces whatever this returns, so the model list, the
+    /// editor and the request all read one declaration.
+    /// </remarks>
+    public override AIModelSettingsSupport GetSettingsSupport(string modelId)
+        => BuildSettingsSupport(modelId, Provider.TryGetModelInfo(modelId));
+
+    /// <summary>
+    /// Turns a model's listing entry into the settings declaration the editor reads and the base enforces.
+    /// </summary>
+    /// <remarks>
+    /// The entry is what makes the deployments API path accurate: it carries the model a deployment fronts,
+    /// so a deployment called <c>prod-chat</c> is judged on the <c>o3</c> behind it. A <c>null</c> entry —
+    /// the models API path, or a model absent from the last listing — falls back to reasoning from the ID.
+    /// </remarks>
+    private static AIModelSettingsSupport BuildSettingsSupport(string modelId, MicrosoftFoundryModelInfo? info)
+        => MicrosoftFoundryModelUtilities.SupportsSamplingParameters(modelId, info?.ModelName, info?.ModelPublisher)
+            ? AIModelSettingsSupport.Default
+            : new AIModelSettingsSupport
+            {
+                UnsupportedProfileSettings = AIProfileSettingKeys.Sampling,
+            };
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// <para>
+    /// Fetches the model list (cached) before building the client, so <see cref="GetSettingsSupport"/> can
+    /// read the target deployment's underlying model synchronously when the base enforces the declaration.
+    /// Without the prefetch, a deployment name that hides its model would always fall back to the ID.
+    /// </para>
+    /// <para>
+    /// A failure is not fatal — the listing refines the decision but is not required to make a request, and
+    /// losing it must not stop chat from working — so it degrades to reasoning from the ID, and logs,
+    /// because that fallback is less accurate and otherwise invisible. Cancellation is not caught: if the
+    /// caller has given up, this should too rather than continue building a client.
+    /// </para>
+    /// </remarks>
     [Experimental("OPENAI001")]
-    protected override IChatClient CreateClient(MicrosoftFoundryProviderSettings settings, string? modelId)
+    protected override async Task<IChatClient> CreateClientAsync(
+        MicrosoftFoundryProviderSettings settings,
+        string? modelId,
+        CancellationToken cancellationToken = default)
     {
+        try
+        {
+            await Provider.GetAvailableModelsAsync(settings, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogDebug(
+                ex,
+                "Could not list Microsoft AI Foundry models while creating a chat client. The model a "
+                + "deployment fronts is unavailable, so setting support will be inferred from the model ID "
+                + "instead.");
+        }
+
         var model = modelId ?? DefaultChatModel;
 
+        // The declaration from GetSettingsSupport is enforced by the base, which wraps this client so the
+        // sampling parameters are stripped for a model that rejects them. See DeclaredSettingsChatClient.
         if (settings.UseResponsesApi)
         {
             return MicrosoftFoundryProvider.CreateOpenAIClient(settings, logger)

--- a/Umbraco.AI.MicrosoftFoundry/src/Umbraco.AI.MicrosoftFoundry/MicrosoftFoundryEmbeddingCapability.cs
+++ b/Umbraco.AI.MicrosoftFoundry/src/Umbraco.AI.MicrosoftFoundry/MicrosoftFoundryEmbeddingCapability.cs
@@ -1,6 +1,10 @@
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Umbraco.AI.Core.Models;
 using Umbraco.AI.Core.Providers;
+using Umbraco.AI.Extensions;
+using Umbraco.Cms.Core.DependencyInjection;
 
 namespace Umbraco.AI.MicrosoftFoundry;
 
@@ -11,13 +15,36 @@ namespace Umbraco.AI.MicrosoftFoundry;
 /// Supports all embedding models available through Microsoft AI Foundry, including
 /// OpenAI (text-embedding-3-small, text-embedding-3-large) and other models.
 /// </remarks>
-public class MicrosoftFoundryEmbeddingCapability(MicrosoftFoundryProvider provider) : AIEmbeddingCapabilityBase<MicrosoftFoundryProviderSettings>(provider)
+public class MicrosoftFoundryEmbeddingCapability(
+    MicrosoftFoundryProvider provider,
+    ILogger<MicrosoftFoundryEmbeddingCapability>? logger)
+    : AIEmbeddingCapabilityBase<MicrosoftFoundryProviderSettings>(provider)
 {
+    /// <summary>
+    /// Initializes a new instance without a logger.
+    /// </summary>
+    /// <remarks>
+    /// Retained so adding the logger parameter stays binary compatible. An optional parameter would not
+    /// achieve that — the compiler emits a single constructor and bakes the default in at each call site,
+    /// so assemblies compiled against the previous signature would fail to bind. The logger is resolved
+    /// through the service locator so a consumer still on this signature gets real logging rather than none;
+    /// null-conditional because the locator is unset before startup and in unit tests.
+    /// </remarks>
+    [Obsolete("Use the constructor that accepts a logger. Will be removed in v20.")]
+    public MicrosoftFoundryEmbeddingCapability(MicrosoftFoundryProvider provider)
+        : this(provider, StaticServiceProvider.Instance?.GetService<ILogger<MicrosoftFoundryEmbeddingCapability>>())
+    {
+    }
+
     private const string DefaultEmbeddingModel = "text-embedding-3-small";
 
     private new MicrosoftFoundryProvider Provider => (MicrosoftFoundryProvider)base.Provider;
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Declarations are attached here from the same predicate <see cref="GetSettingsSupport"/> uses, with
+    /// each model's listing entry passed in directly rather than read back from the provider's cache.
+    /// </remarks>
     protected override async Task<IReadOnlyList<AIModelDescriptor>> GetModelsAsync(
         MicrosoftFoundryProviderSettings settings,
         CancellationToken cancellationToken = default)
@@ -28,15 +55,65 @@ public class MicrosoftFoundryEmbeddingCapability(MicrosoftFoundryProvider provid
             .Where(IsEmbeddingModel)
             .Select(m => new AIModelDescriptor(
                 new AIModelRef(Provider.Id, m.Id),
-                m.Id))
+                MicrosoftFoundryModelUtilities.FormatDisplayName(m.Id, m.ModelName, m.ModelVersion),
+                BuildSettingsSupport(m.Id, m).ToMetadata()))
             .ToList();
     }
 
     /// <inheritdoc />
-    protected override IEmbeddingGenerator<string, Embedding<float>> CreateGenerator(MicrosoftFoundryProviderSettings settings, string? modelId)
-        => MicrosoftFoundryProvider.CreateAzureOpenAIClient(settings)
+    /// <remarks>
+    /// Shortened embeddings are a <c>text-embedding-3</c> feature, so a profile's Dimensions cannot apply to
+    /// an <c>ada-002</c> deployment. Declaring it hides the field for those models and, because the base
+    /// enforces what is declared, also strips the value from a request that still carries one.
+    /// </remarks>
+    public override AIModelSettingsSupport GetSettingsSupport(string modelId)
+        => BuildSettingsSupport(modelId, Provider.TryGetModelInfo(modelId));
+
+    /// <summary>
+    /// Turns a model's listing entry into the settings declaration the editor reads and the base enforces.
+    /// </summary>
+    /// <remarks>
+    /// A <c>null</c> entry — the models API path, or a model absent from the last listing — falls back to
+    /// reasoning from the ID.
+    /// </remarks>
+    private static AIModelSettingsSupport BuildSettingsSupport(string modelId, MicrosoftFoundryModelInfo? info)
+        => MicrosoftFoundryModelUtilities.SupportsDimensions(modelId, info?.ModelName, info?.ModelPublisher)
+            ? AIModelSettingsSupport.Default
+            : new AIModelSettingsSupport
+            {
+                UnsupportedProfileSettings = [AIProfileSettingKeys.Dimensions],
+            };
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Prefetches the model list for the same reason the chat capability does: so the declaration the base
+    /// enforces can be made against the model a deployment fronts rather than its name. A failure degrades
+    /// to reasoning from the ID and logs, since losing the listing must not stop embedding from working.
+    /// </remarks>
+    protected override async Task<IEmbeddingGenerator<string, Embedding<float>>> CreateGeneratorAsync(
+        MicrosoftFoundryProviderSettings settings,
+        string? modelId,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await Provider.GetAvailableModelsAsync(settings, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger?.LogDebug(
+                ex,
+                "Could not list Microsoft AI Foundry models while creating an embedding generator. The "
+                + "model a deployment fronts is unavailable, so setting support will be inferred from the "
+                + "model ID instead.");
+        }
+
+        // The declaration from GetSettingsSupport is enforced by the base, which wraps this generator so
+        // Dimensions is stripped for a model that rejects it. See DeclaredSettingsEmbeddingGenerator.
+        return MicrosoftFoundryProvider.CreateAzureOpenAIClient(settings)
             .GetEmbeddingClient(modelId ?? DefaultEmbeddingModel)
             .AsIEmbeddingGenerator();
+    }
 
     private static bool IsEmbeddingModel(MicrosoftFoundryModelInfo model)
     {

--- a/Umbraco.AI.MicrosoftFoundry/src/Umbraco.AI.MicrosoftFoundry/MicrosoftFoundryModelUtilities.cs
+++ b/Umbraco.AI.MicrosoftFoundry/src/Umbraco.AI.MicrosoftFoundry/MicrosoftFoundryModelUtilities.cs
@@ -1,0 +1,244 @@
+using System.Text.RegularExpressions;
+
+namespace Umbraco.AI.Extensions;
+
+/// <summary>
+/// Utility methods for working with Microsoft AI Foundry models.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Foundry is a gateway: it fronts other vendors' models, so it inherits their per-model restrictions
+/// without owning any of them. That makes the shape of these predicates deliberately different from the
+/// first-party provider packages, and the difference is the whole point of this file — see
+/// <see cref="SupportsSamplingParameters"/>.
+/// </para>
+/// <para>
+/// The family patterns duplicate a small part of <c>OpenAIModelUtilities</c> and
+/// <c>AnthropicModelUtilities</c>. That is intentional: making one provider package depend on another to
+/// share them would couple two independently released packages, and lifting them into core would put
+/// vendor knowledge where it does not belong. When a vendor's restrictions change, all the packages naming
+/// that vendor's families need the same edit.
+/// </para>
+/// </remarks>
+internal static class MicrosoftFoundryModelUtilities
+{
+    /// <summary>
+    /// Publisher names, as reported by the deployments API, for vendors that restrict the sampling
+    /// parameters on some of their models.
+    /// </summary>
+    /// <remarks>
+    /// Used only to rule a restriction <em>out</em> — see <see cref="SupportsSamplingParameters"/>. Matched
+    /// as a substring because the reported value is a display name (<c>OpenAI</c>, <c>Anthropic</c>) rather
+    /// than a stable identifier, and Azure has shipped variations (<c>Azure OpenAI</c>).
+    /// </remarks>
+    private static readonly string[] RestrictiveVendorPublishers = ["openai", "anthropic"];
+
+    /// <summary>
+    /// Model names that read as OpenAI's naming, whether or not this package recognises the specific model.
+    /// </summary>
+    /// <remarks>
+    /// Covers the GPT line, the ChatGPT-branded snapshots and the o-series. Matching one of these means
+    /// OpenAI's allow-list below decides, so an unrecognised <c>gpt-*</c> model fails safe rather than
+    /// falling through to "no known restriction".
+    /// </remarks>
+    private static readonly Regex[] OpenAiNamingPatterns =
+    [
+        new(@"^(gpt|chatgpt)-", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"^o[134](-|$)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+    ];
+
+    /// <summary>
+    /// OpenAI families that accept the sampling parameters. Mirrors
+    /// <c>OpenAIModelUtilities.SupportsSamplingParameters</c>: the reasoning models (the o-series and the
+    /// GPT-5 line) reject a non-default <c>temperature</c> rather than ignoring it.
+    /// </summary>
+    /// <remarks>
+    /// Not quite a copy — Azure names GPT-3.5 without the dot (<c>gpt-35-turbo</c>), because a model name
+    /// there cannot contain one. OpenAI's own <c>^gpt-3\.5</c> never has to match that spelling, so the
+    /// undotted form is listed here as well. Missing it would read <c>gpt-35-turbo</c> as an unrecognised
+    /// OpenAI model and drop a temperature the deployment accepts.
+    /// </remarks>
+    private static readonly Regex[] OpenAiSamplingPatterns =
+    [
+        new(@"^gpt-3\.5", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"^gpt-35", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"^gpt-4", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"^chatgpt-", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+    ];
+
+    /// <summary>
+    /// Model names that read as Anthropic's naming.
+    /// </summary>
+    private static readonly Regex[] AnthropicNamingPatterns =
+    [
+        new(@"^claude-", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+    ];
+
+    /// <summary>
+    /// Claude families that accept the sampling parameters. Mirrors
+    /// <c>AnthropicModelUtilities.SupportsSamplingParameters</c>: Anthropic removed them from Claude Opus
+    /// 4.7 onwards, so 4.7 and 4.8 are deliberately outside the minor versions listed here.
+    /// </summary>
+    private static readonly Regex[] AnthropicSamplingPatterns =
+    [
+        new(@"^claude-3(-|$)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"^claude-(opus|sonnet|haiku)-4(-[0156])?(-\d{8})?$",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled),
+    ];
+
+    /// <summary>
+    /// OpenAI embedding models that accept a <c>dimensions</c> request parameter. Shortening an embedding
+    /// is a <c>text-embedding-3</c> feature; <c>ada-002</c> predates it.
+    /// </summary>
+    private static readonly Regex[] OpenAiDimensionsPatterns =
+    [
+        new(@"^text-embedding-3", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+    ];
+
+    /// <summary>
+    /// Model names that read as OpenAI's embedding naming.
+    /// </summary>
+    private static readonly Regex[] OpenAiEmbeddingNamingPatterns =
+    [
+        new(@"^text-embedding-", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+    ];
+
+    /// <summary>
+    /// Determines whether a Foundry model accepts the sampling parameters (<c>temperature</c>,
+    /// <c>top_p</c>).
+    /// </summary>
+    /// <param name="modelId">The model ID the profile carries — a catalogue model name on the models API path, or a user-chosen deployment name on the deployments API path.</param>
+    /// <param name="modelName">The underlying model the deployment fronts, when the deployments API reported one.</param>
+    /// <param name="publisher">The publisher the deployments API reported, when it reported one.</param>
+    /// <remarks>
+    /// <para>
+    /// <strong>Unknown models are treated as supported.</strong> This inverts the failure direction the
+    /// first-party packages chose, and the reason is that Foundry's unknown-model population is different
+    /// in kind. OpenAI and Anthropic each own a closed set of models with a known restriction, so there an
+    /// allow-list of the families that accept the parameters means an unrecognised model degrades (the
+    /// value is dropped) instead of failing (a 400). Foundry fronts Mistral, Llama, Cohere, Phi, Nova,
+    /// DeepSeek and whatever ships next, almost none of which restrict anything — so the same allow-list
+    /// would silently stop sending a temperature that those models honour today. A regression across most
+    /// of the catalogue is a worse trade than a 400 confined to two vendors' newest models.
+    /// </para>
+    /// <para>
+    /// Within a vendor known to restrict, the allow-list semantics do apply: a model whose name reads as
+    /// OpenAI's or Anthropic's but which this package does not recognise (a future <c>gpt-6</c>, a
+    /// <c>claude-opus-4-9</c>) is treated as restricted. So the fail-safe behaviour is kept exactly where
+    /// it is warranted, and the "no known restriction" default only catches names that look like neither.
+    /// </para>
+    /// <para>
+    /// <paramref name="publisher"/> can only rule a restriction <em>out</em>, never in. A deployment the
+    /// API attributes to Meta or Mistral skips family matching entirely, so a Llama deployment a user
+    /// happened to name <c>o3-llama</c> is not mistaken for OpenAI's o3. It is never used to infer that a
+    /// restriction applies, because knowing the vendor without knowing the model would mean guessing, and
+    /// guessing "restricted" would drop a value from a deployment that works today.
+    /// </para>
+    /// <para>
+    /// The <em>unrestricted</em> default is also why a blank model is supported here rather than dropped:
+    /// no model resolved means the client falls back to the capability's default, which accepts them.
+    /// </para>
+    /// </remarks>
+    public static bool SupportsSamplingParameters(string? modelId, string? modelName = null, string? publisher = null)
+    {
+        var identity = ResolveIdentity(modelId, modelName);
+
+        if (identity is null || IsUnrestrictedPublisher(publisher))
+        {
+            return true;
+        }
+
+        if (Matches(OpenAiNamingPatterns, identity))
+        {
+            return Matches(OpenAiSamplingPatterns, identity);
+        }
+
+        if (Matches(AnthropicNamingPatterns, identity))
+        {
+            return Matches(AnthropicSamplingPatterns, identity);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Determines whether a Foundry embedding model accepts a <c>dimensions</c> request parameter.
+    /// </summary>
+    /// <param name="modelId">The model ID the profile carries — a catalogue model name, or a deployment name.</param>
+    /// <param name="modelName">The underlying model the deployment fronts, when the deployments API reported one.</param>
+    /// <param name="publisher">The publisher the deployments API reported, when it reported one.</param>
+    /// <remarks>
+    /// Same shape and the same reasoning as <see cref="SupportsSamplingParameters"/>: only a name that
+    /// reads as OpenAI's embedding family is held to OpenAI's rule, and anything else — a Cohere embed
+    /// model, a deployment called <c>embeddings-prod</c> — keeps today's behaviour. Note the asymmetry with
+    /// the sampling case: <c>ada-002</c> is the <em>older</em> model here, so an unrecognised
+    /// <c>text-embedding-*</c> name reads as unsupported and the parameter is dropped.
+    /// </remarks>
+    public static bool SupportsDimensions(string? modelId, string? modelName = null, string? publisher = null)
+    {
+        var identity = ResolveIdentity(modelId, modelName);
+
+        if (identity is null || IsUnrestrictedPublisher(publisher))
+        {
+            return true;
+        }
+
+        return !Matches(OpenAiEmbeddingNamingPatterns, identity)
+               || Matches(OpenAiDimensionsPatterns, identity);
+    }
+
+    /// <summary>
+    /// Builds the label the model picker shows for a Foundry model.
+    /// </summary>
+    /// <param name="modelId">The model ID, which on the deployments API path is the deployment name.</param>
+    /// <param name="modelName">The underlying model the deployment fronts, when known.</param>
+    /// <param name="modelVersion">The deployed model version, when known.</param>
+    /// <returns>
+    /// The model ID alone when nothing more is known, otherwise the underlying model and version with the
+    /// deployment name in parentheses — e.g. <c>gpt-4o 2024-11-20 (prod-chat)</c>.
+    /// </returns>
+    /// <remarks>
+    /// A deployment name is user-chosen and can say nothing about what it fronts, so <c>prod-chat-1</c> on
+    /// its own is a poor label. The deployment name is still shown because it is the value stored on the
+    /// profile, so a user comparing the picker against their Azure resource needs to see it.
+    /// </remarks>
+    public static string FormatDisplayName(string modelId, string? modelName = null, string? modelVersion = null)
+    {
+        if (string.IsNullOrWhiteSpace(modelName)
+            || modelName.Equals(modelId, StringComparison.OrdinalIgnoreCase))
+        {
+            return modelId;
+        }
+
+        var label = string.IsNullOrWhiteSpace(modelVersion)
+            ? modelName.Trim()
+            : $"{modelName.Trim()} {modelVersion.Trim()}";
+
+        return $"{label} ({modelId})";
+    }
+
+    /// <summary>
+    /// The name to match patterns against: the underlying model when the deployments API reported one,
+    /// otherwise the model ID, which is all the models API path provides.
+    /// </summary>
+    private static string? ResolveIdentity(string? modelId, string? modelName)
+    {
+        if (!string.IsNullOrWhiteSpace(modelName))
+        {
+            return modelName.Trim();
+        }
+
+        return string.IsNullOrWhiteSpace(modelId) ? null : modelId.Trim();
+    }
+
+    /// <summary>
+    /// Whether the reported publisher is one this package knows imposes no sampling restriction, which
+    /// short-circuits family matching.
+    /// </summary>
+    private static bool IsUnrestrictedPublisher(string? publisher)
+        => !string.IsNullOrWhiteSpace(publisher)
+           && !RestrictiveVendorPublishers.Any(v => publisher.Contains(v, StringComparison.OrdinalIgnoreCase));
+
+    private static bool Matches(Regex[] patterns, string value)
+        => patterns.Any(p => p.IsMatch(value));
+}

--- a/Umbraco.AI.MicrosoftFoundry/src/Umbraco.AI.MicrosoftFoundry/MicrosoftFoundryModelsResponse.cs
+++ b/Umbraco.AI.MicrosoftFoundry/src/Umbraco.AI.MicrosoftFoundry/MicrosoftFoundryModelsResponse.cs
@@ -14,6 +14,13 @@ internal sealed class MicrosoftFoundryModelsResponse
 /// <summary>
 /// Information about a Microsoft AI Foundry model.
 /// </summary>
+/// <remarks>
+/// Fills from either listing path, which report different amounts. The models API supplies only
+/// <see cref="Id"/> (plus capabilities); the deployments API additionally reports what the deployment
+/// fronts, which is carried in <see cref="ModelName"/>, <see cref="ModelVersion"/> and
+/// <see cref="ModelPublisher"/>. Those three are <c>null</c> on the models API path, so every consumer has
+/// to cope with not knowing — see <c>MicrosoftFoundryModelUtilities.SupportsSamplingParameters</c>.
+/// </remarks>
 internal sealed class MicrosoftFoundryModelInfo
 {
     [JsonPropertyName("id")]
@@ -24,6 +31,26 @@ internal sealed class MicrosoftFoundryModelInfo
 
     [JsonPropertyName("capabilities")]
     public MicrosoftFoundryModelCapabilities? Capabilities { get; set; }
+
+    /// <summary>
+    /// The underlying model a deployment fronts (e.g. <c>gpt-4o</c>), when known.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Id"/> is the value passed to the API and stored on a profile. On the deployments path
+    /// that is the deployment's own name, which a user chooses and which need not resemble the model —
+    /// hence this being the name to reason about a model's behaviour from.
+    /// </remarks>
+    public string? ModelName { get; set; }
+
+    /// <summary>
+    /// The deployed model version (e.g. <c>2024-11-20</c>), when known.
+    /// </summary>
+    public string? ModelVersion { get; set; }
+
+    /// <summary>
+    /// The publisher of the underlying model (e.g. <c>OpenAI</c>), when known.
+    /// </summary>
+    public string? ModelPublisher { get; set; }
 }
 
 /// <summary>

--- a/Umbraco.AI.MicrosoftFoundry/src/Umbraco.AI.MicrosoftFoundry/MicrosoftFoundryProvider.cs
+++ b/Umbraco.AI.MicrosoftFoundry/src/Umbraco.AI.MicrosoftFoundry/MicrosoftFoundryProvider.cs
@@ -28,6 +28,13 @@ public class MicrosoftFoundryProvider : AIProviderBase<MicrosoftFoundryProviderS
     private const string AiFoundryScope = "https://ai.azure.com/.default";
     private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(1);
 
+    /// <summary>
+    /// Key prefix for the per-model listing entries read by <see cref="TryGetModelInfo"/>. Internal so a
+    /// test can prime the cache the provider was constructed with, rather than standing up Entra ID auth
+    /// and the deployments endpoint to reach the same state.
+    /// </summary>
+    internal const string ModelInfoCacheKeyPrefix = "MicrosoftFoundry_ModelInfo_";
+
     private readonly IMemoryCache _cache;
     private CancellationTokenSource _cacheEvictionSource = new();
     private readonly IHttpClientFactory _httpClientFactory;
@@ -102,8 +109,41 @@ public class MicrosoftFoundryProvider : AIProviderBase<MicrosoftFoundryProviderS
             .AddExpirationToken(new Microsoft.Extensions.Primitives.CancellationChangeToken(_cacheEvictionSource.Token));
         _cache.Set(cacheKey, models, cacheOptions);
 
+        // Also cache each model on its own key, which is what lets the per-request path read what a
+        // deployment fronts without any I/O — see TryGetModelInfo. The same eviction token is used, so
+        // these never outlive the listing they came from.
+        foreach (var model in models)
+        {
+            _cache.Set(ModelInfoCacheKeyPrefix + model.Id, model, cacheOptions);
+        }
+
         return models;
     }
+
+    /// <summary>
+    /// Reads a model's cached listing entry, or <c>null</c> when the model has not been fetched.
+    /// </summary>
+    /// <param name="modelId">The model ID, which on the deployments API path is the deployment name.</param>
+    /// <remarks>
+    /// <para>
+    /// Warm by construction on the request path: a client cannot exist without the capability having
+    /// fetched the model list first. Returns <c>null</c> for a model absent from that list, where callers
+    /// fall back to reasoning from the ID alone.
+    /// </para>
+    /// <para>
+    /// Keyed by model ID rather than per connection, because the per-request hook that reads this is given
+    /// only a model ID. Two connections on the same Foundry provider can therefore collide if they use the
+    /// same deployment name for different models, and the most recent listing wins. The consequence is
+    /// bounded: a wrong entry can only cause the same silently-dropped parameter, or the same 400, that
+    /// would happen without any of this metadata — never a new failure.
+    /// </para>
+    /// </remarks>
+    internal MicrosoftFoundryModelInfo? TryGetModelInfo(string? modelId)
+        => string.IsNullOrWhiteSpace(modelId)
+            ? null
+            : _cache.TryGetValue<MicrosoftFoundryModelInfo>(ModelInfoCacheKeyPrefix + modelId, out var cached)
+                ? cached
+                : null;
 
     /// <summary>
     /// Creates an <see cref="AzureOpenAIClient"/> configured with the provided settings.
@@ -246,25 +286,45 @@ public class MicrosoftFoundryProvider : AIProviderBase<MicrosoftFoundryProviderS
             var deploymentsResponse = await response.Content
                 .ReadFromJsonAsync<MicrosoftFoundryDeploymentsResponse>(cancellationToken);
 
-            if (deploymentsResponse?.Value is null || deploymentsResponse.Value.Count == 0)
-            {
-                return [];
-            }
-
-            return deploymentsResponse.Value
-                .Select(d => new MicrosoftFoundryModelInfo
-                {
-                    // Use the deployment name as the model ID (this is what gets passed to the API)
-                    Id = d.Name,
-                })
-                .OrderBy(m => m.Id)
-                .ToList();
+            return MapDeployments(deploymentsResponse);
         }
         catch (Exception ex) when (ex is HttpRequestException or Azure.Identity.AuthenticationFailedException)
         {
             _logger.LogWarning(ex, "Failed to fetch deployments from API.");
             return [];
         }
+    }
+
+    /// <summary>
+    /// Projects a deployments API response into the listing entries the capabilities consume.
+    /// </summary>
+    /// <remarks>
+    /// Separate from the fetch so it can be exercised without a live Foundry resource: everything above it
+    /// in <see cref="FetchDeploymentsFromApiAsync"/> is Entra ID token acquisition and HTTP.
+    /// </remarks>
+    internal static IReadOnlyList<MicrosoftFoundryModelInfo> MapDeployments(
+        MicrosoftFoundryDeploymentsResponse? response)
+    {
+        if (response?.Value is null || response.Value.Count == 0)
+        {
+            return [];
+        }
+
+        return response.Value
+            .Select(d => new MicrosoftFoundryModelInfo
+            {
+                // Use the deployment name as the model ID (this is what gets passed to the API)
+                Id = d.Name,
+
+                // What the deployment actually fronts. A deployment name is user-chosen and can say
+                // nothing about the model behind it, so this is the only reliable basis for deciding
+                // which settings the model accepts, and for labelling it in the model picker.
+                ModelName = d.ModelName,
+                ModelVersion = d.ModelVersion,
+                ModelPublisher = d.ModelPublisher,
+            })
+            .OrderBy(m => m.Id)
+            .ToList();
     }
 
     private async Task<IReadOnlyList<MicrosoftFoundryModelInfo>> FetchModelsFromApiAsync(

--- a/Umbraco.AI.MicrosoftFoundry/tests/Umbraco.AI.MicrosoftFoundry.Tests.Unit/Fakes/FakeProviderInfrastructure.cs
+++ b/Umbraco.AI.MicrosoftFoundry/tests/Umbraco.AI.MicrosoftFoundry.Tests.Unit/Fakes/FakeProviderInfrastructure.cs
@@ -1,0 +1,43 @@
+using System.Reflection;
+using Umbraco.AI.Core.EditableModels;
+using Umbraco.AI.Core.Providers;
+
+namespace Umbraco.AI.MicrosoftFoundry.Tests.Unit.Fakes;
+
+/// <summary>
+/// Minimal provider infrastructure for constructing a real provider in a test. Capabilities are created by
+/// activation, which is enough for the provider's own capability wiring.
+/// </summary>
+internal sealed class FakeProviderInfrastructure : IAIProviderInfrastructure
+{
+    public IAICapabilityFactory CapabilityFactory { get; } = new ActivatorCapabilityFactory();
+
+    public IAIEditableModelSchemaBuilder SchemaBuilder
+        => throw new NotSupportedException("Schema building is not exercised by these tests.");
+
+    /// <summary>
+    /// Activates a capability by picking its greediest constructor and supplying the provider plus nulls.
+    /// </summary>
+    /// <remarks>
+    /// The capabilities here take an optional logger alongside the provider, and logging is not what these
+    /// tests are about, so every parameter after the provider is passed as null rather than mocked.
+    /// </remarks>
+    private sealed class ActivatorCapabilityFactory : IAICapabilityFactory
+    {
+        public TCapability Create<TCapability>(IAIProvider provider)
+            where TCapability : class, IAICapability
+        {
+            var constructor = typeof(TCapability)
+                .GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+                .OrderByDescending(c => c.GetParameters().Length)
+                .First();
+
+            var arguments = constructor
+                .GetParameters()
+                .Select((p, i) => i == 0 ? provider : (object?)null)
+                .ToArray();
+
+            return (TCapability)constructor.Invoke(arguments);
+        }
+    }
+}

--- a/Umbraco.AI.MicrosoftFoundry/tests/Umbraco.AI.MicrosoftFoundry.Tests.Unit/Fakes/UnusedHttpClientFactory.cs
+++ b/Umbraco.AI.MicrosoftFoundry/tests/Umbraco.AI.MicrosoftFoundry.Tests.Unit/Fakes/UnusedHttpClientFactory.cs
@@ -1,0 +1,11 @@
+namespace Umbraco.AI.MicrosoftFoundry.Tests.Unit.Fakes;
+
+/// <summary>
+/// Satisfies the provider's constructor for tests that never list models. Throwing rather than returning a
+/// real client keeps an accidental network call from turning into a slow or flaky test.
+/// </summary>
+internal sealed class UnusedHttpClientFactory : IHttpClientFactory
+{
+    public HttpClient CreateClient(string name)
+        => throw new NotSupportedException("These tests do not call the Foundry APIs.");
+}

--- a/Umbraco.AI.MicrosoftFoundry/tests/Umbraco.AI.MicrosoftFoundry.Tests.Unit/MicrosoftFoundryDeclarationTests.cs
+++ b/Umbraco.AI.MicrosoftFoundry/tests/Umbraco.AI.MicrosoftFoundry.Tests.Unit/MicrosoftFoundryDeclarationTests.cs
@@ -1,0 +1,180 @@
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Umbraco.AI.Core.Models;
+using Umbraco.AI.MicrosoftFoundry.Tests.Unit.Fakes;
+
+// The deployments response and its entries are internal to the provider package, reached here through
+// InternalsVisibleTo. Same for the cache-key prefix and MapDeployments.
+
+namespace Umbraco.AI.MicrosoftFoundry.Tests.Unit;
+
+/// <summary>
+/// What the capabilities declare per model, which is both what the profile editor renders from and what the
+/// core capability bases strip from a request. Going through the real capability rather than the predicate
+/// pins the wiring: a capability that stopped overriding <c>GetSettingsSupport</c>, or a provider that
+/// stopped carrying what a deployment fronts, fails here.
+/// </summary>
+public class MicrosoftFoundryDeclarationTests
+{
+    private const string SamplingGroup = "temperature,topP,topK,frequencyPenalty,presencePenalty";
+
+    [Theory]
+    [InlineData("o3")]
+    [InlineData("gpt-5")]
+    [InlineData("claude-opus-4-8")]
+    public void ChatGetSettingsSupport_ModelRejectingSamplingParameters_DeclaresTheSamplingGroup(string modelId)
+    {
+        var metadata = CreateChatCapability(CreateProvider()).GetSettingsSupport(modelId).ToMetadata();
+
+        metadata[AIModelMetadataKeys.ProfileSettingsUnsupported].ShouldBe(SamplingGroup);
+    }
+
+    [Theory]
+    [InlineData("gpt-4o")]
+    [InlineData("gpt-35-turbo")]
+    [InlineData("mistral-large-2411")]
+    [InlineData("prod-chat-1")]
+    public void ChatGetSettingsSupport_ModelAcceptingSamplingParameters_DeclaresNothing(string modelId)
+    {
+        var metadata = CreateChatCapability(CreateProvider()).GetSettingsSupport(modelId).ToMetadata();
+
+        metadata.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ChatGetSettingsSupport_DeploymentFrontingARestrictedModel_DeclaresFromTheDeployment()
+    {
+        // The failure this fix exists for: the profile carries a deployment name that reveals nothing, so
+        // without the deployment's metadata the declaration would be empty and a temperature would go out
+        // to a model that rejects it.
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var provider = CreateProvider(cache);
+        PrimeModelInfo(cache, new MicrosoftFoundryModelInfo
+        {
+            Id = "prod-chat",
+            ModelName = "o3",
+            ModelVersion = "2025-04-16",
+            ModelPublisher = "OpenAI",
+        });
+
+        var metadata = CreateChatCapability(provider).GetSettingsSupport("prod-chat").ToMetadata();
+
+        metadata[AIModelMetadataKeys.ProfileSettingsUnsupported].ShouldBe(SamplingGroup);
+    }
+
+    [Fact]
+    public void ChatGetSettingsSupport_DeploymentFrontingAnAcceptingModel_DeclaresNothing()
+    {
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var provider = CreateProvider(cache);
+        PrimeModelInfo(cache, new MicrosoftFoundryModelInfo
+        {
+            Id = "prod-chat",
+            ModelName = "gpt-4o",
+            ModelPublisher = "OpenAI",
+        });
+
+        CreateChatCapability(provider).GetSettingsSupport("prod-chat").ToMetadata().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ChatGetSettingsSupport_ListingNeverFetched_FallsBackToTheModelId()
+    {
+        // Nothing cached, so the deployment name is all there is. It reads as no known restriction, which
+        // is today's behaviour rather than a new silent drop.
+        CreateChatCapability(CreateProvider())
+            .GetSettingsSupport("prod-chat")
+            .ToMetadata()
+            .ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void EmbeddingGetSettingsSupport_ModelRejectingDimensions_DeclaresDimensions()
+    {
+        var metadata = CreateEmbeddingCapability(CreateProvider())
+            .GetSettingsSupport("text-embedding-ada-002")
+            .ToMetadata();
+
+        metadata[AIModelMetadataKeys.ProfileSettingsUnsupported].ShouldBe("dimensions");
+    }
+
+    [Theory]
+    [InlineData("text-embedding-3-small")]
+    [InlineData("cohere-embed-v3-english")]
+    public void EmbeddingGetSettingsSupport_ModelAcceptingDimensions_DeclaresNothing(string modelId)
+    {
+        var metadata = CreateEmbeddingCapability(CreateProvider()).GetSettingsSupport(modelId).ToMetadata();
+
+        metadata.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void EmbeddingGetSettingsSupport_DeploymentFrontingAda002_DeclaresFromTheDeployment()
+    {
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var provider = CreateProvider(cache);
+        PrimeModelInfo(cache, new MicrosoftFoundryModelInfo
+        {
+            Id = "emb-prod",
+            ModelName = "text-embedding-ada-002",
+            ModelPublisher = "OpenAI",
+        });
+
+        var metadata = CreateEmbeddingCapability(provider).GetSettingsSupport("emb-prod").ToMetadata();
+
+        metadata[AIModelMetadataKeys.ProfileSettingsUnsupported].ShouldBe("dimensions");
+    }
+
+    [Fact]
+    public void MapDeployments_CarriesWhatEachDeploymentFronts()
+    {
+        // The mapping that used to keep only the deployment name. Without these three fields every
+        // declaration above would fall back to the name.
+        var mapped = MicrosoftFoundryProvider.MapDeployments(new MicrosoftFoundryDeploymentsResponse
+        {
+            Value =
+            [
+                new MicrosoftFoundryDeploymentInfo
+                {
+                    Name = "prod-chat",
+                    ModelName = "o3",
+                    ModelVersion = "2025-04-16",
+                    ModelPublisher = "OpenAI",
+                },
+            ],
+        });
+
+        var model = mapped.ShouldHaveSingleItem();
+        model.Id.ShouldBe("prod-chat");
+        model.ModelName.ShouldBe("o3");
+        model.ModelVersion.ShouldBe("2025-04-16");
+        model.ModelPublisher.ShouldBe("OpenAI");
+    }
+
+    [Fact]
+    public void MapDeployments_NoDeployments_ReturnsEmpty()
+    {
+        MicrosoftFoundryProvider.MapDeployments(new MicrosoftFoundryDeploymentsResponse()).ShouldBeEmpty();
+        MicrosoftFoundryProvider.MapDeployments(null).ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// Puts a listing entry where <c>TryGetModelInfo</c> reads it, standing in for a completed model
+    /// listing without needing Entra ID auth and the deployments endpoint.
+    /// </summary>
+    private static void PrimeModelInfo(IMemoryCache cache, MicrosoftFoundryModelInfo model)
+        => cache.Set(MicrosoftFoundryProvider.ModelInfoCacheKeyPrefix + model.Id, model);
+
+    private static MicrosoftFoundryChatCapability CreateChatCapability(MicrosoftFoundryProvider provider)
+        => new(provider, NullLogger<MicrosoftFoundryChatCapability>.Instance);
+
+    private static MicrosoftFoundryEmbeddingCapability CreateEmbeddingCapability(MicrosoftFoundryProvider provider)
+        => new(provider, NullLogger<MicrosoftFoundryEmbeddingCapability>.Instance);
+
+    private static MicrosoftFoundryProvider CreateProvider(IMemoryCache? cache = null)
+        => new(
+            new FakeProviderInfrastructure(),
+            cache ?? new MemoryCache(new MemoryCacheOptions()),
+            new UnusedHttpClientFactory(),
+            NullLogger<MicrosoftFoundryProvider>.Instance);
+}

--- a/Umbraco.AI.MicrosoftFoundry/tests/Umbraco.AI.MicrosoftFoundry.Tests.Unit/MicrosoftFoundrySettingSupportTests.cs
+++ b/Umbraco.AI.MicrosoftFoundry/tests/Umbraco.AI.MicrosoftFoundry.Tests.Unit/MicrosoftFoundrySettingSupportTests.cs
@@ -1,0 +1,168 @@
+using Umbraco.AI.Extensions;
+
+namespace Umbraco.AI.MicrosoftFoundry.Tests.Unit;
+
+/// <summary>
+/// Foundry fronts other vendors' models, so it inherits their per-model restrictions without owning any of
+/// them. These predicates are the single source for both the per-model declaration the profile editor reads
+/// and the request-time filter the capability bases apply, so the table is worth pinning.
+/// </summary>
+/// <remarks>
+/// Model names taken from Azure AI Foundry's model catalogue and the vendors' own model overviews (July
+/// 2026).
+/// </remarks>
+public class MicrosoftFoundrySettingSupportTests
+{
+    [Theory]
+    // Azure's GPT deployments, including the undotted GPT-3.5 spelling Azure uses.
+    [InlineData("gpt-4o")]
+    [InlineData("gpt-4o-mini")]
+    [InlineData("gpt-4.1")]
+    [InlineData("gpt-4-32k")]
+    [InlineData("gpt-35-turbo")]
+    [InlineData("gpt-35-turbo-16k")]
+    [InlineData("chatgpt-4o-latest")]
+    // Claude families that still accept them.
+    [InlineData("claude-3-5-sonnet-20241022")]
+    [InlineData("claude-sonnet-4-6")]
+    // Vendors with no sampling restriction at all, which is most of the catalogue.
+    [InlineData("mistral-large-2411")]
+    [InlineData("Llama-3.3-70B-Instruct")]
+    [InlineData("Phi-4")]
+    [InlineData("cohere-command-r-plus")]
+    [InlineData("DeepSeek-R1")]
+    // A deployment name that says nothing about what it fronts keeps today's behaviour.
+    [InlineData("prod-chat-1")]
+    // No model resolved means the capability's default is used, which accepts them.
+    [InlineData(null)]
+    [InlineData("")]
+    public void SupportsSamplingParameters_ModelAcceptingThem_ReturnsTrue(string? modelId)
+    {
+        MicrosoftFoundryModelUtilities.SupportsSamplingParameters(modelId).ShouldBeTrue();
+    }
+
+    [Theory]
+    // OpenAI's reasoning models reject a non-default temperature rather than ignoring it.
+    [InlineData("o1")]
+    [InlineData("o1-mini")]
+    [InlineData("o3")]
+    [InlineData("o3-mini")]
+    [InlineData("o4-mini")]
+    [InlineData("gpt-5")]
+    [InlineData("gpt-5.6-sol")]
+    // Anthropic removed them from Claude Opus 4.7 onwards.
+    [InlineData("claude-opus-4-7")]
+    [InlineData("claude-opus-4-8")]
+    [InlineData("claude-opus-5")]
+    // A name that reads as a restrictive vendor's but is not recognised fails safe, which is the
+    // allow-list behaviour the first-party packages have — kept exactly where it is warranted.
+    [InlineData("gpt-6-turbo")]
+    [InlineData("claude-opus-4-9")]
+    public void SupportsSamplingParameters_ModelRejectingThem_ReturnsFalse(string modelId)
+    {
+        MicrosoftFoundryModelUtilities.SupportsSamplingParameters(modelId).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SupportsSamplingParameters_DeploymentNameHidingARestrictedModel_ReadsTheUnderlyingModel()
+    {
+        // The deployments API path: the ID is a user-chosen name, so the decision has to come from what
+        // the deployment fronts. This is the case the whole metadata plumbing exists for.
+        MicrosoftFoundryModelUtilities
+            .SupportsSamplingParameters("prod-chat", modelName: "o3", publisher: "OpenAI")
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SupportsSamplingParameters_DeploymentNameHidingAnAcceptingModel_ReadsTheUnderlyingModel()
+    {
+        MicrosoftFoundryModelUtilities
+            .SupportsSamplingParameters("prod-chat", modelName: "gpt-4o", publisher: "OpenAI")
+            .ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("Meta")]
+    [InlineData("Mistral AI")]
+    [InlineData("Microsoft")]
+    public void SupportsSamplingParameters_UnrestrictedPublisher_IgnoresAMisleadingName(string publisher)
+    {
+        // A publisher can only rule a restriction out, never in: a Llama deployment a user named after
+        // OpenAI's o3 must not inherit o3's restriction.
+        MicrosoftFoundryModelUtilities
+            .SupportsSamplingParameters("o3-llama", modelName: "o3-llama", publisher: publisher)
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SupportsSamplingParameters_RestrictiveVendorPublisherWithAnUnknownName_StaysUnrestricted()
+    {
+        // Knowing the vendor but not the model would mean guessing, and guessing "restricted" would drop a
+        // value from a deployment that works today. So the family patterns decide, and an unrecognisable
+        // name reaches neither of them.
+        MicrosoftFoundryModelUtilities
+            .SupportsSamplingParameters("prod-chat", modelName: "prod-chat", publisher: "OpenAI")
+            .ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("text-embedding-3-small")]
+    [InlineData("text-embedding-3-large")]
+    // Not an OpenAI embedding name, so OpenAI's rule does not apply and today's behaviour is kept.
+    [InlineData("cohere-embed-v3-english")]
+    [InlineData("embeddings-prod")]
+    [InlineData(null)]
+    public void SupportsDimensions_ModelAcceptingIt_ReturnsTrue(string? modelId)
+    {
+        MicrosoftFoundryModelUtilities.SupportsDimensions(modelId).ShouldBeTrue();
+    }
+
+    [Theory]
+    // Shortened embeddings are a text-embedding-3 feature; ada-002 predates it. Note the asymmetry with
+    // the sampling case: here the *older* model is the restricted one, so an unrecognised
+    // text-embedding-* name reads as unsupported.
+    [InlineData("text-embedding-ada-002")]
+    [InlineData("text-embedding-4-preview")]
+    public void SupportsDimensions_ModelRejectingIt_ReturnsFalse(string modelId)
+    {
+        MicrosoftFoundryModelUtilities.SupportsDimensions(modelId).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SupportsDimensions_DeploymentNameHidingAda002_ReadsTheUnderlyingModel()
+    {
+        MicrosoftFoundryModelUtilities
+            .SupportsDimensions("emb-prod", modelName: "text-embedding-ada-002", publisher: "OpenAI")
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void FormatDisplayName_NothingButAnId_ReturnsTheIdUnchanged()
+    {
+        // The models API path reports only an ID, so there is nothing to add.
+        MicrosoftFoundryModelUtilities.FormatDisplayName("gpt-4o").ShouldBe("gpt-4o");
+    }
+
+    [Fact]
+    public void FormatDisplayName_DeploymentFrontingAKnownModel_ShowsBoth()
+    {
+        // The deployment name is still shown because it is the value stored on the profile.
+        MicrosoftFoundryModelUtilities
+            .FormatDisplayName("prod-chat", "gpt-4o", "2024-11-20")
+            .ShouldBe("gpt-4o 2024-11-20 (prod-chat)");
+    }
+
+    [Fact]
+    public void FormatDisplayName_DeploymentNamedAfterItsModel_DoesNotRepeatItself()
+    {
+        MicrosoftFoundryModelUtilities.FormatDisplayName("gpt-4o", "gpt-4o", null).ShouldBe("gpt-4o");
+    }
+
+    [Fact]
+    public void FormatDisplayName_KnownModelWithNoVersion_OmitsTheVersion()
+    {
+        MicrosoftFoundryModelUtilities
+            .FormatDisplayName("prod-chat", "gpt-4o", null)
+            .ShouldBe("gpt-4o (prod-chat)");
+    }
+}

--- a/Umbraco.AI.MicrosoftFoundry/tests/Umbraco.AI.MicrosoftFoundry.Tests.Unit/Umbraco.AI.MicrosoftFoundry.Tests.Unit.csproj
+++ b/Umbraco.AI.MicrosoftFoundry/tests/Umbraco.AI.MicrosoftFoundry.Tests.Unit/Umbraco.AI.MicrosoftFoundry.Tests.Unit.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsTestProject>true</IsTestProject>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Umbraco.AI.MicrosoftFoundry\Umbraco.AI.MicrosoftFoundry.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="Shouldly" />
+  </ItemGroup>
+
+</Project>

--- a/Umbraco.AI.MicrosoftFoundry/tests/Umbraco.AI.MicrosoftFoundry.Tests.Unit/packages.lock.json
+++ b/Umbraco.AI.MicrosoftFoundry/tests/Umbraco.AI.MicrosoftFoundry.Tests.Unit/packages.lock.json
@@ -1,0 +1,1973 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[6.0.4, )",
+        "resolved": "6.0.4",
+        "contentHash": "lkhqpF8Pu2Y7IiN7OntbsTtdbpR1syMsm2F3IgX6ootA4ffRqWL5jF7XipHuZQTdVuWG/gVAAcf8mjk8Tz0xPg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.13.0, )",
+        "resolved": "17.13.0",
+        "contentHash": "W19wCPizaIC9Zh47w8wWI/yxuqR7/dtABwOrc8r2jX/8mUNxM2vw4fXDh+DJTeogxV+KzKwg5jNNGQVwf3LXyA==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.13.0",
+          "Microsoft.TestPlatform.TestHost": "17.13.0"
+        }
+      },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[1.1.1, )",
+        "resolved": "1.1.1",
+        "contentHash": "IaJGnOv/M7UQjRJks7B6p7pbPnOwisYGOIzqCz5ilGFTApZ3ktOR+6zJ12ZRPInulBmdAf1SrGdDG2MU8g6XTw==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
+      },
+      "Nerdbank.GitVersioning": {
+        "type": "Direct",
+        "requested": "[3.8.118, )",
+        "resolved": "3.8.118",
+        "contentHash": "cRaG+ICcECG+CzbtQyUV2WftH7yl2B02AjYGGNScXx8TwYavZYwhCewBTiC0qTcsac7m6AzBUYna5xzBWmTGYw=="
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.2.1, )",
+        "resolved": "4.2.1",
+        "contentHash": "dKAKiSuhLKqD2TXwLKtqNg1nwzJcIKOOMncZjk9LYe4W+h+SCftpWdxwR79YZUIHMH+3Vu9s0s0UHNrgICLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "Umbraco.Code": {
+        "type": "Direct",
+        "requested": "[3.0.0-beta, )",
+        "resolved": "3.0.0-beta",
+        "contentHash": "JTd/YgzvdpCM0C7n8iZtS/vjKCo/zAO7j/2ZqEyHiF09RRNeEUOrng5Db8hpbn5+XBY4Ax1MaaOop4g2eprTqg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[5.0.0, 5.999.999)"
+        }
+      },
+      "Umbraco.GitVersioning.Extensions": {
+        "type": "Direct",
+        "requested": "[0.2.0, )",
+        "resolved": "0.2.0",
+        "contentHash": "m85a1RWGllvZxhw4SfnNyHszN9WDqQk6WGpR0Fzu2ZwEHCPesQPc+7NDl/PgUrVLyLDA9HqAasb2NEHqPffaCQ=="
+      },
+      "Umbraco.JsonSchema.Extensions": {
+        "type": "Direct",
+        "requested": "[0.3.0, )",
+        "resolved": "0.3.0",
+        "contentHash": "pvgnrC9vQ/3GvYvAwhLHvqwMgyvndHtKi+io77cMNuY+e/eR0eBV5SyzXmW5q3MFnbV4AizdjZIsuoMszY7mxA=="
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "AngleSharp": {
+        "type": "Transitive",
+        "resolved": "1.4.0",
+        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
+      },
+      "Asp.Versioning.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "cMRE5nvNMfBgfkb0XFWst/7UtyXCjoAXnV0L4Scx4P9fcf0idgrj1Z0c+3ylsy01K4cOib7dKhCBfpg5z3r0Kg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Asp.Versioning.Http": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "xmNm9FM2d20NKy7i1osEQysf7pJ4iJjWnM6e8CoeIhUREqG8nugsfC82pGpmzlatjAJL5T52ieSpyW+GFdSsSQ==",
+        "dependencies": {
+          "Asp.Versioning.Abstractions": "10.0.0"
+        }
+      },
+      "Asp.Versioning.Mvc": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "W0wZ+0uZ0UK4KstjvEkNBZ0xxhBmxunwNg8582SVyyW7txQmSXibtm8fC4o82LaemPquYskms67bIbJOSrnlug==",
+        "dependencies": {
+          "Asp.Versioning.Http": "10.0.0"
+        }
+      },
+      "Asp.Versioning.Mvc.ApiExplorer": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "H54UOpRoc4RmhQ4RA2lzDz43a/hAu/JN19Yyy/DNmH4XlRxhemfhifJyh9BaXNJOtGa2Dnu2xEeP4VSiTdUdAg==",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "10.0.0"
+        }
+      },
+      "Azure.Core": {
+        "type": "Transitive",
+        "resolved": "1.53.0",
+        "contentHash": "x9c/toFMOtRrlTdFuE7rlGCVAduQzWVfKmLz5juj41zJAXEhYD5hluiUyyAEzJ6OxpBnKtiaBztzwpZITAVjtg==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Identity.Client": "4.83.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.83.1",
+          "System.ClientModel": "1.10.0",
+          "System.Memory.Data": "10.0.3"
+        }
+      },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
+      "Dazinator.Extensions.FileProviders": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "Jb10uIvdGdaaOmEGUXeO1ssjp6YuvOuR87B5gLxGORFbroV1j7PDaVfEIgni7vV8KRcyAY5KvuMxgx6ADIEXNw==",
+        "dependencies": {
+          "DotNet.Glob": "3.1.0",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "1.0.2",
+          "Microsoft.AspNetCore.Http.Abstractions": "1.0.2",
+          "Microsoft.Extensions.FileProviders.Abstractions": "1.0.1",
+          "NETStandard.Library": "1.6.1"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "DocumentFormat.OpenXml.Framework": {
+        "type": "Transitive",
+        "resolved": "3.5.1",
+        "contentHash": "U5txtc3ORno73xQx9Lf2gWzfaSZnZwKHfLkTAslhlew9lxe5XbUiCt0dY1fHeAf8yRqszUAe5i/+xLC9R/Xfsw==",
+        "dependencies": {
+          "System.IO.Packaging": "10.0.2"
+        }
+      },
+      "DotNet.Glob": {
+        "type": "Transitive",
+        "resolved": "3.1.0",
+        "contentHash": "i6x0hDsFWg6Ke2isaNAcHQ9ChxBvTJu2cSmBY+Jtjiv2W4q6y9QlA3JKYuZqJ573TAZmpAn65Qf3sRpjvZ1gmw=="
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Examine": {
+        "type": "Transitive",
+        "resolved": "3.7.1",
+        "contentHash": "/Hq2jb+Bv2COlJszLhmsDIN9+8VZnwiaXA1RnzBSp24PfVR/GrY/WzlWNJSzjVt5yvYW7Fuq0V1Bfu9e/v1UIA==",
+        "dependencies": {
+          "Examine.Core": "3.7.1",
+          "Examine.Lucene": "3.7.1",
+          "Microsoft.AspNetCore.DataProtection": "8.0.4",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.1"
+        }
+      },
+      "Examine.Core": {
+        "type": "Transitive",
+        "resolved": "3.7.1",
+        "contentHash": "Vsm5DWtCTZ5cSyYN4Ryy6wWTFM1Q3Nz/1eeWHf5vNWIall0XQySApNbIofDfDNqDPauanHCoulj7y00vkhNBiw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2"
+        }
+      },
+      "Examine.Lucene": {
+        "type": "Transitive",
+        "resolved": "3.7.1",
+        "contentHash": "pRpYAfSJ1DoNhq9gGy3EfSIGkv3BryVEMWvmvvYve5sFRtkK+bQbKIX4BvCbi2TR9ZzOo7mCsCzCj17JJ/CpeQ==",
+        "dependencies": {
+          "Examine.Core": "3.7.1",
+          "Lucene.Net.QueryParser": "4.8.0-beta00017",
+          "Lucene.Net.Replicator": "4.8.0-beta00017"
+        }
+      },
+      "HtmlAgilityPack": {
+        "type": "Transitive",
+        "resolved": "1.12.4",
+        "contentHash": "ljqvBabvFwKoLniuoQKO8b5bJfJweKLs4fUNS/V5dsvpo0A8MlJqxxn9XVmP2DaskbUXty6IYaWAi1SArGIMeQ=="
+      },
+      "Humanizer.Core": {
+        "type": "Transitive",
+        "resolved": "2.14.1",
+        "contentHash": "lQKvtaTDOXnoVJ20ibTuSIOf2i0uO0MPbDhd1jm238I+U/2ZnRENj0cktKZhtchBMtCUSRQ5v4xBCUbKNmyVMw=="
+      },
+      "J2N": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "Vooz1wbnnqWuS+u93tADXK5Owxo8vLJhSrZ9Ac+KpgDF3GJq9TybXXTF1TFcWILgEtRThc8AOBENEzB0TQH1JA=="
+      },
+      "Json.More.Net": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "qtwsyAsL55y2vB2/sK4Pjg3ZyVzD5KKSpV3lOAMHlnjFfsjQ/86eHJfQT9aV1YysVXzF4+xyHOZbh7Iu3YQ7Lg=="
+      },
+      "JsonPatch.Net": {
+        "type": "Transitive",
+        "resolved": "3.3.0",
+        "contentHash": "GIcMMDtzfzVfIpQgey8w7dhzcw6jG5nD4DDAdQCTmHfblkCvN7mI8K03to8YyUhKMl4PTR6D6nLSvWmyOGFNTg==",
+        "dependencies": {
+          "JsonPointer.Net": "5.2.0"
+        }
+      },
+      "JsonPointer.Net": {
+        "type": "Transitive",
+        "resolved": "5.2.0",
+        "contentHash": "qe1F7Tr/p4mgwLPU9P60MbYkp+xnL2uCPnWXGgzfR/AZCunAZIC0RZ32dLGJJEhSuLEfm0YF/1R3u5C7mEVq+w==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Json.More.Net": "2.1.0"
+        }
+      },
+      "K4os.Compression.LZ4": {
+        "type": "Transitive",
+        "resolved": "1.3.8",
+        "contentHash": "LhwlPa7c1zs1OV2XadMtAWdImjLIsqFJPoRcIWAadSRn0Ri1DepK65UbWLPmt4riLqx2d40xjXRk0ogpqNtK7g=="
+      },
+      "Lucene.Net": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "7LLWS9nNwx01AyE/KXMh+qdAlzDkRANE8407AO/wEmLL1InzVKFwfsRdRmwg4ILOMFui4xZ1Y54eqvzo3Tf9Vw==",
+        "dependencies": {
+          "J2N": "[2.1.0, 3.0.0)",
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
+        }
+      },
+      "Lucene.Net.Analysis.Common": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "rPpmww/HgwEwhvfvZgdWITxFsWRoCEpP3+WQBFgbGxTn4eLDr3U/oFoe8KS+8jUNAl2+5atErDrW5JOcFG+gcQ==",
+        "dependencies": {
+          "Lucene.Net": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.Facet": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "LVxGwgRAVq9XdwvNfgCB8OH+ou40I0E1NYN53muPjQK5oUY+HpkgkFUhTFSHdajWWj7xFI1f+UFB23iweoVf2w==",
+        "dependencies": {
+          "Lucene.Net.Join": "4.8.0-beta00017",
+          "Lucene.Net.Queries": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.Grouping": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "nzMGvz0b1cedS8KKOlglJQJpyz8fT0ojgXFkgSkLLhwPNbMPwVoBsR7RlZs1FrF60Oz369O3Pm1a+MIr52KcLQ==",
+        "dependencies": {
+          "Lucene.Net": "4.8.0-beta00017",
+          "Lucene.Net.Queries": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.Join": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "WcJl4O6t3iXiXwXHnhmbVCO7C6ilPxabBCsdW/auQN0lrDpbVIcHorCxwd199fGBEQnk7wbl5pPnk8nw/VK4eQ==",
+        "dependencies": {
+          "Lucene.Net.Grouping": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.Queries": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "RVpZCfa/7pgvytFw64zLqinvZPQt4TojvcFghdAA5vhnpSs5GTbtciPIxFH3wwH3f2dYJywiqYKo1h3JBCXRBA==",
+        "dependencies": {
+          "Lucene.Net": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.QueryParser": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "ZrF7EL06qB+2S2K4T3PliIa5EiJ5Ii7c/zFRMhsNozymz+HRHMVoI/nMYSdN6WF7X1Ef1DTeajMwvsbGTfl28Q==",
+        "dependencies": {
+          "Lucene.Net.Analysis.Common": "4.8.0-beta00017",
+          "Lucene.Net.Queries": "4.8.0-beta00017",
+          "Lucene.Net.Sandbox": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.Replicator": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "YGZcKkQhuLweZ+M4UgA/Uok3Vl3HOTlvZpUmTZMS4J9cBdvTevG0e6rn/pZrfONUpp0TtbXe494oGA1rScouOA==",
+        "dependencies": {
+          "J2N": "[2.1.0, 3.0.0)",
+          "Lucene.Net": "4.8.0-beta00017",
+          "Lucene.Net.Facet": "4.8.0-beta00017",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Lucene.Net.Sandbox": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "wRAzQZ4Z1yEuAaTwO+RrZB6l3Lz+vNGAiDshf0IjAr8qeVvQj74iodEcff4Bes88bnhqsWLUZlDUg/ygraxX2Q==",
+        "dependencies": {
+          "Lucene.Net": "4.8.0-beta00017"
+        }
+      },
+      "MailKit": {
+        "type": "Transitive",
+        "resolved": "4.16.0",
+        "contentHash": "trJ82DOpAmo8i1jO1vNE+dGn4mPRyeYfy4swRcAGgMJhPoI1Kohf4OFJJf0+YIj4iUxgxPn8W+ht7e7KiYzSjg==",
+        "dependencies": {
+          "MimeKit": "4.16.0"
+        }
+      },
+      "Markdig": {
+        "type": "Transitive",
+        "resolved": "1.1.3",
+        "contentHash": "wboYc6YToID7koq+onej7rjd/kv4urZaZ4QMiJoF/jXt/ZlXe2Af9gWG4nOe5tk654UaOPYvKL64iFum7qWEYA=="
+      },
+      "Markdown": {
+        "type": "Transitive",
+        "resolved": "2.2.1",
+        "contentHash": "A6veXuFP1n50RbmFNtTgfHxnHmwMsgFLSCgS1xWbg5L8n5N6HFEksTlXocZ0LsmGW4leBzeLJd+BY7+g83zFJA=="
+      },
+      "MessagePack": {
+        "type": "Transitive",
+        "resolved": "3.1.7",
+        "contentHash": "gXpifaxbhfBqh8bVToQn9j+OgCnhXWMbRCV7RQIbCVa9CNJG1fY6oHAYYl+ER3Tb9uUIHiQ5QbGiGwwFhoagbA==",
+        "dependencies": {
+          "MessagePack.Annotations": "3.1.7",
+          "MessagePackAnalyzer": "3.1.7",
+          "Microsoft.NET.StringTools": "17.11.4"
+        }
+      },
+      "MessagePack.Annotations": {
+        "type": "Transitive",
+        "resolved": "3.1.7",
+        "contentHash": "IW1yX9viarFl/Dsio5G+pM90JkOSW4xhAiJcKxPPF5rzyp2/yCpieWju8G99QLEmaQeze2uQMEskUBA59YZmkw=="
+      },
+      "MessagePackAnalyzer": {
+        "type": "Transitive",
+        "resolved": "3.1.7",
+        "contentHash": "ZF+OOJTRS7Ogzb4gG36hPKVQk3kEbp6kkUcdRjhddDq/uSGcV4BKIdYiyJipExXyE/zsqYb0ic215O9kI+fjPA=="
+      },
+      "Microsoft.AspNetCore.Cryptography.Internal": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "unTeI3bPmzsl5Xo2Irg7jW8osCjo/H2rBT5sTqopUUI0gbLyTYuTjDyxoKjykjS/nS2jUdAKVFWFoGF1s1g4HQ=="
+      },
+      "Microsoft.AspNetCore.Cryptography.KeyDerivation": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "qwLYWCaxt23MF7ea/rIDvaRg3oyi6O51nU1YivAuBojrAvUjROHeIpIBxHaWvpH3WoWFf9lX5V40ufo/KKp5ZQ==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Cryptography.Internal": "10.0.7"
+        }
+      },
+      "Microsoft.AspNetCore.DataProtection": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "ETphwQ9b2gvTK0ET6cYQY77StbIvSmYHZJdsEOf5AY4YNmol5uIncdqLCJzFgE/KEH1ukRdXTkwSC27hNnltOw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Cryptography.Internal": "10.0.7",
+          "Microsoft.AspNetCore.DataProtection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "System.Security.Cryptography.Xml": "10.0.7"
+        }
+      },
+      "Microsoft.AspNetCore.DataProtection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "SitkANPwiW0Z2w9bWAFwZ/MxFDDloBkNZCK+SfFJ+/IMUTMvrczBrHmy66+EdQTd2ybRzCm12aKAztQkDGyH6A=="
+      },
+      "Microsoft.AspNetCore.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "CSVd9h1TdWDT2lt62C4FcgaF285J4O3MaOqTVvc7xP+3bFiwXcdp6qEd+u1CQrdJ+xJuslR+tvDW7vWQ/OH5Qw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Hosting.Server.Abstractions": "1.0.2",
+          "Microsoft.AspNetCore.Http.Abstractions": "1.0.2",
+          "Microsoft.Extensions.Configuration.Abstractions": "1.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.2",
+          "Microsoft.Extensions.FileProviders.Abstractions": "1.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "1.0.2"
+        }
+      },
+      "Microsoft.AspNetCore.Hosting.Server.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "6ZtFh0huTlrUl72u9Vic0icCVIQiEx7ULFDx3P7BpOI97wjb0GAXf8B4m9uSpSGf0vqLEKFlkPbvXF0MXXEzhw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Features": "1.0.2",
+          "Microsoft.Extensions.Configuration.Abstractions": "1.0.2"
+        }
+      },
+      "Microsoft.AspNetCore.Http.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "peJqc7BgYwhTzOIfFHX3/esV6iOXf17Afekh6mCYuUD3aWyaBwQuWYaKLR+RnjBEWaSzpCDgfCMMp5Y3LUXsiA==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Features": "1.0.2"
+        }
+      },
+      "Microsoft.AspNetCore.Http.Features": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "9l/Y/CO3q8tET3w+dDiByREH8lRtpd14cMevwMV5nw2a/avJ5qcE3VVIE5U5hesec2phTT6udQEgwjHmdRRbig==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "1.0.1"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "TV62UsrJZPX6gbt3c4WrtXh7bmaDIcMqf9uft1cc4L6gJXOU07hDGEh+bFQh/L2Az0R1WVOkiT66lFqS6G2NmA=="
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "AT3HlgTjsqHnWpBHSNeR0KxbLZD7bztlZVj7I8vgeYG9SYqbeFGh0TM/KVtC6fg53nrWHl3VfZFvb5BiQFcY6Q=="
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Transitive",
+        "resolved": "3.11.0",
+        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "Al/Q8B+yO8odSqGVpSvrShMFDvlQdIBU//F3E6Rb0YdiLSALE9wh/pvozPNnfmh5HDnvU+mkmSjpz4hQO++jaA==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZbUmIvT6lqTNKiv06Jl5wf0MTMi1vQ1oH7ou4CLcs2C/no/L7EhP3T8y3XXvn9VbqMcJaJnEsNA1jwYUMgc5jg==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.13.0",
+        "contentHash": "9LIUy0y+DvUmEPtbRDw6Bay3rzwqFV8P4efTrK4CZhQle3M/QwLPjISghfcolmEGAPWxuJi6m98ZEfk4VR4Lfg=="
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.7.0",
+        "contentHash": "Lf822igMm8NkTYHZhTp7kjoNYkLLEvJnX3SkG/LVBvsZHC0Y9choogHz8YtITBoy0TOylM3kVUZ6iaHf0my0ug=="
+      },
+      "Microsoft.Extensions.AmbientMetadata.Application": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "Oh/FQJrTZqiqZuFktqDCwLFgxIUnNATZx46AwUTf5A/+FmK/TzPf/iwSqMK85QlioLD9ehOxWe0NBfsCSkp5pw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "5fGxcw2vuYp8s0wio9H1ECiuk4iKSdTIlNuigdLIrkhg+5XAwgFVDB/5Ots3pfN/QhABLYXutA79JFtnUKDSHA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Caching.Hybrid": {
+        "type": "Transitive",
+        "resolved": "10.5.0",
+        "contentHash": "INkOmE/6q6txxCS45A9HfY8dCqqjTMJfGzr3cNoMwuZpHVSr0JhMfgr/QNm9BvtvyzsyiK+q7yhCn57fBmoy9Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Caching.Memory": "10.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Options": "10.0.6"
+        }
+      },
+      "Microsoft.Extensions.Compliance.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "b3gmxtyX0n8bQFuZ679f8QiOWqjeZKFc6XXPUsYNFzMcWi0Q44Ej3pB41N/QQ0maX380kmOMF36bLSBHNThXAg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.ObjectPool": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "qbZLvLsoTdArSloEnSxs21P781YUmwVmHc5NJPQD/ezAreQ7884z+6QfAZVKi86WAZtzx83jK2uC4itxOM44gQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "64dimvyyKk0dbUbrLg/YCv4ugJ4sVz2aXLwfvZwR1EC4tJqW9ru/oVRcXwoJRa2lQGXtYtlpk4maWOeIb48tQw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+      },
+      "Microsoft.Extensions.DependencyInjection.AutoActivation": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "g6/S5rhP1XNBqeDa9zKXri/uDKe6gjzSqGsocuySb1OdVm8fz/M9YcWTJsCw5RHF8xIb/B3NgsfBPQF9Emjk3Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "RFYJR7APio/BiqdQunRq6DB+nDB6nc2qhHr77mlvZ0q0BT8PubMXN7XicmfzCbrDE/dzhBnUKBRXLTcqUiZDGg=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "l+smp1qPlU0OUXD0OGfdp7OUFrbdq7ZaP5T7m2WpfZ4RFKD7iG73BAT7tjSMxNmbSXkhAn1jYHOAqzYG1r9sNg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "TZAZsAFThNQDqCnWaGxV/X7OPSA7b+kY7wNTPNvPvSWa0jcTbmGVyzIY/feF4OgyAUUdzSnnLW6ri2Q+4keM4A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Embedded": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "Btm5vy3ZjIy4GwG5EGSnayiUrLeDsJ6n+RgaPs2xbjA53tXRTCtkZ9v086qHF71tJuVmQiJ8o0IXlm2XVibXJw==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "zhgWg/i0ECj5v0jLFBSZHplvc5ygCI91DR4nne+BP4XAKF5ycz0pEKnFiTw8C1jCABJEZsnBZh6pXAvn71kFmw==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "NTUspqB+vH9g4wAD6KPOBx01xqYuKXR/cHXm449zpbq1GqfjdAxBmg7eJXrNsPw7SKwIdT2cJ05GxYVvc+lvsA=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Http": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "1wbd+RPhRo3hJKNJhdGEO5ls0LGe55Ho4BUjlFtRUrWxDVVBd7g0Ydq9fbNy86pmvx/j7AGcSPo7YNCo1IRI6Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Http.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "/xuNWNxI4WLVatiTvaqfLd5ijFhQ/qvE14bOyWxeEWmXJkjh/g2G/5TdzMfoe0afq16OdWLGbrD9gWHo178hbg==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "10.0.3",
+          "Microsoft.Extensions.Telemetry": "10.3.0"
+        }
+      },
+      "Microsoft.Extensions.Http.Polly": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "pcUsPoqMHvOp+QJsLA/Hlg/W+IBnAoUXKEBc7FqMcY0sUez15DOKXtbEo81TvHL9xwjWQcF3ZMayNpcvpI7Bqg==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "10.0.7",
+          "Polly": "7.2.4",
+          "Polly.Extensions.Http": "3.0.0"
+        }
+      },
+      "Microsoft.Extensions.Http.Resilience": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "P4+s/eUH3dZdn1HnivSL2dh6/Jb0ndLt2l88oQPZ9BYdyb4tSRAsnz4QkJHGfPA9lS/XblI5QYsxEdfkurPvIg==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Diagnostics": "10.3.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.3",
+          "Microsoft.Extensions.Resilience": "10.3.0"
+        }
+      },
+      "Microsoft.Extensions.Identity.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "br70n9iuhhn4HU6DrNH96/Rdh6dnW72VoLioQ9UF+XYSjAEREe1TqgyuvUJBVJzayRyuy+rWQrx3eOF38udeSQ==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Cryptography.KeyDerivation": "10.0.7",
+          "Microsoft.Extensions.Diagnostics": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Identity.Stores": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "zDsolTKiYBP29zxszqNMpecPDkuJtq0JCh4rqXZryGQV+azGDBpCZ7DyUpKk2Pp8Ea3pKaXttZZJRy7c3ay+UA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Identity.Core": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "9S/DFt4cohlMPpzIxjG6kk0L8MuN2vDm9pbMCulxtJzzk82oJHVLBd8vuQxaPskaYQwKqmFmbannf5eoChgjYg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "PBlaoYeusaxNYyN4WFjzcXWlUDSvLUPxy/e6oP1SONOOYA/oBWT2uBmFGJMV9VTtXiXXxCB39LqlYWbsWE4UKA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.3",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Options": "10.0.3",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "dQKlVXzqflsv5X8iDlAN5YmTL1GcLCrOLKo1s9PNdfjqxeu0S/jmWTfiLGno+8+o1qFL3+VFAH5/ftmypN+sPw=="
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options.DataAnnotations": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "KWepqdSD4PxhFvVh3mckkvJ03u3q/VChkr6nT3nf5mm2XBk8ojxt2E4It0RMblb3GE7hJ0zQzFzxGKL0d6TfXA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g=="
+      },
+      "Microsoft.Extensions.Resilience": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "xc0dZuPkBaVIdMlODDppmNY/dxE27wIQ46gTzStoFXO4/yVcOMKlPmtr9vTP4edyXBRizGxPtcAFmqxZ5gPTkQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics": "10.0.3",
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.3.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.3",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.3.0",
+          "Polly.Extensions": "8.4.2",
+          "Polly.RateLimiting": "8.4.2"
+        }
+      },
+      "Microsoft.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "M1esrIGmwU2JBY0JpwdlUTXTNBXSBFEs+41bYBd59+9/vCaXw+vGhtYcCL+JXeGmxTLUHmuXcKbX/uVCSFcuzA==",
+        "dependencies": {
+          "Microsoft.Extensions.AmbientMetadata.Application": "10.3.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.3.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.3",
+          "Microsoft.Extensions.ObjectPool": "10.0.3",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.3.0"
+        }
+      },
+      "Microsoft.Extensions.Telemetry.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "aKxH6ZsGAewGF8uSXyx1WkjqItwZA+hd1hhQ/4i7o5injCWSdr9vIZ3R3djJfy8OG3xaWK+LZY/+slVvlnwEHw==",
+        "dependencies": {
+          "Microsoft.Extensions.Compliance.Abstractions": "10.3.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "Microsoft.Extensions.ObjectPool": "10.0.3",
+          "Microsoft.Extensions.Options": "10.0.3"
+        }
+      },
+      "Microsoft.Identity.Client": {
+        "type": "Transitive",
+        "resolved": "4.83.1",
+        "contentHash": "jOLIrZ3cynoqHLLO1cXplFFabrhrMEYs/EuKHvmCyrOm1axqiVFT6nCSnHxk7w5+d2BeQfCdM12Yf/0X7OeS1g==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.14.0"
+        }
+      },
+      "Microsoft.Identity.Client.Extensions.Msal": {
+        "type": "Transitive",
+        "resolved": "4.83.1",
+        "contentHash": "I3k4J4Hj4KbLEFanjeUzzDOVecukETaTgEkJ7h2pP/Yazs6SLp6TVUTo/Eo+ptPXMwvc+iX7rBFtMSUrA7R+Mg==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.83.1",
+          "System.Security.Cryptography.ProtectedData": "4.5.0"
+        }
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "gSxKLWRZzBpIsEoeUPkxfywNCCvRvl7hkq146XHPk5vOQc9izSf1I+uL1vh4y2U19QPxd9Z8K/8AdWyxYz2lSg=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "prBU72cIP4V8E9fhN+o/YdskTsLeIcnKPbhZf0X6mD7fdxoZqnS/NdEkSr+9Zp+2q7OZBOMfNBKGbTbhXODO4w==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "MTzXmETkNQPACR7/XCXM1OGM6oU9RkyibqeJRtO9Ndew2LnGjMf9Atqj2VSf4XC27X0FQycUAlzxxEgQMWn2xQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "UFrU7d46UTsPQTa2HIEIpB9H1uJe1BW9FLw5uhEJ2ZuKdur8bcUA/bO5caq5dlBt5gNJeRIB3QQXYNs5fCQCZA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "rtViGJcGsN7WcfUNErwNeQgjuU5cJNl6FDQsfi9TncwO+Epzn0FTfBsg3YuFW1Q0Ch/KPxaVdjLw3/+5Z5ceFQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.IdentityModel.Logging": "8.16.0"
+        }
+      },
+      "Microsoft.Net.Http.Headers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "p87EodQmWe5j5y3tETgjVrZ7KYHVEekdVVHKAdZBu3zS2VY7ABd8yFIVpZztE6xNcwikcYHuek2i2c41SLd6kw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.NET.StringTools": {
+        "type": "Transitive",
+        "resolved": "17.11.4",
+        "contentHash": "mudqUHhNpeqIdJoUx2YDWZO/I9uEDYVowan89R6wsomfnUJQk6HteoQTlNjZDixhT2B4IXMkMtgZtoceIjLRmA=="
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      },
+      "Microsoft.OpenApi": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "WMcGpWKrmJmzrNeuaEb23bEMnbtR/vLmvZtkAP5qWu7vQsY59GqfRJd65sFpBszbd2k/bQ8cs8eWawQKAabkVg=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.13.0",
+        "contentHash": "bt0E0Dx+iqW97o4A59RCmUmz/5NarJ7LRL+jXbSHod72ibL5XdNm1Ke+UO5tFhBG4VwHLcSjqq9BUSblGNWamw=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.13.0",
+        "contentHash": "9GGw08Dc3AXspjekdyTdZ/wYWFlxbgcF0s7BKxzVX+hzAwpifDOdxM+ceVaaJSQOwqt3jtuNlHn3XTpKUS9x9Q==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.13.0",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "MimeKit": {
+        "type": "Transitive",
+        "resolved": "4.16.0",
+        "contentHash": "X0LFxeM4gPRIhODyY/HYS9b+zRZ7y//v59rFzgS6wLxcPuZThnMtNZHtrr0fjLyRRkg3gqJBtvW36XfUzZ7Djw==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.6.2",
+          "System.Security.Cryptography.Pkcs": "10.0.0"
+        }
+      },
+      "MiniProfiler.AspNetCore": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "meedJsjpYOeHPhE8H6t+dGQ9zLxcCQVpi4DXzmxmYAXywmTzlo6jv2IASUv5QijTU0CxsROln3FHd8RsTO8Z8A==",
+        "dependencies": {
+          "MiniProfiler.Shared": "4.5.4"
+        }
+      },
+      "MiniProfiler.AspNetCore.Mvc": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "+NqXyCy9aNdroPm6leW5+cpngtCnkCdoyOlJzvVN62uucSx+MYkx8jmKbgAt+aCP6aghADfHBExwrTIldHxapg==",
+        "dependencies": {
+          "MiniProfiler.AspNetCore": "4.5.4"
+        }
+      },
+      "MiniProfiler.Shared": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "f8ckFm/xTS8C2Bn4BdVc94dNvg+tRfk0e4XFaETOqRi6r0PUOyn3Z9jTQCVpB3R1pP5WiRsEIrqqxux95BVpTA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.0.0"
+        }
+      },
+      "NCrontab": {
+        "type": "Transitive",
+        "resolved": "3.4.0",
+        "contentHash": "t3okCB6odi64mZvhetBPSR/ejKib3uSnmyCqj8M0mf2S3yFxbDFZLjxfWqcwvmS3zzgXR6LAIi0XlBU4oqxTlg=="
+      },
+      "NETStandard.Library": {
+        "type": "Transitive",
+        "resolved": "1.6.1",
+        "contentHash": "WcSp3+vP+yHNgS8EV5J7pZ9IRpeDuARBPN28by8zqff1wJQXm26PVU8L3/fYLBJVU7BtDyqNVWq2KlCVvSSR4A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "NPoco": {
+        "type": "Transitive",
+        "resolved": "6.2.0",
+        "contentHash": "/E5smklogHeYhX639dYYhcc0Gx55LriAlU2ZfLDO44g0o4pmKPtJVzE0QR+wPGaskrrZ5JiI3Dd+CKGh8u5YRw==",
+        "dependencies": {
+          "NPoco.Abstractions": "6.2.0"
+        }
+      },
+      "NPoco.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.2.0",
+        "contentHash": "DRx593fF5CJZ8pj94StWdZsE9/iXkJKp3L2xp6Y9EAliHf4+e1y4QvWL/jJmeZ7zb8NKpwyf6tq1CZDS2mQwAA=="
+      },
+      "OpenAI": {
+        "type": "Transitive",
+        "resolved": "2.11.0",
+        "contentHash": "f0y5zOZVNhuc/gPQUHGkiljZlDUq2SddGOkGTPLHnjQC5mCiTCXq1BqxZ+xxxHU6bY0mEtFQJj1RlB2BpwD7Lw==",
+        "dependencies": {
+          "System.ClientModel": "1.10.0"
+        }
+      },
+      "OpenIddict": {
+        "type": "Transitive",
+        "resolved": "7.5.0",
+        "contentHash": "rZyPVHUXwUKEFQr4DO/iWKwmXnUE4IFMoHpYnyq5DgdgiKNFTkjZ4xc1P2ArnwvKNyuNsefGsj+JybGqXwIqsA==",
+        "dependencies": {
+          "OpenIddict.Abstractions": "7.5.0",
+          "OpenIddict.Client": "7.5.0",
+          "OpenIddict.Client.SystemIntegration": "7.5.0",
+          "OpenIddict.Client.SystemNetHttp": "7.5.0",
+          "OpenIddict.Client.WebIntegration": "7.5.0",
+          "OpenIddict.Core": "7.5.0",
+          "OpenIddict.Server": "7.5.0",
+          "OpenIddict.Validation": "7.5.0",
+          "OpenIddict.Validation.ServerIntegration": "7.5.0",
+          "OpenIddict.Validation.SystemNetHttp": "7.5.0"
+        }
+      },
+      "OpenIddict.Abstractions": {
+        "type": "Transitive",
+        "resolved": "7.5.0",
+        "contentHash": "4m3smhkdeWITo1UWc3zYyGketh0ELn6UZRuZEnzcyS6fuflvl1MNSHbg1wPTTGldlxcq6VwWvVvKWyaTW/25Ig==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7",
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
+      },
+      "OpenIddict.AspNetCore": {
+        "type": "Transitive",
+        "resolved": "7.5.0",
+        "contentHash": "D8r7Tve0mTiu27tPWhjOpGnLsblJt/vJWbzSyO4nS5Ve2IIC07QS96uKlgImADU/WW4gLWHM7gVDalHs1c8oSg==",
+        "dependencies": {
+          "OpenIddict": "7.5.0",
+          "OpenIddict.Client.AspNetCore": "7.5.0",
+          "OpenIddict.Client.DataProtection": "7.5.0",
+          "OpenIddict.Server.AspNetCore": "7.5.0",
+          "OpenIddict.Server.DataProtection": "7.5.0",
+          "OpenIddict.Validation.AspNetCore": "7.5.0",
+          "OpenIddict.Validation.DataProtection": "7.5.0"
+        }
+      },
+      "OpenIddict.Client": {
+        "type": "Transitive",
+        "resolved": "7.5.0",
+        "contentHash": "W22MGOGqWVOD2yVPCZmk4ZAH0ssZ/I+qfucBaeaCHpR65+I1vKVtL/tuuhUY1dbdvgARKS1bsZZvWDOroJ2kNQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "Microsoft.IdentityModel.Protocols": "8.16.0",
+          "OpenIddict.Abstractions": "7.5.0"
+        }
+      },
+      "OpenIddict.Client.AspNetCore": {
+        "type": "Transitive",
+        "resolved": "7.5.0",
+        "contentHash": "bVZEYVHdXbfJqTtzamvDjq4Klymjb6uhq3lEF/k27YwBJtBV1QQWnvjQRpjqmhR7UHQSIoKxo6xbPtPxWAlujA==",
+        "dependencies": {
+          "OpenIddict.Client": "7.5.0"
+        }
+      },
+      "OpenIddict.Client.DataProtection": {
+        "type": "Transitive",
+        "resolved": "7.5.0",
+        "contentHash": "zxiYrDLXy2V+TYGmKIJYi29hsZG1U9axMZgWv12FsGE4wJQpdtrKw2J5yplYOiVzMz5DxgXrpTOhQ1bfRLDO+Q==",
+        "dependencies": {
+          "Microsoft.AspNetCore.DataProtection": "10.0.7",
+          "OpenIddict.Client": "7.5.0",
+          "System.Security.Cryptography.Xml": "10.0.7"
+        }
+      },
+      "OpenIddict.Client.SystemIntegration": {
+        "type": "Transitive",
+        "resolved": "7.5.0",
+        "contentHash": "7Z4H1innZap7/ffNE6bsuC9WpwTn0wk+tjeRJD/6dJX4FSVJuVQ8N5yRMLCmXSS/aeVvyMwYpdylLXygI76I5g==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Net.Http.Headers": "10.0.7",
+          "OpenIddict.Client": "7.5.0"
+        }
+      },
+      "OpenIddict.Client.SystemNetHttp": {
+        "type": "Transitive",
+        "resolved": "7.5.0",
+        "contentHash": "Os2tAOMwgkGuBykqDMwIHrcF2wJdhMyfG5uIZlDbIAamDZJriGc6AnVoRNxFiSWCuzhXBhDboZQviecBFc2mQw==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Polly": "10.0.7",
+          "Microsoft.Extensions.Http.Resilience": "10.3.0",
+          "OpenIddict.Client": "7.5.0"
+        }
+      },
+      "OpenIddict.Client.WebIntegration": {
+        "type": "Transitive",
+        "resolved": "7.5.0",
+        "contentHash": "0FNXGJdzdGIO523Dy07APoXmDJPjEIQt/e2SeAQYyrZ0bFC2eKDEdDsw2PLvIMnN5X9GC/n9DhQQWahrLIpXbA==",
+        "dependencies": {
+          "OpenIddict.Client": "7.5.0",
+          "OpenIddict.Client.SystemNetHttp": "7.5.0"
+        }
+      },
+      "OpenIddict.Core": {
+        "type": "Transitive",
+        "resolved": "7.5.0",
+        "contentHash": "8IicfYNZDg2TRzeDG+TOlWjWsneLTFIe1Ai5PMFXgsfti07JDLuvznBTOpCdv7w5DdrrjXxk9xMdRWS8aZ358w==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "OpenIddict.Abstractions": "7.5.0"
+        }
+      },
+      "OpenIddict.Server": {
+        "type": "Transitive",
+        "resolved": "7.5.0",
+        "contentHash": "O8i4aNse1ilwdW/KX86WS6rtwpm+XccYOFKs+8bZeIA+DI3RFgc5nR2k2hEoBYf44ybLiGCWjDqJQdLKfXHhcw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "OpenIddict.Abstractions": "7.5.0"
+        }
+      },
+      "OpenIddict.Server.AspNetCore": {
+        "type": "Transitive",
+        "resolved": "7.5.0",
+        "contentHash": "dPgoG/y7oJcngY+xILxrp+lgGjrOMIrlt/mQcGKMj/g+QlNW8Xod5ibAMbFIQUUWXGVKd+lZKPMa7wPfioLpTw==",
+        "dependencies": {
+          "OpenIddict.Server": "7.5.0"
+        }
+      },
+      "OpenIddict.Server.DataProtection": {
+        "type": "Transitive",
+        "resolved": "7.5.0",
+        "contentHash": "dn49+QwuiHZatgiP0auRG2//Fhnu0yYmtPu5ky89AqjZKSQTDrPwV0Jm1O0OCGM39W7AEWwOtLtvpr/cucxLUA==",
+        "dependencies": {
+          "Microsoft.AspNetCore.DataProtection": "10.0.7",
+          "OpenIddict.Server": "7.5.0",
+          "System.Security.Cryptography.Xml": "10.0.7"
+        }
+      },
+      "OpenIddict.Validation": {
+        "type": "Transitive",
+        "resolved": "7.5.0",
+        "contentHash": "PpAaSD2KfFJn6sODf0JadCcdx2e2hNo23ULYqbv3lGnOLVB3Y8bQoGJNMovxzSq5nKMSLlqi5rtV3sFXln3Kkw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "Microsoft.IdentityModel.Protocols": "8.16.0",
+          "OpenIddict.Abstractions": "7.5.0"
+        }
+      },
+      "OpenIddict.Validation.AspNetCore": {
+        "type": "Transitive",
+        "resolved": "7.5.0",
+        "contentHash": "yTHifKNJLe0uH4fotBQcii8XpHYQOwmACXK2aEeAYadxYlysiO67glfxdETzeAfpJ/QM4cG7V2bjXUCZLCHEbg==",
+        "dependencies": {
+          "OpenIddict.Validation": "7.5.0"
+        }
+      },
+      "OpenIddict.Validation.DataProtection": {
+        "type": "Transitive",
+        "resolved": "7.5.0",
+        "contentHash": "YrjqQgj1c+nmwSjKHB0YUaNA1nNkSVsVuSj1f7eujWif/86IdII49NRfo7NXEn9GVbuoPk3R/hW10fJtp0Q4CA==",
+        "dependencies": {
+          "Microsoft.AspNetCore.DataProtection": "10.0.7",
+          "OpenIddict.Validation": "7.5.0",
+          "System.Security.Cryptography.Xml": "10.0.7"
+        }
+      },
+      "OpenIddict.Validation.ServerIntegration": {
+        "type": "Transitive",
+        "resolved": "7.5.0",
+        "contentHash": "dsAjY4MytgSdMQFjmy+7cTcKTJF0rKiLOu9VAvsxg/mjQU/mDH1gjyQafAHoU9BwDIrbaBZlBRxUNPl14O1GBA==",
+        "dependencies": {
+          "OpenIddict.Server": "7.5.0",
+          "OpenIddict.Validation": "7.5.0"
+        }
+      },
+      "OpenIddict.Validation.SystemNetHttp": {
+        "type": "Transitive",
+        "resolved": "7.5.0",
+        "contentHash": "nRj7Ry1se+hURVx4KADZlnHyYQkK095ybpSq4CC29A+akqDK6GPP04T/zSxIK8bpQSepNqP4w2aWzDZCvcvg9w==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Polly": "10.0.7",
+          "Microsoft.Extensions.Http.Resilience": "10.3.0",
+          "OpenIddict.Validation": "7.5.0"
+        }
+      },
+      "Polly": {
+        "type": "Transitive",
+        "resolved": "7.2.4",
+        "contentHash": "bw00Ck5sh6ekduDE3mnCo1ohzuad946uslCDEENu3091+6UKnBuKLo4e+yaNcCzXxOZCXWY2gV4a35+K1d4LDA=="
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "BpE2I6HBYYA5tF0Vn4eoQOGYTYIK1BlF5EXVgkWGn3mqUUjbXAr13J6fZVbp7Q3epRR8yshacBMlsHMhpOiV3g=="
+      },
+      "Polly.Extensions": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "GZ9vRVmR0jV2JtZavt+pGUsQ1O1cuRKG7R7VOZI6ZDy9y6RNPvRvXK1tuS4ffUrv8L0FTea59oEuQzgS0R7zSA==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Options": "8.0.0",
+          "Polly.Core": "8.4.2"
+        }
+      },
+      "Polly.Extensions.Http": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "drrG+hB3pYFY7w1c3BD+lSGYvH2oIclH8GRSehgfyP5kjnFnHKQuuBhuHLv+PWyFuaTDyk/vfRpnxOzd11+J8g==",
+        "dependencies": {
+          "Polly": "7.1.0"
+        }
+      },
+      "Polly.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "ehTImQ/eUyO07VYW2WvwSmU9rRH200SKJ/3jku9rOkyWE0A2JxNFmAVms8dSn49QLSjmjFRRSgfNyOgr/2PSmA==",
+        "dependencies": {
+          "Polly.Core": "8.4.2",
+          "System.Threading.RateLimiting": "8.0.0"
+        }
+      },
+      "Serilog": {
+        "type": "Transitive",
+        "resolved": "4.3.1",
+        "contentHash": "savYe7h5yRlkqBVOwP8cIRDOdqKiPmYCU4W87JH38sBmcKD5EBoXvQIw6bNEvZ/pTe1gsiye3VFCzBsoppGkXQ=="
+      },
+      "Serilog.AspNetCore": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "a/cNa1mY4On1oJlfGG1wAvxjp5g7OEzk/Jf/nm7NF9cWoE7KlZw1GldrifUBWm9oKibHkR7Lg/l5jy3y7ACR8w==",
+        "dependencies": {
+          "Serilog": "4.3.0",
+          "Serilog.Extensions.Hosting": "10.0.0",
+          "Serilog.Formatting.Compact": "3.0.0",
+          "Serilog.Settings.Configuration": "10.0.0",
+          "Serilog.Sinks.Console": "6.1.1",
+          "Serilog.Sinks.Debug": "3.0.0",
+          "Serilog.Sinks.File": "7.0.0"
+        }
+      },
+      "Serilog.Enrichers.Process": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "/wPYz2PDCJGSHNI+Z0PAacZvrgZgrGduWqLXeC2wvW6pgGM/Bi45JrKy887MRcRPHIZVU0LAlkmJ7TkByC0boQ==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Enrichers.Thread": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "C7BK25a1rhUyr+Tp+1BYcVlBJq7M2VCHlIgnwoIUVJcicM9jYcvQK18+OeHiXw7uLPSjqWxJIp1EfaZ/RGmEwA==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Expressions": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "QhZjXtUcA2QfQRA60m+DfyIfidKsQV7HBstbYEDqzJKMbJH/KnKthkkjciRuYrmFE+scWv1JibC5LlXrdtOUmw==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "E7juuIc+gzoGxgzFooFgAV8g9BfiSXNKsUok9NmEpyAXg2odkcPsMa/Yo4axkJRlh0se7mkYQ1GXDaBemR+b6w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Serilog": "4.3.0",
+          "Serilog.Extensions.Logging": "10.0.0"
+        }
+      },
+      "Serilog.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "vx0kABKl2dWbBhhqAfTOk53/i8aV/5VaT3a6il9gn72Wqs2pM7EK2OB6No6xdqK2IaY6Zf9gdjLuK9BVa2rT+Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Serilog": "4.2.0"
+        }
+      },
+      "Serilog.Formatting.Compact": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "wQsv14w9cqlfB5FX2MZpNsTawckN4a8dryuNGbebB/3Nh1pXnROHZov3swtu3Nj5oNG7Ba+xdu7Et/ulAUPanQ==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Formatting.Compact.Reader": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "E1gvPAx0AsQhlyzGwgcVnGe5QrdkSugwKh+6V/FUSdTMVKKPSiO6Ff5iosjBMNBvq244Zys7BhTfFmgCE0KUyQ==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.3",
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Settings.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "LNq+ibS1sbhTqPV1FIE69/9AJJbfaOhnaqkzcjFy95o+4U+STsta9mi97f1smgXsWYKICDeGUf8xUGzd/52/uA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.DependencyModel": "10.0.0",
+          "Serilog": "4.3.0"
+        }
+      },
+      "Serilog.Sinks.Async": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "SnmRknWsSMgyo9wDXeZZCqSp48kkQYy44taSM6vcpxfiRICzSf09oLKEmVr0RCwQnfd8mJQ2WNN6nvhqf0RowQ==",
+        "dependencies": {
+          "Serilog": "4.1.0"
+        }
+      },
+      "Serilog.Sinks.Console": {
+        "type": "Transitive",
+        "resolved": "6.1.1",
+        "contentHash": "8jbqgjUyZlfCuSTaJk6lOca465OndqOz3KZP6Cryt/IqZYybyBu7GP0fE/AXBzrrQB3EBmQntBFAvMVz1COvAA==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Sinks.Debug": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "4BzXcdrgRX7wde9PmHuYd9U6YqycCC28hhpKonK7hx0wb19eiuRj16fPcPSVp0o/Y1ipJuNLYQ00R3q2Zs8FDA==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Sinks.File": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "fKL7mXv7qaiNBUC71ssvn/dU0k9t0o45+qm2XgKAlSt19xF+ijjxyA3R6HmCgfKEKwfcfkwWjayuQtRueZFkYw==",
+        "dependencies": {
+          "Serilog": "4.2.0"
+        }
+      },
+      "Serilog.Sinks.Map": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "bpfOs8W9r5AwZ65/7IHGDI8eBdd8FgUbLd8aCmaMNN4ZSkcHfXGUnPL+PO/wpGJzw/XQNMLx8tro5H7xf2uL1A==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Swashbuckle.AspNetCore.SwaggerUI": {
+        "type": "Transitive",
+        "resolved": "10.1.7",
+        "contentHash": "iJo3ODyUb/M8Vm8AH1r9y9iAba0w95xsCn3zFVl96ISRHbTDWxi+l7oFVCZqUEdjd97B8VMDPnMliWAdomR8uw=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Composition": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "3Djj70fFTraOarSKmRnmRy/zm4YurICm+kiCtI0dYRqGJnLX6nJ+G3WYuFJ173cAPax/gh96REcbNiVqcrypFQ==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Convention": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0",
+          "System.Composition.TypedParts": "9.0.0"
+        }
+      },
+      "System.Composition.AttributedModel": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "iri00l/zIX9g4lHMY+Nz0qV1n40+jFYAmgsaiNn16xvt2RDwlqByNG4wgblagnDYxm3YSQQ0jLlC/7Xlk9CzyA=="
+      },
+      "System.Composition.Convention": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "+vuqVP6xpi582XIjJi6OCsIxuoTZfR0M7WWufk3uGDeCl3wGW6KnpylUJ3iiXdPByPE0vR5TjJgR6hDLez4FQg==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0"
+        }
+      },
+      "System.Composition.Hosting": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "OFqSeFeJYr7kHxDfaViGM1ymk7d4JxK//VSoNF9Ux0gpqkLsauDZpu89kTHHNdCWfSljbFcvAafGyBoY094btQ==",
+        "dependencies": {
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Composition.Runtime": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "w1HOlQY1zsOWYussjFGZCEYF2UZXgvoYnS94NIu2CBnAGMbXFAX8PY8c92KwUItPmowal68jnVLBCzdrWLeEKA=="
+      },
+      "System.Composition.TypedParts": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "aRZlojCCGEHDKqh43jaDgaVpYETsgd7Nx4g1zwLKMtv4iTo0627715ajEFNpEEBTgLmvZuv8K0EVxc3sM4NWJA==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Interactive.Async": {
+        "type": "Transitive",
+        "resolved": "7.0.1",
+        "contentHash": "oL1iox7sAJL8i+muGzVMQjDB0axQgOoT5CkwYdap8cQJMkWDWMRErNqhOcZkn31+aKr/uCfgMEdhUARCU4G7gg=="
+      },
+      "System.IO.Packaging": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "JTpM4z0wpoIHHDvlCU27HsXo+zVnpWib94HXQpzzr+jc/P9NYf4w353AK4MXyGq/grm1mbLi7eXsOsDU8sGmNg=="
+      },
+      "System.Linq.Async": {
+        "type": "Transitive",
+        "resolved": "7.0.1",
+        "contentHash": "gwQtBHVY/WgqWgAYSe4JspXR+f1FvMbVIW4ixsJpGV/Kj8Nun3zp1ajIdvCWfmac8ektJGVLiJ/OR8JU9nZnMg==",
+        "dependencies": {
+          "System.Interactive.Async": "7.0.1"
+        }
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "System.Memory.Data": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "MaGhRfGunmrj/nHjtsi9XkhlYJ/ERGWrbA+BiSKNtGnAjc9XlG5EhAvak6VRcX5LYzPF6pBO8nJ613dTgzabig=="
+      },
+      "System.Numerics.Tensors": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "Rb71S3gggYVwEce9ugNw91vbr4vC4gThtx/imSJtLBW3AupEKujJPPQL6xF9q0DcNm6+z7hnYk7XqXaUpA4wDg=="
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "dbdKfF3eA5l+CXiAbDxiCxdezoxeanbue1ck8m49ih1L9uZG6ry8Ul8On6vpragyMDJJP4rQHUY/SWgk66tCYA=="
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "wLBKzFnDCxP12VL9ANydSYhk59fC4cvOr9ypYQLPnAj48NQIhqnjdD2yhP8yEKyBJEjERWS9DisKL7rX5eU25Q=="
+      },
+      "System.Security.Cryptography.Xml": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "wG/+ospsC2oR6j7INYh2V5/CWR6Cpt1Zjkxbo0lfovoi/2RpIcGZPVXOPBNVrI5fmrrji0mdNgez+FClDsIuYA==",
+        "dependencies": {
+          "System.Security.Cryptography.Pkcs": "10.0.7"
+        }
+      },
+      "System.Threading.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "7mu9v0QDv66ar3DpGSZHg9NuNcxDaaAcnMULuZlaTpP9+hwXhrxNGsF5GmLkSHxFdb5bBc1TzeujsRgTrPWi+Q=="
+      },
+      "Umbraco.Cms.Api.Common": {
+        "type": "Transitive",
+        "resolved": "18.0.0",
+        "contentHash": "HA+3PEv7E67OkfxTWbMehFgeL1PnXTZlRNGqD14sRRaWyEVwvniGx97j0CoQYTizIEpXEz10tXAutJl4UWMupw==",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "10.0.0",
+          "Asp.Versioning.Mvc.ApiExplorer": "10.0.0",
+          "Dazinator.Extensions.FileProviders": "2.0.0",
+          "Examine": "3.7.1",
+          "Examine.Core": "3.7.1",
+          "HtmlAgilityPack": "1.12.4",
+          "K4os.Compression.LZ4": "1.3.8",
+          "MailKit": "4.16.0",
+          "Markdig": "1.1.3",
+          "Markdown": "2.2.1",
+          "MessagePack": "3.1.7",
+          "Microsoft.AspNetCore.OpenApi": "10.0.7",
+          "Microsoft.Extensions.Caching.Hybrid": "10.5.0",
+          "Microsoft.Extensions.FileProviders.Embedded": "10.0.7",
+          "MiniProfiler.AspNetCore.Mvc": "4.5.4",
+          "MiniProfiler.Shared": "4.5.4",
+          "NPoco": "6.2.0",
+          "OpenIddict.Abstractions": "7.5.0",
+          "OpenIddict.AspNetCore": "7.5.0",
+          "Serilog": "4.3.1",
+          "Serilog.AspNetCore": "10.0.0",
+          "Serilog.Enrichers.Process": "3.0.0",
+          "Serilog.Enrichers.Thread": "4.0.0",
+          "Serilog.Expressions": "5.0.0",
+          "Serilog.Extensions.Hosting": "10.0.0",
+          "Serilog.Formatting.Compact": "3.0.0",
+          "Serilog.Formatting.Compact.Reader": "4.0.0",
+          "Serilog.Settings.Configuration": "10.0.0",
+          "Serilog.Sinks.Async": "2.1.0",
+          "Serilog.Sinks.File": "7.0.0",
+          "Serilog.Sinks.Map": "2.0.0",
+          "Swashbuckle.AspNetCore.SwaggerUI": "10.1.7",
+          "System.Linq.Async": "7.0.1",
+          "Umbraco.Cms.Core": "[18.0.0, 19.0.0)",
+          "Umbraco.Cms.Web.Common": "[18.0.0, 19.0.0)",
+          "ncrontab": "3.4.0"
+        }
+      },
+      "Umbraco.Cms.Examine.Lucene": {
+        "type": "Transitive",
+        "resolved": "18.0.0",
+        "contentHash": "cCObE4X3PrAk42P2DwpijLJNexZ8dp5cM8l3/5X1E7WSfwDNR3vFu8+PnOpgBGbdPiIJrDrt6nZWL59OqhVbZA==",
+        "dependencies": {
+          "Examine": "3.7.1",
+          "Examine.Core": "3.7.1",
+          "HtmlAgilityPack": "1.12.4",
+          "MailKit": "4.16.0",
+          "Markdig": "1.1.3",
+          "Markdown": "2.2.1",
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Json": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Embedded": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Http": "10.0.7",
+          "Microsoft.Extensions.Identity.Core": "10.0.7",
+          "Microsoft.Extensions.Identity.Stores": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7",
+          "Microsoft.Extensions.Options.DataAnnotations": "10.0.7",
+          "MiniProfiler.Shared": "4.5.4",
+          "NPoco": "6.2.0",
+          "OpenIddict.Abstractions": "7.5.0",
+          "Serilog": "4.3.1",
+          "Serilog.Enrichers.Process": "3.0.0",
+          "Serilog.Enrichers.Thread": "4.0.0",
+          "Serilog.Expressions": "5.0.0",
+          "Serilog.Extensions.Hosting": "10.0.0",
+          "Serilog.Formatting.Compact": "3.0.0",
+          "Serilog.Formatting.Compact.Reader": "4.0.0",
+          "Serilog.Settings.Configuration": "10.0.0",
+          "Serilog.Sinks.Async": "2.1.0",
+          "Serilog.Sinks.File": "7.0.0",
+          "Serilog.Sinks.Map": "2.0.0",
+          "System.Linq.Async": "7.0.1",
+          "System.Security.Cryptography.Xml": "10.0.7",
+          "Umbraco.Cms.Infrastructure": "[18.0.0, 19.0.0)",
+          "ncrontab": "3.4.0"
+        }
+      },
+      "Umbraco.Cms.PublishedCache.HybridCache": {
+        "type": "Transitive",
+        "resolved": "18.0.0",
+        "contentHash": "DfEM9pid0R9X5ug5Rt2fEKM9rRUzWfHpOxMorAXhZLqPz1iZVIiJkLS2vTwj7s8BRGyMKXlHVlJMJFRjsWrQ3A==",
+        "dependencies": {
+          "Examine.Core": "3.7.1",
+          "HtmlAgilityPack": "1.12.4",
+          "K4os.Compression.LZ4": "1.3.8",
+          "MailKit": "4.16.0",
+          "Markdig": "1.1.3",
+          "Markdown": "2.2.1",
+          "MessagePack": "3.1.7",
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Caching.Hybrid": "10.5.0",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Json": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Embedded": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Http": "10.0.7",
+          "Microsoft.Extensions.Identity.Core": "10.0.7",
+          "Microsoft.Extensions.Identity.Stores": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7",
+          "Microsoft.Extensions.Options.DataAnnotations": "10.0.7",
+          "MiniProfiler.Shared": "4.5.4",
+          "NPoco": "6.2.0",
+          "OpenIddict.Abstractions": "7.5.0",
+          "Serilog": "4.3.1",
+          "Serilog.Enrichers.Process": "3.0.0",
+          "Serilog.Enrichers.Thread": "4.0.0",
+          "Serilog.Expressions": "5.0.0",
+          "Serilog.Extensions.Hosting": "10.0.0",
+          "Serilog.Formatting.Compact": "3.0.0",
+          "Serilog.Formatting.Compact.Reader": "4.0.0",
+          "Serilog.Settings.Configuration": "10.0.0",
+          "Serilog.Sinks.Async": "2.1.0",
+          "Serilog.Sinks.File": "7.0.0",
+          "Serilog.Sinks.Map": "2.0.0",
+          "System.Linq.Async": "7.0.1",
+          "Umbraco.Cms.Core": "[18.0.0, 19.0.0)",
+          "Umbraco.Cms.Infrastructure": "[18.0.0, 19.0.0)",
+          "ncrontab": "3.4.0"
+        }
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "umbraco.ai.core": {
+        "type": "Project",
+        "dependencies": {
+          "DocumentFormat.OpenXml": "[3.5.1, 3.999.999)",
+          "Microsoft.Extensions.AI": "[10.7.0, 10.999.999)",
+          "Microsoft.Extensions.Caching.Memory": "[10.0.9, 10.999.999)",
+          "Microsoft.Extensions.Options": "[10.0.9, 10.999.999)",
+          "SixLabors.ImageSharp": "[3.1.12, 3.999.999)",
+          "SmartReader": "[0.11.0, 0.999.999)",
+          "System.ClientModel": "[1.5.0, 1.999.999)",
+          "Umbraco.Cms.Api.Management": "[18.0.0, 18.999.999)",
+          "Umbraco.Cms.Core": "[18.0.0, 18.999.999)",
+          "Umbraco.Cms.Infrastructure": "[18.0.0, 18.999.999)",
+          "Umbraco.Cms.Web.Common": "[18.0.0, 18.999.999)"
+        }
+      },
+      "umbraco.ai.microsoftfoundry": {
+        "type": "Project",
+        "dependencies": {
+          "Azure.AI.OpenAI": "[2.1.0, 2.999.999)",
+          "Azure.Identity": "[1.21.0, 1.999.999)",
+          "Microsoft.Extensions.AI.OpenAI": "[10.7.0, 10.999.999)",
+          "Umbraco.AI.Core": "[1.0.0, )"
+        }
+      },
+      "Azure.AI.OpenAI": {
+        "type": "CentralTransitive",
+        "requested": "[2.1.0, 2.999.999)",
+        "resolved": "2.1.0",
+        "contentHash": "doixr3tcsIcdzbzF9NxKt+6U0NKj6aPeOCPYONPsWjyf3gxVndVJAdjPcVdqeR/3vcRHXRgGnGlv+iXx5jMA4g==",
+        "dependencies": {
+          "Azure.Core": "1.44.1",
+          "OpenAI": "2.1.0"
+        }
+      },
+      "Azure.Identity": {
+        "type": "CentralTransitive",
+        "requested": "[1.21.0, 1.999.999)",
+        "resolved": "1.21.0",
+        "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
+        "dependencies": {
+          "Azure.Core": "1.53.0"
+        }
+      },
+      "DocumentFormat.OpenXml": {
+        "type": "CentralTransitive",
+        "requested": "[3.5.1, 3.999.999)",
+        "resolved": "3.5.1",
+        "contentHash": "zxdOf5VVCe/uNklbRhj8dVBzQGj3DoqkUuqOp9cAZVuN8mNYDjof1lvSQA2OQNr8Ptc9d7pbA7Azq/ReaI3FpA==",
+        "dependencies": {
+          "DocumentFormat.OpenXml.Framework": "3.5.1"
+        }
+      },
+      "Microsoft.AspNetCore.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.7, 10.999.999)",
+        "resolved": "10.0.7",
+        "contentHash": "vKiAcGXG0BwNVw3bOjjWRLnp9tR18dR7MiwpvC94h0yFS+zfnzGHzS/JmmgwUdRixrGxrlIMRAWrVc+2DfAGlg==",
+        "dependencies": {
+          "Microsoft.OpenApi": "2.0.0"
+        }
+      },
+      "Microsoft.Extensions.AI": {
+        "type": "CentralTransitive",
+        "requested": "[10.7.0, 10.999.999)",
+        "resolved": "10.7.0",
+        "contentHash": "r8z4uyPq0kTk4+jH92/hPshf3HNUXKOQ9axJwp57QFz43G45BG4DNYpVE0vuSan1dI69LtWx9ttF0Z2ibnghNg==",
+        "dependencies": {
+          "Microsoft.Extensions.AI.Abstractions": "10.7.0",
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "System.Numerics.Tensors": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.AI.OpenAI": {
+        "type": "CentralTransitive",
+        "requested": "[10.7.0, 10.999.999)",
+        "resolved": "10.7.0",
+        "contentHash": "K/xC0SRJeQiHJNNx+ZIYq9liAB5Uy/wUGjHPljEtRW63TCyGWEBkNVU7/UwizTxQk0Tm9pclDEoNmKTw7xtKfg==",
+        "dependencies": {
+          "Microsoft.Extensions.AI.Abstractions": "10.7.0",
+          "OpenAI": "2.11.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, 10.999.999)",
+        "resolved": "10.0.9",
+        "contentHash": "G9mregdatGWMCQWeCw012LDeJVP7G/XIxH8Ddbjc8bD1//dA+8VVQdcRE9jI1moyoJxSSZhHITUnNQ8FUDl5+Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, 10.999.999)",
+        "resolved": "10.0.9",
+        "contentHash": "hyNdX4c2UwkRkzb9byw0H2DQkRzwBM3mzY2sCM9egwzTyg8dvQJmp5noQHGEaaCORQrNK3DD2gREBsc2DlXS4A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "SixLabors.ImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[3.1.12, 3.999.999)",
+        "resolved": "3.1.12",
+        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
+      },
+      "SmartReader": {
+        "type": "CentralTransitive",
+        "requested": "[0.11.0, 0.999.999)",
+        "resolved": "0.11.0",
+        "contentHash": "DSn2HErPhhaf+IIyFFQNAyPS1Z4Dv3EYLQlgHwdDlpDxolvB8RCDvTiQZGP3yg9tLMTT2eA9RIN7DbZLbiamhg==",
+        "dependencies": {
+          "AngleSharp": "1.4.0"
+        }
+      },
+      "System.ClientModel": {
+        "type": "CentralTransitive",
+        "requested": "[1.5.0, 1.999.999)",
+        "resolved": "1.10.0",
+        "contentHash": "lBEWs54F5Y5pZ9hC+8z4S/X76957ex+DPk7WecRHlbIHtrPfbRMMlOgI3iDn4Jpb3bSxvBnKaaHoD59auFjlBA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "System.Memory.Data": "10.0.3"
+        }
+      },
+      "Umbraco.Cms.Api.Management": {
+        "type": "CentralTransitive",
+        "requested": "[18.0.0, 18.999.999)",
+        "resolved": "18.0.0",
+        "contentHash": "tuxXGtQV0yvF/Cf0TieLBlW6z+lFygL95IJmVCS2L4K0F+Dw5c3oZkIvZ/pPowopas11ptq3UpDfPzhS1WgULg==",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "10.0.0",
+          "Asp.Versioning.Mvc.ApiExplorer": "10.0.0",
+          "Dazinator.Extensions.FileProviders": "2.0.0",
+          "Examine": "3.7.1",
+          "Examine.Core": "3.7.1",
+          "HtmlAgilityPack": "1.12.4",
+          "JsonPatch.Net": "3.3.0",
+          "K4os.Compression.LZ4": "1.3.8",
+          "MailKit": "4.16.0",
+          "Markdig": "1.1.3",
+          "Markdown": "2.2.1",
+          "MessagePack": "3.1.7",
+          "Microsoft.AspNetCore.OpenApi": "10.0.7",
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Caching.Hybrid": "10.5.0",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Json": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Embedded": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Http": "10.0.7",
+          "Microsoft.Extensions.Identity.Core": "10.0.7",
+          "Microsoft.Extensions.Identity.Stores": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7",
+          "Microsoft.Extensions.Options.DataAnnotations": "10.0.7",
+          "MiniProfiler.AspNetCore.Mvc": "4.5.4",
+          "MiniProfiler.Shared": "4.5.4",
+          "NPoco": "6.2.0",
+          "OpenIddict.Abstractions": "7.5.0",
+          "OpenIddict.AspNetCore": "7.5.0",
+          "Serilog": "4.3.1",
+          "Serilog.AspNetCore": "10.0.0",
+          "Serilog.Enrichers.Process": "3.0.0",
+          "Serilog.Enrichers.Thread": "4.0.0",
+          "Serilog.Expressions": "5.0.0",
+          "Serilog.Extensions.Hosting": "10.0.0",
+          "Serilog.Formatting.Compact": "3.0.0",
+          "Serilog.Formatting.Compact.Reader": "4.0.0",
+          "Serilog.Settings.Configuration": "10.0.0",
+          "Serilog.Sinks.Async": "2.1.0",
+          "Serilog.Sinks.File": "7.0.0",
+          "Serilog.Sinks.Map": "2.0.0",
+          "Swashbuckle.AspNetCore.SwaggerUI": "10.1.7",
+          "System.Linq.Async": "7.0.1",
+          "System.Security.Cryptography.Xml": "10.0.7",
+          "Umbraco.Cms.Api.Common": "[18.0.0, 19.0.0)",
+          "Umbraco.Cms.Infrastructure": "[18.0.0, 19.0.0)",
+          "Umbraco.Cms.PublishedCache.HybridCache": "[18.0.0, 19.0.0)",
+          "ncrontab": "3.4.0"
+        }
+      },
+      "Umbraco.Cms.Core": {
+        "type": "CentralTransitive",
+        "requested": "[18.0.0, 18.999.999)",
+        "resolved": "18.0.0",
+        "contentHash": "VS0UNcn8DzCABYczauahvlb3pBqzw6nl7WRWZMOKRlTz0238ms9KtnplJqphwFrsF3OdyNijUFuNf1TwJv4dqA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Embedded": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Identity.Core": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7",
+          "Microsoft.Extensions.Options.DataAnnotations": "10.0.7"
+        }
+      },
+      "Umbraco.Cms.Infrastructure": {
+        "type": "CentralTransitive",
+        "requested": "[18.0.0, 18.999.999)",
+        "resolved": "18.0.0",
+        "contentHash": "dtDxfWuFMTHyjSWbKe+mQBQi3dG4LJFepeyMmQOh3OoTXxbRKNkZqJczXe3UTw+EQTA2S36L1s90alHjvFz3AA==",
+        "dependencies": {
+          "Examine.Core": "3.7.1",
+          "HtmlAgilityPack": "1.12.4",
+          "MailKit": "4.16.0",
+          "Markdig": "1.1.3",
+          "Markdown": "2.2.1",
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Json": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Embedded": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Http": "10.0.7",
+          "Microsoft.Extensions.Identity.Core": "10.0.7",
+          "Microsoft.Extensions.Identity.Stores": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7",
+          "Microsoft.Extensions.Options.DataAnnotations": "10.0.7",
+          "MiniProfiler.Shared": "4.5.4",
+          "NPoco": "6.2.0",
+          "OpenIddict.Abstractions": "7.5.0",
+          "Serilog": "4.3.1",
+          "Serilog.Enrichers.Process": "3.0.0",
+          "Serilog.Enrichers.Thread": "4.0.0",
+          "Serilog.Expressions": "5.0.0",
+          "Serilog.Extensions.Hosting": "10.0.0",
+          "Serilog.Formatting.Compact": "3.0.0",
+          "Serilog.Formatting.Compact.Reader": "4.0.0",
+          "Serilog.Settings.Configuration": "10.0.0",
+          "Serilog.Sinks.Async": "2.1.0",
+          "Serilog.Sinks.File": "7.0.0",
+          "Serilog.Sinks.Map": "2.0.0",
+          "System.Linq.Async": "7.0.1",
+          "Umbraco.Cms.Core": "[18.0.0, 19.0.0)",
+          "ncrontab": "3.4.0"
+        }
+      },
+      "Umbraco.Cms.Web.Common": {
+        "type": "CentralTransitive",
+        "requested": "[18.0.0, 18.999.999)",
+        "resolved": "18.0.0",
+        "contentHash": "C8HQgeOlDRrqurElg63GhX7xXTYzxSOZJ9crxyiKOtgfXGlaQXSuOxWB4WM4wuKOh0jQPZiyB7+cjbaVGw7JhQ==",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "10.0.0",
+          "Asp.Versioning.Mvc.ApiExplorer": "10.0.0",
+          "Dazinator.Extensions.FileProviders": "2.0.0",
+          "Examine": "3.7.1",
+          "Examine.Core": "3.7.1",
+          "HtmlAgilityPack": "1.12.4",
+          "K4os.Compression.LZ4": "1.3.8",
+          "MailKit": "4.16.0",
+          "Markdig": "1.1.3",
+          "Markdown": "2.2.1",
+          "MessagePack": "3.1.7",
+          "Microsoft.Extensions.Caching.Hybrid": "10.5.0",
+          "Microsoft.Extensions.FileProviders.Embedded": "10.0.7",
+          "MiniProfiler.AspNetCore.Mvc": "4.5.4",
+          "MiniProfiler.Shared": "4.5.4",
+          "NPoco": "6.2.0",
+          "OpenIddict.Abstractions": "7.5.0",
+          "Serilog": "4.3.1",
+          "Serilog.AspNetCore": "10.0.0",
+          "Serilog.Enrichers.Process": "3.0.0",
+          "Serilog.Enrichers.Thread": "4.0.0",
+          "Serilog.Expressions": "5.0.0",
+          "Serilog.Extensions.Hosting": "10.0.0",
+          "Serilog.Formatting.Compact": "3.0.0",
+          "Serilog.Formatting.Compact.Reader": "4.0.0",
+          "Serilog.Settings.Configuration": "10.0.0",
+          "Serilog.Sinks.Async": "2.1.0",
+          "Serilog.Sinks.File": "7.0.0",
+          "Serilog.Sinks.Map": "2.0.0",
+          "System.Linq.Async": "7.0.1",
+          "Umbraco.Cms.Examine.Lucene": "[18.0.0, 19.0.0)",
+          "Umbraco.Cms.PublishedCache.HybridCache": "[18.0.0, 19.0.0)",
+          "ncrontab": "3.4.0"
+        }
+      }
+    }
+  }
+}

--- a/Umbraco.AI.slnx
+++ b/Umbraco.AI.slnx
@@ -90,6 +90,7 @@
   </Folder>
   <Folder Name="/Providers/MicrosoftFoundry/">
     <Project Path="Umbraco.AI.MicrosoftFoundry/src/Umbraco.AI.MicrosoftFoundry/Umbraco.AI.MicrosoftFoundry.csproj" />
+    <Project Path="Umbraco.AI.MicrosoftFoundry/tests/Umbraco.AI.MicrosoftFoundry.Tests.Unit/Umbraco.AI.MicrosoftFoundry.Tests.Unit.csproj" />
   </Folder>
   <Folder Name="/Providers/Mistral/">
     <Project Path="Umbraco.AI.Mistral/src/Umbraco.AI.Mistral/Umbraco.AI.Mistral.csproj" />


### PR DESCRIPTION
Closes #286 — the one item carried out of #266 when the rest was closed as low priority.

## The failure

Foundry sent the sampling parameters to every model, so a connection pointed at an o-series, GPT-5 or Claude 4.7+ deployment took a hard 400 on `temperature`. The same failure as #256, fixed for the first-party providers in #265 and moved into the core bases in #283 — never applied here.

#283 is what made this small: Foundry needs no decorator of its own, only a predicate. Both capabilities now override `GetSettingsSupport`, so the core bases hide the field in the editor and strip the value from the request off **one** predicate. Embedding `Dimensions` is declared the same way for `ada-002` deployments.

## The metadata that was being thrown away

`MicrosoftFoundryDeploymentInfo` already deserialized `modelName`, `modelVersion` and `modelPublisher`. The mapping kept only the deployment name:

```csharp
.Select(d => new MicrosoftFoundryModelInfo { Id = d.Name })
```

All three are now carried onto `MicrosoftFoundryModelInfo` and cached per model, so a deployment called `prod-chat` is judged on the `o3` behind it rather than on its name. The capabilities prefetch the (cached) listing when creating a client so that lookup is warm at request time — the same shape `AnthropicChatCapability` uses.

The model picker uses them too. It previously showed a raw deployment name as the display name, so `prod-chat-1` was the whole label; it now reads `o3 2025-04-16 (prod-chat-1)`, keeping the deployment name because that is the value stored on the profile.

## Unknown models are treated as supported

This inverts the allow-list direction the first-party packages use, and it is the one decision here worth a second pair of eyes.

Those packages each own a closed set of models with a known restriction, so an allow-list means an unrecognised model **degrades** (value dropped) instead of **failing** (400). Foundry is a gateway: most of what it fronts — Mistral, Llama, Cohere, Phi, Nova, DeepSeek — restricts nothing, so the same allow-list would silently stop sending a temperature that most of the catalogue honours today. A regression across the catalogue is a worse trade than a 400 confined to two vendors' newest models.

The fail-safe behaviour is kept where it is warranted:

- **Within a vendor known to restrict, allow-list semantics apply.** A name that reads as OpenAI's or Anthropic's but is unrecognised — a future `gpt-6`, a `claude-opus-4-9` — is treated as restricted.
- **A reported publisher can only rule a restriction out, never in.** A Llama deployment a user named `o3-llama` does not inherit o3's restriction; but knowing only that a vendor is OpenAI is not enough to infer a given deployment is restricted, because guessing "restricted" would drop a value from a deployment that works today.

## Found while doing it

**`gpt-35-turbo` would have lost its temperature.** Azure spells GPT-3.5 without the dot, because an Azure model name cannot contain one, so OpenAI's own `^gpt-3\.5` pattern never has to match that form. Copying it verbatim would have read `gpt-35-turbo` as an unrecognised OpenAI model and dropped a parameter it accepts. The undotted spelling is listed separately, with a regression row.

This is the concrete argument for Foundry holding its own table rather than sharing one: the same vendor's models arrive under different names through a gateway. The duplication of the family patterns is deliberate — sharing them would couple independently released packages, and lifting them into core would put vendor knowledge where it does not belong — so a change to a vendor's restrictions needs the same edit in every package naming that vendor's families. Noted in the package's `CLAUDE.md`.

## Not addressed, by design

The models API fallback path still has only an `id`, which for an Azure OpenAI deployment can be a user-chosen name that says nothing about the model. Name matching catches the common case and misses the rest. That residual slice is what the runtime-recovery proposal on #266 was for, and it is not a blocker: an allow-list only ever under-sends, so this cannot itself provoke a 400, and an unidentifiable deployment keeps today's behaviour rather than guessing. Pinned by a test.

## Tests

The package **had no test project at all** — the `InternalsVisibleTo` for `Umbraco.AI.MicrosoftFoundry.Tests.Unit` was in the csproj, but nothing on the other end of it. Added and registered in both `Umbraco.AI.MicrosoftFoundry.slnx` and the root `Umbraco.AI.slnx` (the latter being what CI actually runs, per #271).

63 tests: the predicate table for both capabilities, the deployment-fronting cases, the publisher-rules-out case, the unidentifiable-name fallback, display-name formatting, and the deployments mapping carrying all three fields. The declaration tests go through the real capability rather than the predicate, so a capability that stopped overriding `GetSettingsSupport`, or a provider that stopped carrying the metadata, fails.

Two seams were opened to make the deployments path reachable without a live Foundry resource, since everything above it is Entra ID token acquisition and HTTP: `MapDeployments` is now a named internal static rather than inline in the fetch, and the per-model cache key prefix is `internal`.

```
Passed! - Failed: 0, Passed: 63, Skipped: 0, Total: 63
```

## Note for review

- `MicrosoftFoundryEmbeddingCapability` gained a logger parameter. The previous single-argument constructor is retained as `[Obsolete("… Will be removed in v20.")]` resolving the logger through the service locator, per the backwards-compatibility rule and matching `AnthropicChatCapability`. The chat capability already took a logger, so it needs no such shim.
- The per-model cache is keyed by model ID, not per connection, because the hook that reads it is given only a model ID. Two connections using the same deployment name for different models therefore collide, most recent listing winning. The consequence is bounded to the same dropped parameter or the same 400 that would happen without any of this metadata — never a new failure — and is documented on `TryGetModelInfo`. Fixing it properly would mean changing the core hook's signature.

Verified by build and unit tests. A live Foundry deployment would be the real check; I don't have one, so the o-series/Claude behaviour is pinned by the predicate tests plus core's existing `DeclaredSettingsEnforcementTests` covering the base wiring.

v17 backport to follow once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)