### PR TITLE
Mask sensitive field values by default

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/AIEditableModelField.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/AIEditableModelField.cs
@@ -61,8 +61,9 @@ public class AIEditableModelField
     public IEnumerable<ValidationAttribute> ValidationRules { get; set; } = Array.Empty<ValidationAttribute>();
 
     /// <summary>
-    /// Indicates whether the field contains sensitive data that should be encrypted at rest.
-    /// When true, the field value will be encrypted during persistence and the UI may mask the value.
+    /// Indicates whether the field holds a secret. When true the value is encrypted at rest, masked
+    /// in version-history diffs, and (unless <see cref="EditorUiAlias"/> says otherwise) rendered
+    /// with a masked editor. See <see cref="AIEditableModelFieldAttribute.IsSensitive"/>.
     /// </summary>
     public bool IsSensitive { get; set; }
 

--- a/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/AIEditableModelFieldAttribute.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/AIEditableModelFieldAttribute.cs
@@ -33,9 +33,18 @@ public class AIEditableModelFieldAttribute : Attribute
     public int SortOrder { get; set; }
 
     /// <summary>
-    /// Indicates whether the field contains sensitive data that should be encrypted at rest.
-    /// When true, the field value will be encrypted during persistence and the UI may mask the value.
+    /// Indicates whether the field holds a secret (an API key, client secret, connection string).
     /// </summary>
+    /// <remarks>
+    /// Marking a field sensitive has four effects: the value is encrypted at rest, it is masked in
+    /// version-history diffs, it becomes the only kind of field allowed to reference a configuration
+    /// key under <c>Umbraco:AI:Secrets</c>, and it renders with a masked editor (with a reveal
+    /// toggle) instead of a plain text box.
+    ///
+    /// Set <see cref="EditorUiAlias"/> to opt out of the masked editor — masking a multi-line field,
+    /// for instance, would make it unusable. Sensitive values should be strings; the persistence
+    /// layer only encrypts string values.
+    /// </remarks>
     public bool IsSensitive { get; set; }
 
     /// <summary>

--- a/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/AIEditableModelSchemaBuilder.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/AIEditableModelSchemaBuilder.cs
@@ -52,7 +52,7 @@ internal sealed class AIEditableModelSchemaBuilder : IAIEditableModelSchemaBuild
             PropertyType = property.PropertyType,
             Label = attr?.Label ?? $"#uaiFields_{modelKey}{property.Name}Label",
             Description = attr?.Description ?? $"#uaiFields_{modelKey}{property.Name}Description",
-            EditorUiAlias = attr?.EditorUiAlias ?? InferEditorUiAlias(property.PropertyType),
+            EditorUiAlias = attr?.EditorUiAlias ?? InferEditorUiAlias(property.PropertyType, attr?.IsSensitive ?? false),
             EditorConfig = attr?.EditorConfig != null
                 ? JsonSerializer.Deserialize<JsonElement>(attr.EditorConfig, Constants.DefaultJsonSerializerOptions)
                 : null,
@@ -65,12 +65,24 @@ internal sealed class AIEditableModelSchemaBuilder : IAIEditableModelSchemaBuild
         };
     }
 
-    private static string InferEditorUiAlias(Type type)
+    /// <summary>
+    /// Picks the editor to render a field with when its <see cref="AIEditableModelFieldAttribute"/>
+    /// does not name one explicitly.
+    /// </summary>
+    /// <remarks>
+    /// Sensitive strings default to a masked editor (with a reveal toggle) so credentials are not
+    /// left on screen during screen shares and demos. This is inferred here rather than flagged to
+    /// the client, so <c>IsSensitive</c> never has to cross the API boundary — the same approach
+    /// already taken for <c>IsRequired</c>. A settings author who wants a sensitive field rendered
+    /// some other way sets <see cref="AIEditableModelFieldAttribute.EditorUiAlias"/>, which is
+    /// checked first by the caller and so always wins.
+    /// </remarks>
+    private static string InferEditorUiAlias(Type type, bool isSensitive)
     {
         var underlyingType = Nullable.GetUnderlyingType(type) ?? type;
 
         if (underlyingType == typeof(string))
-            return "Umb.PropertyEditorUi.TextBox";
+            return isSensitive ? "Uai.PropertyEditorUi.MaskedTextBox" : "Umb.PropertyEditorUi.TextBox";
         if (underlyingType == typeof(int) || underlyingType == typeof(long))
             return "Umb.PropertyEditorUi.Integer";
         if (underlyingType == typeof(bool))
@@ -80,7 +92,8 @@ internal sealed class AIEditableModelSchemaBuilder : IAIEditableModelSchemaBuild
         if (underlyingType == typeof(DateTime) || underlyingType == typeof(DateTimeOffset))
             return "Umb.PropertyEditorUi.DatePicker";
 
-        return "Umb.PropertyEditorUi.TextBox";
+        // Anything else also falls back to a text box, so keep the sensitive/masked pairing here too.
+        return isSensitive ? "Uai.PropertyEditorUi.MaskedTextBox" : "Umb.PropertyEditorUi.TextBox";
     }
 
     private static IEnumerable<ValidationAttribute> InferValidationAttributes(PropertyInfo property)

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/property-editors/index.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/property-editors/index.ts
@@ -1,4 +1,5 @@
 export { UaiPropertyEditorUIContextPickerElement } from "./context-picker/index.js";
 export { UaiPropertyEditorUIEntityPickerElement } from "./entity-picker/index.js";
 export { UaiPropertyEditorUIEntityPropertyPickerElement } from "./entity-property-picker/index.js";
+export { UaiPropertyEditorUIMaskedTextBoxElement } from "./masked-text-box/index.js";
 export { UaiPropertyEditorUIProfilePickerElement } from "./profile-picker/index.js";

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/property-editors/manifests.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/property-editors/manifests.ts
@@ -1,6 +1,7 @@
 import { contextPickerPropertyEditorManifests } from "./context-picker/manifests.js";
 import { entityPickerPropertyEditorManifests } from "./entity-picker/manifests.js";
 import { entityPropertyPickerPropertyEditorManifests } from "./entity-property-picker/manifests.js";
+import { maskedTextBoxPropertyEditorManifests } from "./masked-text-box/manifests.js";
 import { profilePickerPropertyEditorManifests } from "./profile-picker/manifests.js";
 import { mockEntityPropertyEditorManifests } from "./mock-entity/manifests.js";
 
@@ -8,6 +9,7 @@ export const propertyEditorManifests = [
     ...contextPickerPropertyEditorManifests,
     ...entityPickerPropertyEditorManifests,
     ...entityPropertyPickerPropertyEditorManifests,
+    ...maskedTextBoxPropertyEditorManifests,
     ...profilePickerPropertyEditorManifests,
     ...mockEntityPropertyEditorManifests
 ];

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/property-editors/masked-text-box/index.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/property-editors/masked-text-box/index.ts
@@ -1,0 +1,1 @@
+export * from "./property-editor-ui-masked-text-box.element.js";

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/property-editors/masked-text-box/manifests.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/property-editors/masked-text-box/manifests.ts
@@ -1,0 +1,26 @@
+import type { ManifestPropertyEditorUi } from "@umbraco-cms/backoffice/property-editor";
+
+const propertyEditorUi: ManifestPropertyEditorUi = {
+    type: "propertyEditorUi",
+    alias: "Uai.PropertyEditorUi.MaskedTextBox",
+    name: "AI Masked Text Box Property Editor UI",
+    element: () => import("./property-editor-ui-masked-text-box.element.js"),
+    meta: {
+        label: "AI Masked Text Box",
+        icon: "icon-lock",
+        group: "Umbraco AI",
+        keywords: ["ai", "umbraco ai", "masked", "password", "secret", "sensitive", "api key"],
+        settings: {
+            properties: [
+                {
+                    alias: "placeholder",
+                    label: "Placeholder",
+                    description: "Text shown while the field is empty",
+                    propertyEditorUiAlias: "Umb.PropertyEditorUi.TextBox",
+                },
+            ],
+        },
+    },
+};
+
+export const maskedTextBoxPropertyEditorManifests = [propertyEditorUi];

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/property-editors/masked-text-box/property-editor-ui-masked-text-box.element.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/property-editors/masked-text-box/property-editor-ui-masked-text-box.element.ts
@@ -30,11 +30,13 @@ function isConfigReference(value: unknown): boolean {
  * travels to the browser in full, so this guards against being read over someone's shoulder,
  * not against anyone who opens dev tools.
  *
- * Configuration references (`$Umbraco:AI:Secrets:ApiKey`) render unmasked: they are pointers,
+ * Configuration references (`$Umbraco:AI:Secrets:ApiKey`) start revealed: they are pointers,
  * not secrets, and hiding them makes it impossible to see which key a connection points at.
  *
- * The masked/plain decision is re-evaluated only while the field is unfocused, so typing a
- * leading `$` doesn't swap the input out from under the cursor.
+ * This drives `uui-input-password`'s type rather than swapping in a different element, so the
+ * masking keeps up with what is actually in the field as it is typed. Replacing the element
+ * would be the obvious way to drop the reveal toggle for a reference, but it destroys and
+ * recreates the input — which takes the caret with it mid-edit.
  */
 @customElement(elementName)
 export class UaiPropertyEditorUIMaskedTextBoxElement
@@ -57,16 +59,7 @@ export class UaiPropertyEditorUIMaskedTextBoxElement
     name?: string;
 
     @state()
-    private _isReference = false;
-
-    @state()
     private _placeholder?: string;
-
-    /**
-     * The inner input currently registered for validation. Tracked because switching between the
-     * masked and plain inputs replaces the element, and the stale one has to be unregistered.
-     */
-    #formControl?: UUIInputElement;
 
     public set config(config: UmbPropertyEditorConfigCollection | undefined) {
         if (!config) return;
@@ -74,64 +67,13 @@ export class UaiPropertyEditorUIMaskedTextBoxElement
         this._placeholder = this.localize.string(config.getValueByAlias<string>("placeholder") ?? "");
     }
 
-    override connectedCallback() {
-        super.connectedCallback();
-        this.addEventListener("focusout", this.#onFocusOut);
-    }
-
-    override disconnectedCallback() {
-        this.removeEventListener("focusout", this.#onFocusOut);
-        super.disconnectedCallback();
-    }
-
-    override willUpdate(changedProperties: Map<string, unknown>) {
-        super.willUpdate(changedProperties);
-
-        if (changedProperties.has("value")) {
-            this.#syncReferenceState();
-        }
-    }
-
-    override updated(changedProperties: Map<string, unknown>) {
-        super.updated(changedProperties);
-
-        // Re-point validation at the inner input whenever the masked/plain swap replaces it.
-        const input = this.shadowRoot?.querySelector<UUIInputElement>("uui-input, uui-input-password") ?? undefined;
-        if (input === this.#formControl) return;
-
-        if (this.#formControl) {
-            this.removeFormControlElement(this.#formControl);
-        }
-
-        this.#formControl = input;
-
-        if (input) {
-            this.addFormControlElement(input);
-        }
+    protected override firstUpdated(): void {
+        this.addFormControlElement(this.shadowRoot!.querySelector("uui-input-password")!);
     }
 
     override focus() {
-        return this.#formControl?.focus();
+        return this.shadowRoot?.querySelector<UUIInputElement>("uui-input-password")?.focus();
     }
-
-    /**
-     * Re-evaluates whether the current value is a configuration reference, but only while the
-     * field is unfocused — swapping the input mid-edit would drop the cursor.
-     *
-     * `:focus-within` is used rather than the `focusout` event's `relatedTarget` because the
-     * reveal toggle lives inside the input's own shadow root, where `relatedTarget` is retargeted.
-     */
-    #syncReferenceState() {
-        if (this.matches(":focus-within")) return;
-
-        this._isReference = isConfigReference(this.value);
-    }
-
-    #onFocusOut = () => {
-        // Deferred a frame so focus moving between the input and its reveal toggle — which fires
-        // focusout before the matching focusin — doesn't read as having left the field.
-        requestAnimationFrame(() => this.#syncReferenceState());
-    };
 
     #onInput(e: InputEvent) {
         const newValue = (e.target as HTMLInputElement).value;
@@ -142,40 +84,28 @@ export class UaiPropertyEditorUIMaskedTextBoxElement
     }
 
     override render() {
-        const label = this.localize.term("general_fieldFor", [this.name]);
+        // Only re-committed when the bound value itself changes, so a reveal the user toggled by
+        // hand survives further typing — Lit skips the property write while this stays the same.
+        const type = isConfigReference(this.value) ? "text" : "password";
 
-        return this._isReference
-            ? html`
-                  <uui-input
-                      .label=${label}
-                      .placeholder=${this._placeholder ?? ""}
-                      .requiredMessage=${this.mandatoryMessage}
-                      .value=${this.value ?? ""}
-                      ?readonly=${this.readonly}
-                      ?required=${this.mandatory}
-                      spellcheck="false"
-                      @input=${this.#onInput}
-                  >
-                  </uui-input>
-              `
-            : html`
-                  <uui-input-password
-                      .label=${label}
-                      .placeholder=${this._placeholder ?? ""}
-                      .requiredMessage=${this.mandatoryMessage}
-                      .value=${this.value ?? ""}
-                      ?readonly=${this.readonly}
-                      ?required=${this.mandatory}
-                      autocomplete="off"
-                      @input=${this.#onInput}
-                  >
-                  </uui-input-password>
-              `;
+        return html`
+            <uui-input-password
+                .label=${this.localize.term("general_fieldFor", [this.name])}
+                .placeholder=${this._placeholder ?? ""}
+                .requiredMessage=${this.mandatoryMessage}
+                .type=${type}
+                .value=${this.value ?? ""}
+                ?readonly=${this.readonly}
+                ?required=${this.mandatory}
+                autocomplete="off"
+                @input=${this.#onInput}
+            >
+            </uui-input-password>
+        `;
     }
 
     static override styles = [
         css`
-            uui-input,
             uui-input-password {
                 width: 100%;
             }

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/property-editors/masked-text-box/property-editor-ui-masked-text-box.element.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/property-editors/masked-text-box/property-editor-ui-masked-text-box.element.ts
@@ -1,0 +1,192 @@
+import { css, customElement, html, property, state } from "@umbraco-cms/backoffice/external/lit";
+import { UmbChangeEvent } from "@umbraco-cms/backoffice/event";
+import { UmbLitElement } from "@umbraco-cms/backoffice/lit-element";
+import { UMB_VALIDATION_EMPTY_LOCALIZATION_KEY, UmbFormControlMixin } from "@umbraco-cms/backoffice/validation";
+import type { UUIInputElement } from "@umbraco-cms/backoffice/external/uui";
+import type {
+    UmbPropertyEditorConfigCollection,
+    UmbPropertyEditorUiElement,
+} from "@umbraco-cms/backoffice/property-editor";
+
+const elementName = "uai-property-editor-ui-masked-text-box";
+
+/**
+ * Determines whether a value is a configuration reference rather than a literal secret.
+ *
+ * Mirrors the server-side rule in `AIEditableModelResolver`: a single leading `$` denotes a
+ * configuration key, while `$$` is the escape hatch for a literal value that happens to start
+ * with `$` — and a literal is still a secret, so it stays masked.
+ */
+function isConfigReference(value: unknown): boolean {
+    return typeof value === "string" && value.startsWith("$") && !value.startsWith("$$");
+}
+
+/**
+ * Text box that masks its value by default, with a built-in toggle to reveal it.
+ *
+ * Applied automatically to fields marked `[AIField(IsSensitive = true)]` — the schema builder
+ * infers this alias server-side, so `isSensitive` never needs to reach the client. It stops
+ * credentials sitting in plain sight during screen shares and demos. Note the value still
+ * travels to the browser in full, so this guards against being read over someone's shoulder,
+ * not against anyone who opens dev tools.
+ *
+ * Configuration references (`$Umbraco:AI:Secrets:ApiKey`) render unmasked: they are pointers,
+ * not secrets, and hiding them makes it impossible to see which key a connection points at.
+ *
+ * The masked/plain decision is re-evaluated only while the field is unfocused, so typing a
+ * leading `$` doesn't swap the input out from under the cursor.
+ */
+@customElement(elementName)
+export class UaiPropertyEditorUIMaskedTextBoxElement
+    extends UmbFormControlMixin<string, typeof UmbLitElement, undefined>(UmbLitElement, undefined)
+    implements UmbPropertyEditorUiElement
+{
+    @property({ type: Boolean, reflect: true })
+    readonly = false;
+
+    @property({ type: Boolean })
+    mandatory?: boolean;
+
+    @property({ type: String })
+    mandatoryMessage = UMB_VALIDATION_EMPTY_LOCALIZATION_KEY;
+
+    /**
+     * The name of this field.
+     */
+    @property({ type: String })
+    name?: string;
+
+    @state()
+    private _isReference = false;
+
+    @state()
+    private _placeholder?: string;
+
+    /**
+     * The inner input currently registered for validation. Tracked because switching between the
+     * masked and plain inputs replaces the element, and the stale one has to be unregistered.
+     */
+    #formControl?: UUIInputElement;
+
+    public set config(config: UmbPropertyEditorConfigCollection | undefined) {
+        if (!config) return;
+
+        this._placeholder = this.localize.string(config.getValueByAlias<string>("placeholder") ?? "");
+    }
+
+    override connectedCallback() {
+        super.connectedCallback();
+        this.addEventListener("focusout", this.#onFocusOut);
+    }
+
+    override disconnectedCallback() {
+        this.removeEventListener("focusout", this.#onFocusOut);
+        super.disconnectedCallback();
+    }
+
+    override willUpdate(changedProperties: Map<string, unknown>) {
+        super.willUpdate(changedProperties);
+
+        if (changedProperties.has("value")) {
+            this.#syncReferenceState();
+        }
+    }
+
+    override updated(changedProperties: Map<string, unknown>) {
+        super.updated(changedProperties);
+
+        // Re-point validation at the inner input whenever the masked/plain swap replaces it.
+        const input = this.shadowRoot?.querySelector<UUIInputElement>("uui-input, uui-input-password") ?? undefined;
+        if (input === this.#formControl) return;
+
+        if (this.#formControl) {
+            this.removeFormControlElement(this.#formControl);
+        }
+
+        this.#formControl = input;
+
+        if (input) {
+            this.addFormControlElement(input);
+        }
+    }
+
+    override focus() {
+        return this.#formControl?.focus();
+    }
+
+    /**
+     * Re-evaluates whether the current value is a configuration reference, but only while the
+     * field is unfocused — swapping the input mid-edit would drop the cursor.
+     *
+     * `:focus-within` is used rather than the `focusout` event's `relatedTarget` because the
+     * reveal toggle lives inside the input's own shadow root, where `relatedTarget` is retargeted.
+     */
+    #syncReferenceState() {
+        if (this.matches(":focus-within")) return;
+
+        this._isReference = isConfigReference(this.value);
+    }
+
+    #onFocusOut = () => {
+        // Deferred a frame so focus moving between the input and its reveal toggle — which fires
+        // focusout before the matching focusin — doesn't read as having left the field.
+        requestAnimationFrame(() => this.#syncReferenceState());
+    };
+
+    #onInput(e: InputEvent) {
+        const newValue = (e.target as HTMLInputElement).value;
+        if (newValue === this.value) return;
+
+        this.value = newValue;
+        this.dispatchEvent(new UmbChangeEvent());
+    }
+
+    override render() {
+        const label = this.localize.term("general_fieldFor", [this.name]);
+
+        return this._isReference
+            ? html`
+                  <uui-input
+                      .label=${label}
+                      .placeholder=${this._placeholder ?? ""}
+                      .requiredMessage=${this.mandatoryMessage}
+                      .value=${this.value ?? ""}
+                      ?readonly=${this.readonly}
+                      ?required=${this.mandatory}
+                      spellcheck="false"
+                      @input=${this.#onInput}
+                  >
+                  </uui-input>
+              `
+            : html`
+                  <uui-input-password
+                      .label=${label}
+                      .placeholder=${this._placeholder ?? ""}
+                      .requiredMessage=${this.mandatoryMessage}
+                      .value=${this.value ?? ""}
+                      ?readonly=${this.readonly}
+                      ?required=${this.mandatory}
+                      autocomplete="off"
+                      @input=${this.#onInput}
+                  >
+                  </uui-input-password>
+              `;
+    }
+
+    static override styles = [
+        css`
+            uui-input,
+            uui-input-password {
+                width: 100%;
+            }
+        `,
+    ];
+}
+
+export { UaiPropertyEditorUIMaskedTextBoxElement as element };
+
+declare global {
+    interface HTMLElementTagNameMap {
+        [elementName]: UaiPropertyEditorUIMaskedTextBoxElement;
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Settings/AIEditableModelSchemaBuilderTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Settings/AIEditableModelSchemaBuilderTests.cs
@@ -1,0 +1,59 @@
+using Shouldly;
+using Umbraco.AI.Core.EditableModels;
+
+namespace Umbraco.AI.Tests.Unit.Settings;
+
+public class AIEditableModelSchemaBuilderTests
+{
+    private const string MaskedTextBox = "Uai.PropertyEditorUi.MaskedTextBox";
+    private const string TextBox = "Umb.PropertyEditorUi.TextBox";
+
+    private readonly AIEditableModelSchemaBuilder _builder = new();
+
+    private class TestSettings
+    {
+        [AIField(IsSensitive = true)]
+        public string? ApiKey { get; set; }
+
+        [AIField]
+        public string? BaseUrl { get; set; }
+
+        [AIField(IsSensitive = true, EditorUiAlias = "Umb.PropertyEditorUi.TextArea")]
+        public string? PrivateKey { get; set; }
+
+        [AIField(IsSensitive = true)]
+        public int RotationDays { get; set; }
+    }
+
+    private AIEditableModelField GetField(string key)
+        => _builder.BuildForType<TestSettings>("test").Fields.Single(f => f.Key == key);
+
+    [Fact]
+    public void BuildForType_WithSensitiveString_UsesMaskedEditor()
+    {
+        // A sensitive credential should never render as a plain text box by default,
+        // so it isn't left on screen during screen shares and demos.
+        GetField("apiKey").EditorUiAlias.ShouldBe(MaskedTextBox);
+    }
+
+    [Fact]
+    public void BuildForType_WithNonSensitiveString_UsesTextBox()
+    {
+        GetField("baseUrl").EditorUiAlias.ShouldBe(TextBox);
+    }
+
+    [Fact]
+    public void BuildForType_WithSensitiveStringAndExplicitEditor_KeepsExplicitEditor()
+    {
+        // The explicit alias is the escape hatch: masking a multi-line field would make it
+        // unusable, so an author who names an editor always wins over the inferred default.
+        GetField("privateKey").EditorUiAlias.ShouldBe("Umb.PropertyEditorUi.TextArea");
+    }
+
+    [Fact]
+    public void BuildForType_WithSensitiveNonStringType_KeepsTypeSpecificEditor()
+    {
+        // Masking only substitutes for a text box. A type with its own editor keeps it.
+        GetField("rotationDays").EditorUiAlias.ShouldBe("Umb.PropertyEditorUi.Integer");
+    }
+}


### PR DESCRIPTION
## Problem

Fields marked `[AIField(IsSensitive = true)]` (API keys, client secrets) rendered as plain text boxes. Connection screens therefore left credentials on display during demos and screen shares.

## Approach

Sensitive string fields now default to a masked editor with a reveal toggle.

The alias is inferred **server-side** in `AIEditableModelSchemaBuilder`, so `IsSensitive` never has to cross the API boundary. This mirrors how `IsRequired` is already derived and flattened before reaching the client.

An explicit `EditorUiAlias` still wins, which is the escape hatch for a sensitive field that masking would make unusable (a multi-line field, for example).

### Why masked-by-default rather than a new opt-in flag

`IsSensitive` already means "this is a secret" in three places: the value is encrypted at rest, masked in version-history diffs, and it is the only kind of field permitted to reference a configuration key under `Umbraco:AI:Secrets`. A "sensitive but freely displayed" mode would contradict all three, and would add a second axis to decide (does it also unmask the diff?). Every field marked sensitive across all 10 provider packages today is a credential.

### Configuration references stay visible

Values like `$Umbraco:AI:Secrets:ApiKey` render unmasked. They are pointers, not secrets, and hiding them makes it impossible to see which key a connection points at. `$$` is excluded, matching `AIEditableModelResolver` — that is the escape for a literal value starting with `$`, and a literal is still a secret.

### Implementation note

The editor drives `uui-input-password`'s type rather than swapping in a different element for references. Swapping destroys and recreates the input, taking the caret with it, which would force the masked/plain decision to be deferred until blur. Driving the type keeps masking in step with each keystroke. Lit only writes the property when the bound value changes, so a reveal the user toggled by hand survives further typing.

## Scope note

This guards against shoulder-surfing, not disclosure. The value still travels to the browser in full and is visible in dev tools. A write-only pattern (server returns a redacted placeholder, writes only on change) would be the real fix and is deliberately out of scope here — it touches Deploy, versioning, and the connection test flow.

## Changes

- New `Uai.PropertyEditorUi.MaskedTextBox` property editor UI, built on `uui-input-password`
- `AIEditableModelSchemaBuilder.InferEditorUiAlias` picks it for sensitive fields that would otherwise render as a text box
- Tightened the `IsSensitive` XML docs to state all four effects
- 4 unit tests covering the alias inference

## Testing

Unit tests pass. Smoke-tested on the v18 demo site against a real OpenAI connection:

- `$` reference loads revealed and readable
- Select-all then typing a key masks on the first character, caret preserved, no blur needed
- Select-all then typing `$` reveals immediately
- Typing a second `$` (`$$`) masks again
- Reveal toggle flips the value; a manual reveal survives further typing
- Non-sensitive fields on the same screen unaffected
- Save and reload round-trips correctly, no console errors

## Follow-ups (not in this PR)

- `AIEditableModelSerializer` skips encryption for anything starting with `$`, but the resolver treats `$$` as a literal. A value entered as `$$mysecret` is therefore stored unencrypted.
- `EncryptSensitiveFields` calls `GetValue<string>()` with no try/catch, so a non-string field marked sensitive throws on save.
- `npm run commit-options` crashes reading scopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)