### PR TITLE
Encrypt escaped literals in sensitive fields

### DIFF
--- a/Umbraco.AI.Deploy/src/Umbraco.AI.Deploy/Connectors/ServiceConnectors/UmbracoAIConnectionServiceConnector.cs
+++ b/Umbraco.AI.Deploy/src/Umbraco.AI.Deploy/Connectors/ServiceConnectors/UmbracoAIConnectionServiceConnector.cs
@@ -187,8 +187,12 @@ public class UmbracoAIConnectionServiceConnector(
                     return false;
                 }
 
-                // Check value characteristics
-                bool isConfigReference = value?.StartsWith("$") == true;
+                // Check value characteristics. Uses the shared definition so an escaped literal
+                // ($$foo — a real secret, not a pointer) is never waved through as a reference.
+                // No behaviour change today, since the only branch reading isConfigReference already
+                // requires an "ENC:" value and so can never see a "$" one; this keeps the rule from
+                // drifting if that changes.
+                bool isConfigReference = AIConfigurationReference.IsReference(value);
                 bool isEncryptedValue = value?.StartsWith("ENC:") == true;
 
                 // Layer 3: IgnoreEncrypted - block encrypted values but allow $ config references

--- a/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/AIConfigurationReference.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/AIConfigurationReference.cs
@@ -1,0 +1,48 @@
+namespace Umbraco.AI.Core.EditableModels;
+
+/// <summary>
+/// The single definition of what makes a settings value a configuration reference.
+/// </summary>
+/// <remarks>
+/// A value starting with <c>$</c> normally names a configuration key to dereference
+/// (<c>$Umbraco:AI:Secrets:ApiKey</c>). A value starting with <c>$$</c> is the escape hatch for a
+/// literal that happens to begin with <c>$</c> — <c>$$foo</c> resolves to the literal <c>$foo</c>.
+///
+/// The distinction matters beyond resolution: a reference is a pointer and safe to store and display
+/// as-is, while an escaped literal in a sensitive field is a real secret and must be treated like any
+/// other. Getting that wrong stored <c>$$mysecret</c> in plaintext, so the rule lives here rather than
+/// being restated at each call site.
+/// </remarks>
+internal static class AIConfigurationReference
+{
+    /// <summary>
+    /// The prefix marking a value as a configuration reference.
+    /// </summary>
+    internal const string Prefix = "$";
+
+    /// <summary>
+    /// The prefix marking a value as an escaped literal rather than a reference.
+    /// </summary>
+    internal const string EscapedPrefix = "$$";
+
+    /// <summary>
+    /// Determines whether <paramref name="value"/> dereferences a configuration key.
+    /// Escaped literals (<c>$$...</c>) are not references.
+    /// </summary>
+    internal static bool IsReference(string? value)
+        => value is not null
+           && value.StartsWith(Prefix, StringComparison.Ordinal)
+           && !value.StartsWith(EscapedPrefix, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Determines whether <paramref name="value"/> is an escaped literal — a value the author wants
+    /// taken verbatim even though it starts with <c>$</c>. Use <see cref="Unescape"/> to read it.
+    /// </summary>
+    internal static bool IsEscapedLiteral(string? value)
+        => value is not null && value.StartsWith(EscapedPrefix, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Strips the escape from an escaped literal, so <c>$$foo</c> becomes <c>$foo</c>.
+    /// </summary>
+    internal static string Unescape(string value) => value[1..];
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/AIEditableModelResolver.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/AIEditableModelResolver.cs
@@ -21,8 +21,6 @@ namespace Umbraco.AI.Core.EditableModels;
 /// </remarks>
 internal sealed class AIEditableModelResolver : IAIEditableModelResolver
 {
-    private const string ConfigPrefix = "$";
-
     private readonly IConfiguration _configuration;
     private readonly IReadOnlyList<string> _allowedConfigKeyPrefixes;
     private readonly IReadOnlyList<string> _secretConfigKeyPrefixes;
@@ -124,8 +122,7 @@ internal sealed class AIEditableModelResolver : IAIEditableModelResolver
 
     private object? ResolveConfigurationVariable(object? value, Type targetType, bool isSensitiveField)
     {
-        // Only handle string values with the $ prefix
-        if (value is not string strValue || !strValue.StartsWith(ConfigPrefix))
+        if (value is not string strValue)
         {
             return value;
         }
@@ -135,13 +132,18 @@ internal sealed class AIEditableModelResolver : IAIEditableModelResolver
         // Strip one '$' and return the remainder verbatim — no allow-list or lookup applied.
         // Note this only concerns values that START with '$'; a trailing '$' (e.g. a regex
         // end-of-line anchor) is never treated as a reference and needs no escaping.
-        if (strValue.StartsWith("$$", StringComparison.Ordinal))
+        if (AIConfigurationReference.IsEscapedLiteral(strValue))
         {
-            return strValue.Substring(1);
+            return AIConfigurationReference.Unescape(strValue);
+        }
+
+        if (!AIConfigurationReference.IsReference(strValue))
+        {
+            return value;
         }
 
         // Extract configuration key
-        var configKey = strValue.Substring(ConfigPrefix.Length);
+        var configKey = strValue.Substring(AIConfigurationReference.Prefix.Length);
 
         // Default-deny: only keys under an allowed prefix may be dereferenced. Checked
         // before the lookup so the rejection does not depend on whether the key exists.

--- a/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/AIEditableModelSerializer.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/AIEditableModelSerializer.cs
@@ -87,9 +87,11 @@ internal sealed class AIEditableModelSerializer : IAIEditableModelSerializer
                 var stringValue = jsonValue.GetValue<string>();
                 if (!string.IsNullOrEmpty(stringValue))
                 {
-                    // Skip encryption for configuration references (values starting with $)
-                    // These are pointers to IConfiguration, not actual secrets
-                    if (stringValue.StartsWith("$", StringComparison.Ordinal))
+                    // Skip encryption for configuration references. These are pointers to
+                    // IConfiguration, not actual secrets. An escaped literal ($$foo, meaning the
+                    // literal $foo) is NOT a reference and must still be encrypted — treating it as
+                    // one stored the secret in plaintext.
+                    if (AIConfigurationReference.IsReference(stringValue))
                     {
                         continue;
                     }

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Security/AIEditableModelSerializerTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Security/AIEditableModelSerializerTests.cs
@@ -258,6 +258,57 @@ public class AIEditableModelSerializerTests
         _protectorMock.Verify(p => p.Protect(It.IsAny<string>()), Times.Never);
     }
 
+    [Theory]
+    [InlineData("$$mysecret")]
+    [InlineData("$$Umbraco:AI:Secrets:ApiKey")]
+    [InlineData("$$")]
+    public void Serialize_WithEscapedLiteral_Encrypts(string escapedLiteral)
+    {
+        // A leading "$$" escapes a literal starting with "$" — the resolver hands back "$mysecret",
+        // so the stored value is a real secret and not a pointer to configuration. Skipping it
+        // because it starts with "$" left it sitting in the database in plaintext.
+
+        // Arrange
+        var model = new TestModel { ApiKey = escapedLiteral, Endpoint = "https://api.example.com" };
+        var schema = CreateSchema(new AIEditableModelField
+        {
+            Key = "apiKey",
+            Label = "API Key",
+            IsSensitive = true
+        });
+
+        // Act
+        var result = _serializer.Serialize(model, schema);
+
+        // Assert
+        result.ShouldContain($"\"apiKey\":\"ENC:{escapedLiteral}\"");
+        _protectorMock.Verify(p => p.Protect(escapedLiteral), Times.Once);
+    }
+
+    [Fact]
+    public void SerializeThenDeserialize_WithEscapedLiteral_RoundTripsUnchanged()
+    {
+        // Encrypting the escaped literal must not disturb what the resolver later sees, otherwise
+        // the escape would stop meaning what it meant before.
+
+        // Arrange
+        var model = new TestModel { ApiKey = "$$mysecret", Endpoint = "https://api.example.com" };
+        var schema = CreateSchema(new AIEditableModelField
+        {
+            Key = "apiKey",
+            Label = "API Key",
+            IsSensitive = true
+        });
+
+        // Act
+        var json = _serializer.Serialize(model, schema);
+        var roundTripped = _serializer.Deserialize<TestModel>(json);
+
+        // Assert
+        roundTripped.ShouldNotBeNull();
+        roundTripped!.ApiKey.ShouldBe("$$mysecret");
+    }
+
     #endregion
 
     #region Deserialize


### PR DESCRIPTION
Found while building #293. Reported privately rather than as a public issue, per responsible disclosure.

## Problem

`AIEditableModelSerializer` skips encrypting any sensitive value starting with `$`, on the reasoning that those are configuration references — pointers, not secrets.

But `AIEditableModelResolver` treats a leading `$$` as an *escape*: `$$foo` resolves to the literal `$foo`. So a user who enters `$$mysecret` in an API key field is storing a real secret, and it matched the serializer's `$` check and went to the database in plaintext.

Narrow in practice (few API keys start with `$`), but it is a credential stored unencrypted, and the two components disagreeing about what `$$` means is the kind of thing that drifts further.

## Fix

The definition of "is this a configuration reference" now lives in one place, `AIConfigurationReference`, and the serializer and resolver both use it. An escaped literal is explicitly not a reference, so it encrypts like any other secret.

## Existing data

Rows already holding a plaintext `$$` value keep it until the connection is next saved, at which point it encrypts. Runtime resolution is unchanged either way — decryption happens before the resolver sees the value, so the escape still means what it always meant. Verified by a round-trip test.

## Deploy connector

`UmbracoAIConnectionServiceConnector` had the same loose `StartsWith("$")` check, so it now uses the shared helper too.

To be clear, **this is not a second fix**: the only branch reading `isConfigReference` is already guarded by `isEncryptedValue`, and a value starting with `ENC:` can never also start with `$`. The variable is effectively dead there and the change is behaviour-neutral. It is in so the rule cannot drift if that branch is ever restructured. Worth a maintainer's eye separately — the branch looks like it intends something it does not do.

## Testing

- 3 new theory cases covering `$$mysecret`, `$$Umbraco:AI:Secrets:ApiKey`, and bare `$$`
- 1 round-trip test proving serialize/deserialize leaves `$$mysecret` intact
- Full suites pass: 1044 core unit, 30 integration, 19 deploy
- `Umbraco.AI.local.slnx` builds

## Not in this PR

`EncryptSensitiveFields` calls `jsonValue.GetValue<string>()` with no try/catch, so a non-string field marked sensitive throws on save. Same method, separate bug, left alone to keep this focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)