### PR TITLE
Sensitive field follow-ups: non-string crash, dead Deploy condition

### DIFF
--- a/Umbraco.AI.Deploy/src/Umbraco.AI.Deploy/Connectors/ServiceConnectors/UmbracoAIConnectionServiceConnector.cs
+++ b/Umbraco.AI.Deploy/src/Umbraco.AI.Deploy/Connectors/ServiceConnectors/UmbracoAIConnectionServiceConnector.cs
@@ -187,21 +187,19 @@ public class UmbracoAIConnectionServiceConnector(
                     return false;
                 }
 
-                // Check value characteristics. Uses the shared definition so an escaped literal
-                // ($$foo — a real secret, not a pointer) is never waved through as a reference.
-                // No behaviour change today, since the only branch reading isConfigReference already
-                // requires an "ENC:" value and so can never see a "$" one; this keeps the rule from
-                // drifting if that changes.
-                bool isConfigReference = AIConfigurationReference.IsReference(value);
                 bool isEncryptedValue = value?.StartsWith("ENC:") == true;
 
-                // Layer 3: IgnoreEncrypted - block encrypted values but allow $ config references
+                // Layer 3: IgnoreEncrypted - block encrypted values.
+                // Configuration references ($Umbraco:AI:Secrets:ApiKey) are never encrypted, so they
+                // are not caught here and reach the include below. This used to read
+                // "return isConfigReference" to express that, but a value can only be one or the
+                // other — an "ENC:" value never also starts with "$" — so it always meant false.
                 if (_settingsAccessor.Settings.Connections.IgnoreEncrypted && isEncryptedValue)
                 {
-                    return isConfigReference;  // Block encrypted, allow $ refs
+                    return false;
                 }
 
-                return true;  // Include all other fields
+                return true;  // Include all other fields, config references among them
             })
             .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 

--- a/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/AIEditableModelSchemaBuilder.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/AIEditableModelSchemaBuilder.cs
@@ -1,6 +1,8 @@
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Umbraco.AI.Extensions;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Extensions;
@@ -9,6 +11,11 @@ namespace Umbraco.AI.Core.EditableModels;
 
 internal sealed class AIEditableModelSchemaBuilder : IAIEditableModelSchemaBuilder
 {
+    private readonly ILogger<AIEditableModelSchemaBuilder> _logger;
+
+    public AIEditableModelSchemaBuilder(ILogger<AIEditableModelSchemaBuilder>? logger = null)
+        => _logger = logger ?? NullLogger<AIEditableModelSchemaBuilder>.Instance;
+
     public AIEditableModelSchema BuildForType(Type modelType, string modelId)
     {
         var properties = modelType
@@ -30,6 +37,8 @@ internal sealed class AIEditableModelSchemaBuilder : IAIEditableModelSchemaBuild
         var attr = property.GetCustomAttribute<AIEditableModelFieldAttribute>();
         var key = property.Name.ToCamelCase();
         var modelKey = modelId.ToCamelCase();
+
+        WarnIfSensitiveFieldCannotBeEncrypted(attr, property, modelId);
 
         // Read default value from the model instance's property initializer
         object? defaultValue = null;
@@ -63,6 +72,42 @@ internal sealed class AIEditableModelSchemaBuilder : IAIEditableModelSchemaBuild
             Group = (attr?.Group).IsNullOrWhiteSpace() ? null :
                 attr.Group.StartsWith("#") ? attr.Group :  $"#uaiFieldGroups_{attr.Group.ToCamelCase()}Label"
         };
+    }
+
+    /// <summary>
+    /// Warns when a property is marked sensitive but holds a type the persistence layer cannot
+    /// protect.
+    /// </summary>
+    /// <remarks>
+    /// Encryption only covers strings, so such a field is stored in the clear. That used to surface
+    /// as an exception when saving the whole entity; the serializer now skips the value instead, and
+    /// this keeps the declaration mistake from disappearing with it. A warning rather than a throw
+    /// deliberately: schemas are built per provider, and one mis-declared field in a third-party
+    /// package should not take the AI section down.
+    /// </remarks>
+    private void WarnIfSensitiveFieldCannotBeEncrypted(
+        AIEditableModelFieldAttribute? attr,
+        PropertyInfo property,
+        string modelId)
+    {
+        if (attr?.IsSensitive != true)
+        {
+            return;
+        }
+
+        var underlyingType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+        if (underlyingType == typeof(string))
+        {
+            return;
+        }
+
+        _logger.LogWarning(
+            "{ModelId}.{PropertyName} is marked [AIField(IsSensitive = true)] but is of type {PropertyType}. " +
+            "Only string values are encrypted at rest, so this value will be stored unprotected. " +
+            "Either change the property to a string or drop IsSensitive.",
+            modelId,
+            property.Name,
+            underlyingType.Name);
     }
 
     /// <summary>

--- a/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/AIEditableModelSerializer.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/EditableModels/AIEditableModelSerializer.cs
@@ -82,9 +82,14 @@ internal sealed class AIEditableModelSerializer : IAIEditableModelSerializer
 
         foreach (var property in jsonObject.ToList())
         {
-            if (sensitiveKeys.Contains(property.Key) && property.Value is JsonValue jsonValue)
+            // Only string values can be protected. A sensitive field of another type is a
+            // declaration mistake, reported by the schema builder rather than thrown from here —
+            // GetValue<string> on a number- or bool-backed value throws, which took saving the whole
+            // connection down.
+            if (sensitiveKeys.Contains(property.Key)
+                && property.Value is JsonValue jsonValue
+                && jsonValue.TryGetValue<string>(out var stringValue))
             {
-                var stringValue = jsonValue.GetValue<string>();
                 if (!string.IsNullOrEmpty(stringValue))
                 {
                     // Skip encryption for configuration references. These are pointers to

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Security/AIEditableModelSerializerTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Security/AIEditableModelSerializerTests.cs
@@ -286,6 +286,43 @@ public class AIEditableModelSerializerTests
     }
 
     [Fact]
+    public void Serialize_WithNonStringSensitiveField_SkipsItInsteadOfThrowing()
+    {
+        // Only strings can be protected. Reading a number- or bool-backed value as a string threw,
+        // and since nothing caught it the whole entity failed to save. The field is a declaration
+        // mistake either way — the schema builder warns about it — but it must not break saving.
+
+        // Arrange
+        var model = new NonStringSensitiveModel
+        {
+            RotationDays = 30,
+            Enabled = true,
+            Endpoint = "https://api.example.com"
+        };
+        var schema = CreateSchema(new AIEditableModelField
+        {
+            Key = "rotationDays",
+            Label = "Rotation Days",
+            IsSensitive = true
+        }, new AIEditableModelField
+        {
+            Key = "enabled",
+            Label = "Enabled",
+            IsSensitive = true
+        });
+
+        // Act
+        var result = Should.NotThrow(() => _serializer.Serialize(model, schema));
+
+        // Assert — values pass through untouched
+        result.ShouldNotBeNull();
+        result.ShouldContain("\"rotationDays\":30");
+        result.ShouldContain("\"enabled\":true");
+        result.ShouldContain("\"endpoint\":\"https://api.example.com\"");
+        _protectorMock.Verify(p => p.Protect(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
     public void SerializeThenDeserialize_WithEscapedLiteral_RoundTripsUnchanged()
     {
         // Encrypting the escaped literal must not disturb what the resolver later sees, otherwise
@@ -480,6 +517,13 @@ public class AIEditableModelSerializerTests
         public string? AccessKeyId { get; set; }
         public string? SecretAccessKey { get; set; }
         public string? Region { get; set; }
+    }
+
+    private class NonStringSensitiveModel
+    {
+        public int RotationDays { get; set; }
+        public bool Enabled { get; set; }
+        public string? Endpoint { get; set; }
     }
 
     #endregion

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Settings/AIEditableModelSchemaBuilderTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Settings/AIEditableModelSchemaBuilderTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+using Moq;
 using Shouldly;
 using Umbraco.AI.Core.EditableModels;
 
@@ -55,5 +57,39 @@ public class AIEditableModelSchemaBuilderTests
     {
         // Masking only substitutes for a text box. A type with its own editor keeps it.
         GetField("rotationDays").EditorUiAlias.ShouldBe("Umb.PropertyEditorUi.Integer");
+    }
+
+    [Fact]
+    public void BuildForType_WithSensitiveNonStringType_WarnsItCannotBeEncrypted()
+    {
+        // Only strings are encrypted at rest, so marking an int sensitive silently stores it in the
+        // clear. The serializer skips such a value rather than throwing, so this warning is the only
+        // thing standing between the mis-declaration and nobody noticing.
+
+        // Arrange
+        var loggerMock = new Mock<ILogger<AIEditableModelSchemaBuilder>>();
+        var builder = new AIEditableModelSchemaBuilder(loggerMock.Object);
+
+        // Act
+        builder.BuildForType<TestSettings>("test");
+
+        // Assert — once for RotationDays, and not for the sensitive string fields alongside it
+        loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("RotationDays")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+
+        loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
     }
 }


### PR DESCRIPTION
The two remaining findings from the #293 / #297 review. Two commits, kept separate because they are different products and independently revertible.

## 1. A non-string sensitive field broke save (`fix(core)`)

Only strings can be encrypted, but `EncryptSensitiveFields` read every sensitive field as one. `[AIField(IsSensitive = true)]` on an `int` or `bool` made `GetValue<string>()` throw, nothing caught it, and saving the entire entity failed.

Two changes:

- The serializer skips values that are not strings, so save cannot crash.
- `AIEditableModelSchemaBuilder` logs one warning naming the property and its type, so the mis-declaration does not disappear along with the exception. Without this the field would silently store in the clear, which is worse than the crash.

A warning rather than a throw is deliberate: schemas are built per provider, and one bad field in a third-party package should not take the AI section down. Open to being overruled if you would rather fail fast.

`AIEditableModelSchemaBuilder` gains an optional `ILogger` parameter, defaulting to `NullLogger`. All existing DI registrations already call `AddLogging()`, and the optional default keeps direct construction working.

## 2. A condition that could only ever be false (`refactor(deploy)`)

The `IgnoreEncrypted` branch in `UmbracoAIConnectionServiceConnector` returned `isConfigReference` to express "block encrypted values, allow `$` config references". But the branch is already guarded on the value being encrypted, and an `ENC:` value never also starts with `$`, so the expression was always `false`.

The intent still holds — configuration references are never encrypted, so they miss this branch and reach the include below. Now returns `false` outright with a comment saying so.

**No behaviour change.** I flagged this during #297 as possibly hiding a leak; it is not one, it was just misleading. If it was meant to do something else, this is the moment to say so.

## Testing

- New: schema builder warns exactly once for a sensitive `int`, and not for the sensitive strings beside it
- New: serializing a model with sensitive `int` and `bool` fields does not throw, passes the values through, and never calls the protector
- Full suites pass: 1046 core unit, 30 integration, 19 deploy
- `Umbraco.AI.local.slnx` builds

## Closes out

With this, all three findings from that review are done — the third (`npm run commit-options`) was already fixed by e5370ecf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)