### PR TITLE
fix(core): Don't require AI section access for property value operations (2026.08.1)

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/PropertyValueOperation/Controllers/InvokePropertyValueOperationController.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Web/Api/Management/PropertyValueOperation/Controllers/InvokePropertyValueOperationController.cs
@@ -1,10 +1,8 @@
 using Asp.Versioning;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.AI.Core.PropertyValueOperations;
 using Umbraco.AI.Web.Api.Management.PropertyValueOperation.Models;
-using Umbraco.AI.Web.Authorization;
 
 namespace Umbraco.AI.Web.Api.Management.PropertyValueOperation.Controllers;
 
@@ -19,12 +17,20 @@ namespace Umbraco.AI.Web.Api.Management.PropertyValueOperation.Controllers;
 /// future server-side AI tools will call the dispatcher in-process.
 /// </para>
 /// <para>
-/// The auth boundary is <c>SectionAccessAI</c>; the same surface as other AI management APIs.
-/// Frontend tools delegate authorization to this policy and do not duplicate it client-side.
+/// The auth boundary is deliberately just <c>BackOfficeAccess</c>, inherited from the base
+/// controller — this endpoint does NOT carry the <c>SectionAccessAI</c> policy that the rest of the
+/// AI management API uses. Because the operation is a pure transform over a value the caller
+/// already supplied, granting it exposes no data the caller could not already read and no write
+/// the caller could not already perform: persistence happens later through the CMS content APIs,
+/// which enforce their own permissions on the document being saved.
+/// </para>
+/// <para>
+/// Do NOT add <c>SectionAccessAI</c> here. Gating this on the AI section would mean any editor
+/// using an AI feature in the content workspace (e.g. Copilot's <c>set_value</c> tool) would also
+/// need full access to Connections, Profiles, Agents and Guardrails administration. See issue #306.
 /// </para>
 /// </remarks>
 [ApiVersion("1.0")]
-[Authorize(Policy = AIAuthorizationPolicies.SectionAccessAI)]
 public sealed class InvokePropertyValueOperationController : PropertyValueOperationControllerBase
 {
     private readonly IAIPropertyValueDispatcher _dispatcher;

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Api/Management/PropertyValueOperation/InvokePropertyValueOperationControllerTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Api/Management/PropertyValueOperation/InvokePropertyValueOperationControllerTests.cs
@@ -1,9 +1,13 @@
+using System.Reflection;
 using System.Text.Json.Nodes;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Umbraco.AI.Core.PropertyValueOperations;
 using Umbraco.AI.Web.Api.Management.PropertyValueOperation.Controllers;
 using Umbraco.AI.Web.Api.Management.PropertyValueOperation.Models;
+using Umbraco.AI.Web.Authorization;
+using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.AI.Tests.Unit.Api.Management.PropertyValueOperation;
 
@@ -140,5 +144,40 @@ public class InvokePropertyValueOperationControllerTests
 
         // Assert
         result.Result.ShouldBeOfType<BadRequestResult>();
+    }
+
+    /// <summary>
+    /// Load-bearing test for the auth boundary (issue #306): this endpoint is a pure transform over a
+    /// caller-supplied value, so it must NOT require the AI section. Requiring it forces editors who
+    /// use AI features in the content workspace to also be granted full AI administration access.
+    /// </summary>
+    [Fact]
+    public void Controller_DoesNotRequireAISectionAccess()
+    {
+        // Arrange & Act
+        var policies = typeof(InvokePropertyValueOperationController)
+            .GetCustomAttributes<AuthorizeAttribute>(inherit: true)
+            .Select(a => a.Policy)
+            .ToList();
+
+        // Assert
+        policies.ShouldNotContain(AIAuthorizationPolicies.SectionAccessAI);
+    }
+
+    /// <summary>
+    /// The endpoint must still be behind backoffice authentication — dropping
+    /// <c>SectionAccessAI</c> must not leave it anonymous.
+    /// </summary>
+    [Fact]
+    public void Controller_StillRequiresBackOfficeAccess()
+    {
+        // Arrange & Act
+        var policies = typeof(InvokePropertyValueOperationController)
+            .GetCustomAttributes<AuthorizeAttribute>(inherit: true)
+            .Select(a => a.Policy)
+            .ToList();
+
+        // Assert
+        policies.ShouldContain(AuthorizationPolicies.BackOfficeAccess);
     }
 }


### PR DESCRIPTION
Cherry-pick of #307 onto the 2026.08.1 release branch, so the fix ships with the Copilot RC rather than waiting for the next release after it.

Clean cherry-pick, no conflicts, no changes beyond #307.

**Also verified on this branch** (it carries the Copilot Workspace feature, which `dev` does not):
- `property-value-operation` is still the only AI Management API endpoint Copilot's client calls.
- The Workspace's Conversations and Projects controllers are gated by their own `SectionAccessCopilotWorkspace` policy, not `SectionAccessAI`, so they need no equivalent change.
- `Umbraco.AI.Tests.Unit` green.

---

Fixes #306

## Problem

`property-value-operation` was gated by `SectionAccessAI` — the same policy that governs Connections / Profiles / Agents / Guardrails administration and whether the AI section appears in the nav at all.

That endpoint is the only AI Management API call Copilot's content-editor tools make (`set_value`, `add_item`, `remove_item`, `move_item`, `clear_value`). So an editor without AI section access could chat with Copilot and approve tool calls, but every one of them 403'd. The only workaround was granting editors the full AI section, which also hands them CRUD on connection credentials, profiles, agents and guardrails.

## Why this is the right fix

The endpoint performs no privileged action. It takes a JSON value the caller already supplied, applies one transform via `IAIPropertyValueDispatcher`, and returns it. It never reads or writes the database — there's already a load-bearing test pinning that behaviour.

Persistence is not part of this endpoint. Copilot's `save` and `save_and_publish` tools go through the CMS workspace context, so the real security boundary is the CMS content API, which enforces its own permissions on the document being saved.

So `SectionAccessAI` was the wrong gate rather than a missing permission tier. Removing it leaves `BackOfficeAccess` — inherited from `UmbracoAIManagementControllerBase` — as the boundary, and exposes nothing a backoffice user couldn't already do.

## Changes

- Drop `[Authorize(Policy = SectionAccessAI)]` from `InvokePropertyValueOperationController`.
- Rewrite the `<remarks>` to explain the boundary and warn against re-adding the policy.
- Two tests: the controller must **not** carry `SectionAccessAI`, and must still carry `BackOfficeAccess`. Guards both directions so the gate can't return silently and the endpoint can't drift to anonymous.

## Testing

`Umbraco.AI.Tests.Unit` green (1058 on v18 / 1061 on v17). No OpenAPI snapshots reference the endpoint.

## Not in scope

Two related findings from investigating #306, both worth separate issues:

1. **The broader permission split is still unaddressed.** `SectionAccessAI` remains the only policy in `AIAuthorizationPolicies`, covering 78 controllers with no read-only or use-only tier. This PR fixes the reported symptom, not the underlying model. The issue's suggested split (plus a granular user-group permission via the CMS `IPermissionPresentationModel` mappers) is a much larger, breaking change.
2. **Agent endpoints have no AI section gate at all.** `AllAgentController`, `ByIdOrAliasAgentController`, `RunAgentController`, `StreamAgentController` and `StreamAgentAGUIController` carry only the inherited `BackOfficeAccess`, unlike the 78 gated controllers — so any backoffice user can already list and run agents, spending tokens. This asymmetry is why the reporter's editor could chat at all and only failed at `set_value`. Looks unintended and should be reviewed on its own.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
