### PR TITLE
fix(core): Resolve the admin group by key instead of assuming id 1

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Core/Migrations/AddAISectionToAdminGroup.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Migrations/AddAISectionToAdminGroup.cs
@@ -12,7 +12,9 @@ namespace Umbraco.AI.Core.Migrations;
 /// </remarks>
 public class AddAISectionToAdminGroup : AsyncMigrationBase
 {
+    private const string UserGroupTable = Cms.Core.Constants.DatabaseSchema.Tables.UserGroup;
     private const string UserGroup2AppTable = Cms.Core.Constants.DatabaseSchema.Tables.UserGroup2App;
+    private const string KeyColumn = Cms.Core.Constants.DatabaseSchema.Columns.PrimaryKeyNameKey;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AddAISectionToAdminGroup"/> class.
@@ -25,11 +27,23 @@ public class AddAISectionToAdminGroup : AsyncMigrationBase
     /// <inheritdoc/>
     protected override Task MigrateAsync()
     {
+        var quotedUserGroupTable = SqlSyntax.GetQuotedTableName(UserGroupTable);
+        var quotedKeyColumn = SqlSyntax.GetQuotedColumnName(KeyColumn);
         var quotedTable = SqlSyntax.GetQuotedTableName(UserGroup2AppTable);
 
-        // Check if the AI section is already assigned to the admin group (userGroupId = 1)
+        // Resolve the admin group by its well-known key rather than assuming id = 1, since the
+        // seeded admin group's id can differ on sites where user groups have been recreated.
+        var adminGroupId = Database.ExecuteScalar<int?>(
+            Sql($"SELECT id FROM {quotedUserGroupTable} WHERE {quotedKeyColumn} = @0", Cms.Core.Constants.Security.AdminGroupKey));
+
+        if (adminGroupId is null)
+        {
+            Logger.LogWarning("Could not find the Admin user group; skipping assignment of the Umbraco AI Application/Section");
+            return Task.CompletedTask;
+        }
+
         var exists = Database.ExecuteScalar<int>(
-            Sql($"SELECT COUNT(*) FROM {quotedTable} WHERE userGroupId = @0 AND app = @1", 1, Constants.Sections.AI));
+            Sql($"SELECT COUNT(*) FROM {quotedTable} WHERE userGroupId = @0 AND app = @1", adminGroupId, Constants.Sections.AI));
 
         if (exists > 0)
         {
@@ -38,7 +52,7 @@ public class AddAISectionToAdminGroup : AsyncMigrationBase
         }
 
         Database.Execute(
-            Sql($"INSERT INTO {quotedTable} (userGroupId, app) VALUES (@0, @1)", 1, Constants.Sections.AI));
+            Sql($"INSERT INTO {quotedTable} (userGroupId, app) VALUES (@0, @1)", adminGroupId, Constants.Sections.AI));
 
         Logger.LogInformation("The Umbraco AI Application/Section has been assigned to the Admin group");
 


### PR DESCRIPTION
## Summary
- `AddAISectionToAdminGroup` hardcoded `userGroupId = 1` when granting the AI section to the admin group. On sites where the admin group's id is not 1 (e.g. after group ids were reassigned during an earlier CMS upgrade), the insert violates a foreign key and the migration plan fails on its first step.
- Because the plan fails before recording state, it retries and fails on every subsequent boot, leaving the site stuck at the `Upgrading` runtime level.
- Resolves the admin group by its well-known key (`Constants.Security.AdminGroupKey`) instead of assuming id 1, and skips the grant (instead of crashing) if no admin group is found.
- v17 backport of #314.

Fixes #312

## Test plan
- [x] `dotnet build src/Umbraco.AI.Core/Umbraco.AI.Core.csproj` — builds clean, no new warnings
- [ ] Manual repro on a site with a non-1 admin group id (not verified locally — no existing migration test harness in this repo)
