### PR TITLE
fix(copilot): Make the header button transparent so it inherits header theming

### DIFF
--- a/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/copilot/components/header-app/copilot-header-app.element.ts
+++ b/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/copilot/components/header-app/copilot-header-app.element.ts
@@ -41,6 +41,10 @@ export class UaiCopilotHeaderAppElement extends UmbLitElement {
             display: flex;
             align-items: center;
         }
+        uui-button {
+            --uui-button-background-color: var(--umb-header-app-button-background-color, transparent);
+            --uui-button-background-color-hover: var(--umb-header-app-button-background-color-hover);
+        }
         uui-button.active {
             background-color: var(--uui-color-selected);
         }


### PR DESCRIPTION
## Summary
- The Copilot header button had no `--uui-button-background-color` set, so it fell back to `--uui-color-default` (navy) instead of blending in like the other header apps (search, help, current user)
- Maps the button's background to `--umb-header-app-button-background-color` (and hover variant), matching how core header apps pick up header theming

Fixes #313

## Test plan
- [ ] Run demo site, recolour the header via `document.documentElement.style.setProperty('--umb-header-background-color', '#1b5e20')`
- [ ] Confirm the Copilot button blends in like the other header apps instead of showing a navy tile
