### PR TITLE
fix(core,agent,prompt,copilot): Stop leaking internal components into the shared entry file

### DIFF
--- a/.azure-pipelines/templates/pack-product.yml
+++ b/.azure-pipelines/templates/pack-product.yml
@@ -80,12 +80,17 @@ steps:
             BUILD_FLAG="--no-restore"
           fi
 
+          # ContinuousIntegrationBuild gates each product's UpdatePackageManifestVersion
+          # MSBuild target (stamps the real PackageVersion into umbraco-package.json's
+          # "version", which drives cache-busting). Without it explicitly set here, that
+          # target never fires and every shipped package keeps its placeholder version.
           dotnet pack ${{ parameters.product }}/${{ parameters.product }}.slnx \
             --configuration Release \
             $BUILD_FLAG \
             --output ./artifacts/nupkg \
             -p:UseProjectReferences=${{ parameters.useProjectReferences }} \
-            -p:DisableCloudBuildNumber=true
+            -p:DisableCloudBuildNumber=true \
+            -p:ContinuousIntegrationBuild=true
       displayName: Pack ${{ parameters.product }} (NuGet)
       condition: ${{ parameters.condition }}
 

--- a/.claude/memory/frontend-entry-points.md
+++ b/.claude/memory/frontend-entry-points.md
@@ -1,0 +1,35 @@
+# Frontend Entry-Point Architecture (Client packages)
+
+Applies to every product's `src/*.Web.StaticAssets/Client` (or equivalent) folder: Umbraco.AI,
+Umbraco.AI.Agent, Umbraco.AI.Prompt, Umbraco.AI.Agent.Copilot, and any future product built the same
+way. Established while fixing umbraco/Umbraco.AI#324.
+
+Five entry points, each with one job. New files/exports must go in the right one:
+
+| File | Job | Rules |
+|---|---|---|
+| `manifests.ts` | CMS extension manifest *definitions only* | Never re-export component barrels or add side-effect component imports here |
+| `app.ts` | PUBLIC runtime entry — the address another add-on's bare specifier (`@umbraco-ai/x`) resolves to via the import map, and its own `backofficeEntryPoint` | Export ONLY `export * from "./exports.js"`, its own `onInit`/`onUnload`, and directly-declared values like `xClientReady`. Never `export * from "./index.js"` here. |
+| `exports.ts` | Curated, deliberate public API — anything a real cross-package consumer needs | `api-extractor.json`'s `mainEntryPointFilePath` points here for products that publish npm types; required as the runtime curation point even without publishing, since `app.ts` only re-exports this |
+| `index.ts` | Broad internal barrel — aggregates every feature `index.ts`, public or not | Used for local monorepo dev / TS project-reference resolution (`package.json`'s `main`/`exports.import`), and re-exported by `internal-components.ts` |
+| `internal-components.ts` | Side-effect-only: `export * from "./index.js"` and nothing else | Its own `backofficeEntryPoint` in `public/umbraco-package.json` (loads every page) but NEVER given an importmap entry. Home for components referenced only by tag name within the same product, never imported as a real value elsewhere. |
+
+**Why `app.ts` can't just re-export everything.** It has two addresses: the import-map target and its
+own entry point. Umbraco 18.1's per-package cache-busting stamps the import-map address but can't reach
+a relative import elsewhere in the same bundle — so if any internal file (hand-written, or
+bundler-injected via shared-chunk splitting) imports from `app.js`/`app.ts` by relative path, the browser
+ends up loading two different-looking copies of the same file and double-registers every custom element
+bundled into it. `internal-components.ts` has only one address, ever, so it can't develop this problem
+regardless of what the bundler decides to share across chunks.
+
+**Where does a new export go?** Genuinely public (another package needs it at runtime) → `exports.ts`
+only, never duplicated in `index.ts`'s chain too. Everything else (internal-only, tag-name-referenced
+components) → `index.ts`'s chain, reached only via `internal-components.ts`.
+
+**Never import from `app.js`/`app.ts` by relative path from another file.** It's fine to import
+something app.ts defines directly (e.g. `xClientReady`) since app.ts is genuinely where it lives —
+but service/mapper/component classes should be imported from their real defining module, not routed
+through app.ts. Caught during the #324 fix:
+`Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/audit-log/repository/collection/audit-log-collection.server.data-source.ts`
+was importing `AuditLogsService`/`UaiAuditLogTypeMapper` from `../../../app.js` instead of their real
+modules (`../../../api` and `../../type-mapper.js`, matching its sibling data source file).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -398,5 +398,5 @@ message `"Will be removed in vX"`, where **X = current major version + 2** (curr
 
 ## Lessons Learned
 
-- Never import Lit components by path; export through `index.ts`/`export.ts` for global accessibility
+- Never import Lit components by path; export through the barrel chain — see [.claude/memory/frontend-entry-points.md](.claude/memory/frontend-entry-points.md) for which entry point (`app.ts`/`exports.ts`/`index.ts`/`internal-components.ts`) a new export belongs in
 - Avoid god objects

--- a/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/public/umbraco-package.json
+++ b/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/public/umbraco-package.json
@@ -15,6 +15,12 @@
             "name": "Umbraco AI Agent Copilot Backoffice Entry Point",
             "alias": "Umbraco.AI.Agent.Copilot.BackofficeEntryPoint",
             "js": "/App_Plugins/UmbracoAIAgentCopilot/umbraco-ai-agent-copilot-app.js"
+        },
+        {
+            "type": "backofficeEntryPoint",
+            "name": "Umbraco AI Agent Copilot Internal Components Entry Point",
+            "alias": "Umbraco.AI.Agent.Copilot.InternalComponentsEntryPoint",
+            "js": "/App_Plugins/UmbracoAIAgentCopilot/umbraco-ai-agent-copilot-internal-components.js"
         }
     ],
     "importmap": {

--- a/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/app.ts
+++ b/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/app.ts
@@ -1,7 +1,6 @@
 ﻿import { UmbEntryPointOnInit, UmbEntryPointOnUnload } from "@umbraco-cms/backoffice/extension-api";
 
-// Ensure all exports from index are available from the bundle
-export * from "./index.js";
+// Re-export the public API
 export * from "./exports.js";
 
 // Entry point initialization

--- a/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/internal-components.ts
+++ b/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/src/internal-components.ts
@@ -1,0 +1,4 @@
+// Side-effect-only entry point: registers internal components (referenced only by tag
+// name in templates) on every page load. Kept separate from app.ts, which is also the
+// address other add-ons resolve "@umbraco-ai/agent-copilot" to.
+export * from "./index.js";

--- a/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/vite.config.ts
+++ b/Umbraco.AI.Agent.Copilot/src/Umbraco.AI.Agent.Copilot/Client/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
             entry: {
                 "umbraco-ai-agent-copilot-manifests": resolve(__dirname, "src/manifests.ts"),
                 "umbraco-ai-agent-copilot-app": resolve(__dirname, "src/app.ts"),
+                "umbraco-ai-agent-copilot-internal-components": resolve(__dirname, "src/internal-components.ts"),
             },
             formats: ["es"],
         },

--- a/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/public/umbraco-package.json
+++ b/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/public/umbraco-package.json
@@ -15,6 +15,12 @@
             "alias": "Umbraco.AI.Agent.UI.BackofficeEntryPoint",
             "name": "Umbraco AI Agent UI Backoffice Entry Point",
             "js": "/App_Plugins/UmbracoAIAgentUI/umbraco-ai-agent-ui-app.js"
+        },
+        {
+            "type": "backofficeEntryPoint",
+            "alias": "Umbraco.AI.Agent.UI.InternalComponentsEntryPoint",
+            "name": "Umbraco AI Agent UI Internal Components Entry Point",
+            "js": "/App_Plugins/UmbracoAIAgentUI/umbraco-ai-agent-ui-internal-components.js"
         }
     ],
     "importmap": {

--- a/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/app.ts
+++ b/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/app.ts
@@ -1,18 +1,4 @@
-// Import all custom elements to register them
-import "./chat/components/chat.element.js";
-import "./chat/components/message.element.js";
-import "./chat/components/input.element.js";
-import "./chat/components/agent-status.element.js";
-import "./chat/components/tool-renderer.element.js";
-import "./chat/components/tool-status.element.js";
-import "./chat/components/hitl-approval.element.js";
-import "./chat/components/approval-base.element.js";
-import "./chat/components/message-copy-button.element.js";
-import "./chat/components/message-regenerate-button.element.js";
-import "./chat/components/voice-button.element.js";
-
-// Re-export all public APIs from the package.
-export * from "./index.js";
+// Re-export the public API
 export * from "./exports.js";
 
 /**

--- a/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/internal-components.ts
+++ b/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/internal-components.ts
@@ -1,0 +1,7 @@
+// Side-effect-only entry point: registers internal components (referenced only by tag
+// name in templates, not part of exports.ts) on every page load. Kept separate from
+// app.ts, which is also the address other add-ons resolve "@umbraco-ai/agent-ui" to.
+import "./chat/components/hitl-approval.element.js";
+import "./chat/components/approval-base.element.js";
+import "./chat/components/message-copy-button.element.js";
+import "./chat/components/message-regenerate-button.element.js";

--- a/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/vite.config.ts
+++ b/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
             entry: {
                 "umbraco-ai-agent-ui-manifests": resolve(__dirname, "src/manifests.ts"),
                 "umbraco-ai-agent-ui-app": resolve(__dirname, "src/app.ts"),
+                "umbraco-ai-agent-ui-internal-components": resolve(__dirname, "src/internal-components.ts"),
             },
             formats: ["es"],
         },

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Client/public/umbraco-package.json
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Client/public/umbraco-package.json
@@ -15,6 +15,12 @@
             "name": "Umbraco AI Agent Backoffice Entry Point",
             "alias": "Umbraco.AI.Agent.BackofficeEntryPoint",
             "js": "/App_Plugins/UmbracoAIAgent/umbraco-ai-agent-app.js"
+        },
+        {
+            "type": "backofficeEntryPoint",
+            "name": "Umbraco AI Agent Internal Components Entry Point",
+            "alias": "Umbraco.AI.Agent.InternalComponentsEntryPoint",
+            "js": "/App_Plugins/UmbracoAIAgent/umbraco-ai-agent-internal-components.js"
         }
     ],
     "importmap": {

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Client/src/app.ts
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Client/src/app.ts
@@ -2,9 +2,6 @@ import { UmbEntryPointOnInit, UmbEntryPointOnUnload } from "@umbraco-cms/backoff
 import { configureAiClient } from "@umbraco-ai/core";
 import { client } from "./api/client.gen.ts";
 
-// Ensure all exports from index are available from the bundle
-export * from "./index.js";
-
 // Re-export the public API
 export * from "./exports.js";
 

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Client/src/internal-components.ts
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Client/src/internal-components.ts
@@ -1,0 +1,4 @@
+// Side-effect-only entry point: registers internal components (referenced only by tag
+// name in templates) on every page load. Kept separate from app.ts, which is also the
+// address other add-ons resolve "@umbraco-ai/agent" to.
+export * from "./index.js";

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Client/vite.config.ts
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Web.StaticAssets/Client/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
             entry: {
                 "umbraco-ai-agent-manifests": resolve(__dirname, "src/manifests.ts"),
                 "umbraco-ai-agent-app": resolve(__dirname, "src/app.ts"),
+                "umbraco-ai-agent-internal-components": resolve(__dirname, "src/internal-components.ts"),
             },
             formats: ["es"],
         },

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/public/umbraco-package.json
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/public/umbraco-package.json
@@ -15,6 +15,12 @@
             "name": "Umbraco AI Prompt Backoffice Entry Point",
             "alias": "Umbraco.AI.Prompt.BackofficeEntryPoint",
             "js": "/App_Plugins/UmbracoAIPrompt/umbraco-ai-prompt-app.js"
+        },
+        {
+            "type": "backofficeEntryPoint",
+            "name": "Umbraco AI Prompt Internal Components Entry Point",
+            "alias": "Umbraco.AI.Prompt.InternalComponentsEntryPoint",
+            "js": "/App_Plugins/UmbracoAIPrompt/umbraco-ai-prompt-internal-components.js"
         }
     ],
     "importmap": {

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/app.ts
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/app.ts
@@ -3,9 +3,6 @@ import { configureAiClient } from "@umbraco-ai/core";
 import { client } from "./api/client.gen.ts";
 import { UmbPromptRegistrarController } from "./prompt/controllers";
 
-// Re-export everything from the main index
-export * from "./index.js";
-
 // Promise that resolves when the prompt client is configured with auth
 let promptClientReadyResolve: (() => void) | undefined;
 export const promptClientReady = new Promise<void>((resolve) => {

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/index.ts
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/index.ts
@@ -1,6 +1,3 @@
 export * from "./api/index.js";
 export * from "./core/index.js";
 export * from "./prompt/index.js";
-
-// Export client ready promise for nested packages to wait on
-export { promptClientReady } from "./app.js";

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/internal-components.ts
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/src/internal-components.ts
@@ -1,0 +1,4 @@
+// Side-effect-only entry point: registers internal components (referenced only by tag
+// name in templates) on every page load. Kept separate from app.ts, which is also the
+// address other add-ons resolve "@umbraco-ai/prompt" to.
+export * from "./index.js";

--- a/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/vite.config.ts
+++ b/Umbraco.AI.Prompt/src/Umbraco.AI.Prompt.Web.StaticAssets/Client/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
             entry: {
                 "umbraco-ai-prompt-manifests": resolve(__dirname, "src/manifests.ts"),
                 "umbraco-ai-prompt-app": resolve(__dirname, "src/app.ts"),
+                "umbraco-ai-prompt-internal-components": resolve(__dirname, "src/internal-components.ts"),
             },
             formats: ["es"],
         },

--- a/Umbraco.AI/CLAUDE.md
+++ b/Umbraco.AI/CLAUDE.md
@@ -375,7 +375,7 @@ Located in `src/Umbraco.AI.Web.StaticAssets/Client/`:
 
 ### Component Registration via Barrel Exports
 
-All custom elements are registered through barrel `index.ts` files that chain up to the app entry point (`app.ts` → `index.ts` → feature `index.ts` → `components/index.ts`). This means every component exported in a barrel is already registered by the time any chunk loads.
+Internal-only custom elements (referenced only by tag name in templates) are registered through barrel `index.ts` files that chain up to `internal-components.ts` (`internal-components.ts` → `index.ts` → feature `index.ts` → `components/index.ts`), loaded on every page via its own `backofficeEntryPoint`. Deliberately public components go through `exports.ts` instead, re-exported by `app.ts`. See [../.claude/memory/frontend-entry-points.md](../.claude/memory/frontend-entry-points.md) for the full entry-point breakdown — critically, `app.ts` must never re-export `index.ts` (fixed post-umbraco/Umbraco.AI#324).
 
 **Do NOT add side-effect imports** (e.g., `import "../some-component/some-component.element.js"`) for components that are already exported in the barrel chain. The barrel export handles registration; redundant imports add noise and can cause confusion about which mechanism is authoritative.
 

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/public/umbraco-package.json
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/public/umbraco-package.json
@@ -15,6 +15,12 @@
             "name": "Umbraco AI Backoffice Entry Point",
             "alias": "Umbraco.AI.BackofficeEntryPoint",
             "js": "/App_Plugins/UmbracoAI/umbraco-ai-app.js"
+        },
+        {
+            "type": "backofficeEntryPoint",
+            "name": "Umbraco AI Internal Components Entry Point",
+            "alias": "Umbraco.AI.InternalComponentsEntryPoint",
+            "js": "/App_Plugins/UmbracoAI/umbraco-ai-internal-components.js"
         }
     ],
     "importmap": {

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/app.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/app.ts
@@ -2,8 +2,7 @@ import { UmbEntryPointOnInit, UmbEntryPointOnUnload } from "@umbraco-cms/backoff
 import { client } from "./api/client.gen.ts";
 import { configureAiClient } from "./core/client/index.js";
 
-// Re-export everything from the main index files
-export * from "./index.js";
+// Re-export the public API
 export * from "./exports.js";
 
 // Promise that resolves when the core client is configured with auth

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/audit-log/repository/collection/audit-log-collection.server.data-source.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/audit-log/repository/collection/audit-log-collection.server.data-source.ts
@@ -2,7 +2,8 @@ import type { UmbControllerHost } from "@umbraco-cms/backoffice/controller-api";
 import type { UmbCollectionDataSource, UmbCollectionFilterModel } from "@umbraco-cms/backoffice/collection";
 import type { UaiAuditLogItemModel } from "../../types.js";
 import { tryExecute } from "@umbraco-cms/backoffice/resources";
-import { AuditLogsService, UaiAuditLogTypeMapper } from "../../../app.js";
+import { AuditLogsService } from "../../../api";
+import { UaiAuditLogTypeMapper } from "../../type-mapper.js";
 
 /**
  * Server data source for AuditLog collection operations.

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/internal-components.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/src/internal-components.ts
@@ -1,0 +1,4 @@
+// Side-effect-only entry point: registers internal components (referenced only by tag
+// name in templates) on every page load. Kept separate from app.ts, which is also the
+// address other add-ons resolve "@umbraco-ai/core" to.
+export * from "./index.js";

--- a/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/vite.config.ts
+++ b/Umbraco.AI/src/Umbraco.AI.Web.StaticAssets/Client/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
             entry: {
                 "umbraco-ai-manifests": resolve(__dirname, "src/manifests.ts"),
                 "umbraco-ai-app": resolve(__dirname, "src/app.ts"),
+                "umbraco-ai-internal-components": resolve(__dirname, "src/internal-components.ts"),
             },
             formats: ["es"],
         },


### PR DESCRIPTION
## Summary

v17 backport of #325.

**Note on urgency for this specific line:** the underlying crash (#324) is triggered by Umbraco CMS 18.1.0's per-package cache-busting feature, which only exists on the v18 CMS line (`Umbraco.Cms.Core` `[17.5.0, 17.999.999)` here vs `[18.0.0, ...)` on v18/dev) — so v17 cannot hit this specific crash today. This PR ports the same structural hardening for consistency across both lines, since all the affected source files were byte-identical between `v17/dev` and `v18/dev` before the fix (cherry-picked cleanly, see below).

See #325 for the full root-cause writeup. Short version: `app.ts` is the one file another add-on's bare specifier resolves to via the import map, so anything it bundles beyond the deliberate public API (`exports.ts`) risks a second, unstamped address if any internal chunk ever references it by relative path. Moved each product's internal-only barrel to a new `internal-components.ts` entry point instead, which is loaded on every page but never exposed via the import map.

Same two pre-existing instances of the anti-pattern fixed here too (present identically on this line): `Umbraco.AI`'s audit-log collection data source importing from `app.js` instead of its real modules, and `Umbraco.AI.Prompt`'s dead `promptClientReady` re-export back through `index.ts`.

## Test plan

- [x] Cherry-picked cleanly from `v18/feature/fix-agent-public-api-leak` (b7bbf7e6) — all touched files were byte-identical between the two lines pre-fix
- [x] `npm run build` (core → prompt → agent → agent-ui → copilot) — clean, no errors
- [x] `dotnet build Umbraco.AI.slnx` — 0 errors
- [x] Checked compiled output of all four fixed products on this line: zero cross-chunk relative references into any `app.ts`/`internal-components.ts` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)