### PR TITLE
feat(core): Backend content/media write tools + tool-approval session fix

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,8 +68,8 @@
 
   <!-- Microsoft AI Agent packages -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Agents.AI" Version="[1.10.0, 1.999.999)" />
-    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="[1.10.0, 1.999.999)" />
+    <PackageVersion Include="Microsoft.Agents.AI" Version="[1.18.0, 1.999.999)" />
+    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="[1.18.0, 1.999.999)" />
   </ItemGroup>
 
   <!-- Provider packages -->

--- a/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Conversations.Core/Conversations/ConversationChatHistoryProvider.cs
+++ b/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Conversations.Core/Conversations/ConversationChatHistoryProvider.cs
@@ -62,16 +62,64 @@ public sealed class ConversationChatHistoryProvider : ChatHistoryProvider
     }
 
     /// <summary>
-    /// Recovers the original tool calls (name + arguments) for the given approval <paramref name="callIds"/>
-    /// from the conversation's persisted history — so a human-approval resume after a reload can correlate
-    /// against the real call rather than a synthesised empty one (B2). Returns only the callIds found.
+    /// Loads the conversation's persisted MAF session-state blob (see
+    /// <c>AIConversationEntity.SessionStateJson</c>), or null when the conversation has never run.
+    /// Used by the host's stream endpoint to restore a run's session via
+    /// <c>AIAgent.DeserializeSessionAsync</c> instead of always starting a bare one — session-scoped
+    /// decorators (e.g. the tool-approval-response binder) record their own state directly on the
+    /// session object rather than in chat history, so a fresh session per HTTP request would otherwise
+    /// lose it.
     /// </summary>
-    public async Task<IReadOnlyDictionary<string, FunctionCallContent>> GetApprovalToolCallsAsync(
+    public async Task<JsonElement?> GetSessionStateAsync(Guid conversationId, CancellationToken cancellationToken = default)
+    {
+        var json = await _repository.GetSessionStateJsonAsync(conversationId, cancellationToken);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<JsonElement>(json, AIJsonUtilities.DefaultOptions);
+        }
+        catch (JsonException)
+        {
+            // A corrupt/foreign blob shouldn't fail the run — just start the next session bare.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Persists the conversation's MAF session-state blob after a run, so the next request's fresh
+    /// session can be restored via <c>AIAgent.DeserializeSessionAsync</c> (see <see cref="GetSessionStateAsync"/>).
+    /// </summary>
+    public async Task SaveSessionStateAsync(Guid conversationId, JsonElement state, CancellationToken cancellationToken = default)
+    {
+        var json = JsonSerializer.Serialize(state, AIJsonUtilities.DefaultOptions);
+        await _repository.SetSessionStateJsonAsync(conversationId, json, cancellationToken);
+    }
+
+    /// <summary>
+    /// Recovers the original approval requests for the given tool-call <paramref name="callIds"/> from the
+    /// conversation's persisted history — so a human-approval resume after a reload can correlate against
+    /// the real call rather than a synthesised empty one (B2). Returns only the callIds found.
+    /// </summary>
+    /// <remarks>
+    /// Returns the full <see cref="ToolApprovalRequestContent"/> — not just its wrapped tool call — because
+    /// its <see cref="ToolApprovalRequestContent.RequestId"/> is FICC's own correlation id (typically
+    /// <c>"ficc_" + callId</c>, not the callId itself). <c>Microsoft.Agents.AI</c>'s
+    /// <c>ApprovalResponseBindingChatClient</c> matches an inbound <see cref="ToolApprovalResponseContent"/>
+    /// against its session-recorded pending requests by that id, silently dropping any response built with
+    /// the wrong one — so the resume path must build its response via
+    /// <see cref="ToolApprovalRequestContent.CreateResponse(bool, string?)"/> off this recovered request,
+    /// not by hand-constructing one from just the callId.
+    /// </remarks>
+    public async Task<IReadOnlyDictionary<string, ToolApprovalRequestContent>> GetApprovalToolCallsAsync(
         Guid conversationId,
         IReadOnlyCollection<string> callIds,
         CancellationToken cancellationToken = default)
     {
-        var result = new Dictionary<string, FunctionCallContent>(StringComparer.Ordinal);
+        var result = new Dictionary<string, ToolApprovalRequestContent>(StringComparer.Ordinal);
         if (conversationId == Guid.Empty || callIds.Count == 0)
         {
             return result;
@@ -90,18 +138,9 @@ public sealed class ConversationChatHistoryProvider : ChatHistoryProvider
 
             foreach (var content in chatMessage.Contents)
             {
-                // The interrupted run persisted the approval request (FICC emits ToolApprovalRequestContent);
-                // fall back to a raw FunctionCallContent in case it was stored pre-promotion.
-                var call = content switch
+                if (content is ToolApprovalRequestContent request && wanted.Contains(request.ToolCall.CallId))
                 {
-                    ToolApprovalRequestContent { ToolCall: FunctionCallContent fcc } => fcc,
-                    FunctionCallContent fcc => fcc,
-                    _ => null,
-                };
-
-                if (call is not null && wanted.Contains(call.CallId))
-                {
-                    result[call.CallId] = call;
+                    result[request.ToolCall.CallId] = request;
                 }
             }
         }

--- a/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Conversations.Core/Conversations/IAIConversationRepository.cs
+++ b/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Conversations.Core/Conversations/IAIConversationRepository.cs
@@ -40,6 +40,21 @@ internal interface IAIConversationRepository
     /// <summary>Deletes a conversation (cascades to its messages).</summary>
     Task DeleteAsync(Guid id, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Gets the conversation's persisted MAF session-state blob (see <c>AIConversationEntity.SessionStateJson</c>),
+    /// or null when the conversation doesn't exist or has never run. Deliberately separate from
+    /// <see cref="GetByIdAsync"/>/<see cref="UpdateAsync"/>: it is an execution detail read/written every
+    /// run, not part of the <see cref="AIConversation"/> domain model shown through the conversation API.
+    /// </summary>
+    Task<string?> GetSessionStateJsonAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Saves the conversation's MAF session-state blob. A no-op when the conversation no longer exists
+    /// (e.g. deleted mid-run). Does not bump <see cref="AIConversation.Version"/> or <c>DateModified</c> —
+    /// this is an execution detail, not user-visible conversation metadata.
+    /// </summary>
+    Task SetSessionStateJsonAsync(Guid id, string? sessionStateJson, CancellationToken cancellationToken = default);
+
     // --- Messages ---
 
     /// <summary>Loads all messages for a conversation in sequence order.</summary>

--- a/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Conversations.Persistence.SqlServer/Migrations/20260819063424_UmbracoAIConversations_SessionState.Designer.cs
+++ b/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Conversations.Persistence.SqlServer/Migrations/20260819063424_UmbracoAIConversations_SessionState.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Umbraco.AI.Agent.Conversations.Persistence;
 
@@ -11,9 +12,11 @@ using Umbraco.AI.Agent.Conversations.Persistence;
 namespace Umbraco.AI.Agent.Conversations.Persistence.SqlServer.Migrations
 {
     [DbContext(typeof(UmbracoAIConversationsDbContext))]
-    partial class UmbracoAIConversationsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260819063424_UmbracoAIConversations_SessionState")]
+    partial class UmbracoAIConversations_SessionState
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Conversations.Persistence.SqlServer/Migrations/20260819063424_UmbracoAIConversations_SessionState.cs
+++ b/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Conversations.Persistence.SqlServer/Migrations/20260819063424_UmbracoAIConversations_SessionState.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Umbraco.AI.Agent.Conversations.Persistence.SqlServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class UmbracoAIConversations_SessionState : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "SessionStateJson",
+                table: "umbracoAIConversationsConversation",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SessionStateJson",
+                table: "umbracoAIConversationsConversation");
+        }
+    }
+}

--- a/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Conversations.Persistence.Sqlite/Migrations/20260819063412_UmbracoAIConversations_SessionState.Designer.cs
+++ b/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Conversations.Persistence.Sqlite/Migrations/20260819063412_UmbracoAIConversations_SessionState.Designer.cs
@@ -2,78 +2,76 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Umbraco.AI.Agent.Conversations.Persistence;
 
 #nullable disable
 
-namespace Umbraco.AI.Agent.Conversations.Persistence.SqlServer.Migrations
+namespace Umbraco.AI.Agent.Conversations.Persistence.Sqlite.Migrations
 {
     [DbContext(typeof(UmbracoAIConversationsDbContext))]
-    partial class UmbracoAIConversationsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260819063412_UmbracoAIConversations_SessionState")]
+    partial class UmbracoAIConversations_SessionState
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder
-                .HasAnnotation("ProductVersion", "10.0.7")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
-
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+            modelBuilder.HasAnnotation("ProductVersion", "10.0.7");
 
             modelBuilder.Entity("Umbraco.AI.Agent.Conversations.Persistence.Conversations.AIConversationEntity", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AgentIdOrAlias")
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ContextIds")
                         .HasMaxLength(4000)
-                        .HasColumnType("nvarchar(4000)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateCreated")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateModified")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("IsArchived")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bit")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(false);
 
                     b.Property<bool>("IsPinned")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bit")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(false);
 
                     b.Property<DateTime?>("LastMessageAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("ProfileId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("ProjectId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SessionStateJson")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Title")
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("UserKey")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Version")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(1);
 
                     b.HasKey("Id");
@@ -91,35 +89,35 @@ namespace Umbraco.AI.Agent.Conversations.Persistence.SqlServer.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("ConversationId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Description")
                         .HasMaxLength(1000)
-                        .HasColumnType("nvarchar(1000)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("InjectionMode")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(0);
 
                     b.Property<string>("Name")
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ResourceTypeId")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Settings")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("SortOrder")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(0);
 
                     b.HasKey("Id");
@@ -133,39 +131,39 @@ namespace Umbraco.AI.Agent.Conversations.Persistence.SqlServer.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ContentJson")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ContentText")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("ConversationId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateCreated")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("InputTokens")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("OutputTokens")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Role")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("SchemaVersion")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(1);
 
                     b.Property<int>("Sequence")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
@@ -179,36 +177,36 @@ namespace Umbraco.AI.Agent.Conversations.Persistence.SqlServer.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ContextIds")
                         .HasMaxLength(4000)
-                        .HasColumnType("nvarchar(4000)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateCreated")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateModified")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Description")
                         .HasMaxLength(1000)
-                        .HasColumnType("nvarchar(1000)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Instructions")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("UserKey")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Version")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(1);
 
                     b.HasKey("Id");
@@ -222,35 +220,35 @@ namespace Umbraco.AI.Agent.Conversations.Persistence.SqlServer.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Description")
                         .HasMaxLength(1000)
-                        .HasColumnType("nvarchar(1000)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("InjectionMode")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(0);
 
                     b.Property<string>("Name")
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("ProjectId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ResourceTypeId")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Settings")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("SortOrder")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(0);
 
                     b.HasKey("Id");

--- a/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Conversations.Persistence.Sqlite/Migrations/20260819063412_UmbracoAIConversations_SessionState.cs
+++ b/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Conversations.Persistence.Sqlite/Migrations/20260819063412_UmbracoAIConversations_SessionState.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Umbraco.AI.Agent.Conversations.Persistence.Sqlite.Migrations
+{
+    /// <inheritdoc />
+    public partial class UmbracoAIConversations_SessionState : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "SessionStateJson",
+                table: "umbracoAIConversationsConversation",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SessionStateJson",
+                table: "umbracoAIConversationsConversation");
+        }
+    }
+}

--- a/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Conversations.Persistence.Sqlite/Migrations/UmbracoAIConversationsDbContextModelSnapshot.cs
+++ b/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Conversations.Persistence.Sqlite/Migrations/UmbracoAIConversationsDbContextModelSnapshot.cs
@@ -56,6 +56,9 @@ namespace Umbraco.AI.Agent.Conversations.Persistence.Sqlite.Migrations
                     b.Property<Guid?>("ProjectId")
                         .HasColumnType("TEXT");
 
+                    b.Property<string>("SessionStateJson")
+                        .HasColumnType("TEXT");
+
                     b.Property<string>("Title")
                         .HasMaxLength(255)
                         .HasColumnType("TEXT");

--- a/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Conversations.Persistence/Conversations/AIConversationEntity.cs
+++ b/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Conversations.Persistence/Conversations/AIConversationEntity.cs
@@ -73,4 +73,15 @@ internal class AIConversationEntity
     /// concurrent-append reconcile (interrogation B1).
     /// </summary>
     public int Version { get; set; } = 1;
+
+    /// <summary>
+    /// Opaque, MAF-serialized <c>AgentSession</c> state (JSON produced by
+    /// <c>AIAgent.SerializeSessionAsync</c>) from the most recent run — restored into the fresh session
+    /// created for the next run via <c>AIAgent.DeserializeSessionAsync</c>. Session-scoped decorators
+    /// (e.g. the tool-approval-response binder) record state directly on the session object rather than
+    /// in chat history, so a request handled by a brand-new session per HTTP call needs this to survive
+    /// across requests. Not part of the <see cref="AIConversation"/> domain model: it is an execution
+    /// detail, never shown or edited through the conversation API.
+    /// </summary>
+    public string? SessionStateJson { get; set; }
 }

--- a/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Conversations.Persistence/Conversations/EFCoreAIConversationRepository.cs
+++ b/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Conversations.Persistence/Conversations/EFCoreAIConversationRepository.cs
@@ -237,7 +237,7 @@ internal sealed class EFCoreAIConversationRepository : IAIConversationRepository
 
     public async Task<string?> GetSessionStateJsonAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        using IEFCoreScope<UmbracoAIConversationsDbContext> scope = _scopeProvider.CreateScope();
+        using IEfCoreScope<UmbracoAIConversationsDbContext> scope = _scopeProvider.CreateScope();
         var json = await scope.ExecuteWithContextAsync(async db =>
             await db.Conversations.AsNoTracking()
                 .Where(e => e.Id == id)
@@ -249,7 +249,7 @@ internal sealed class EFCoreAIConversationRepository : IAIConversationRepository
 
     public async Task SetSessionStateJsonAsync(Guid id, string? sessionStateJson, CancellationToken cancellationToken = default)
     {
-        using IEFCoreScope<UmbracoAIConversationsDbContext> scope = _scopeProvider.CreateScope();
+        using IEfCoreScope<UmbracoAIConversationsDbContext> scope = _scopeProvider.CreateScope();
         await scope.ExecuteWithContextAsync(async db =>
         {
             var entity = await db.Conversations.FirstOrDefaultAsync(e => e.Id == id, cancellationToken);

--- a/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Conversations.Persistence/Conversations/EFCoreAIConversationRepository.cs
+++ b/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Conversations.Persistence/Conversations/EFCoreAIConversationRepository.cs
@@ -235,6 +235,35 @@ internal sealed class EFCoreAIConversationRepository : IAIConversationRepository
         scope.Complete();
     }
 
+    public async Task<string?> GetSessionStateJsonAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        using IEFCoreScope<UmbracoAIConversationsDbContext> scope = _scopeProvider.CreateScope();
+        var json = await scope.ExecuteWithContextAsync(async db =>
+            await db.Conversations.AsNoTracking()
+                .Where(e => e.Id == id)
+                .Select(e => e.SessionStateJson)
+                .FirstOrDefaultAsync(cancellationToken));
+        scope.Complete();
+        return json;
+    }
+
+    public async Task SetSessionStateJsonAsync(Guid id, string? sessionStateJson, CancellationToken cancellationToken = default)
+    {
+        using IEFCoreScope<UmbracoAIConversationsDbContext> scope = _scopeProvider.CreateScope();
+        await scope.ExecuteWithContextAsync(async db =>
+        {
+            var entity = await db.Conversations.FirstOrDefaultAsync(e => e.Id == id, cancellationToken);
+            if (entity is null)
+            {
+                return 0;
+            }
+
+            entity.SessionStateJson = sessionStateJson;
+            return await db.SaveChangesAsync(cancellationToken);
+        });
+        scope.Complete();
+    }
+
     // --- Messages ---
 
     public async Task<IReadOnlyList<AIMessage>> GetMessagesAsync(Guid conversationId, CancellationToken cancellationToken = default)

--- a/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Conversations.Persistence/UmbracoAIConversationsDbContext.cs
+++ b/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Conversations.Persistence/UmbracoAIConversationsDbContext.cs
@@ -138,6 +138,7 @@ public class UmbracoAIConversationsDbContext : DbContext
             entity.Property(e => e.DateModified).IsRequired();
             entity.Property(e => e.LastMessageAt).IsRequired(false);
             entity.Property(e => e.Version).IsRequired().HasDefaultValue(1);
+            entity.Property(e => e.SessionStateJson);
 
             entity.HasIndex(e => e.UserKey);
             entity.HasIndex(e => e.ProjectId);

--- a/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Copilot.Workspace.Web.StaticAssets/Client/src/conversation/workspace/conversation-chat-view.element.ts
+++ b/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Copilot.Workspace.Web.StaticAssets/Client/src/conversation/workspace/conversation-chat-view.element.ts
@@ -60,6 +60,11 @@ export class UaiCopilotWorkspaceConversationChatViewElement extends UmbLitElemen
                 height: 100%;
                 width: 100%;
                 --uai-chat-content-max-width: 860px;
+                /* Tool chips, agent status, response bubbles, and approval cards default to a grey
+                   "alternate surface" tuned for the contextual copilot sidebar's light background.
+                   Copilot Workspace's own canvas is grey, so that default disappears into it -- override
+                   to a proper elevated surface so these elements read as cards against the canvas. */
+                --uai-chat-surface-alt: var(--uui-color-surface);
             }
         `,
     ];

--- a/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Copilot.Workspace.Web/Api/Management/Stream/Controllers/StreamConversationAGUIController.cs
+++ b/Umbraco.AI.Agent.Copilot.Workspace/src/Umbraco.AI.Agent.Copilot.Workspace.Web/Api/Management/Stream/Controllers/StreamConversationAGUIController.cs
@@ -98,6 +98,13 @@ public class StreamConversationAGUIController : CopilotWorkspaceStreamController
             // history — recover it so the run can correlate the approval rather than skip it (B2).
             ResolveApprovalToolCalls = async (callIds, ct) =>
                 await _historyProvider.GetApprovalToolCallsAsync(id, callIds, ct),
+
+            // A fresh AgentSession is created per HTTP request (below), but session-scoped decorators
+            // (e.g. tool-approval-response binding) record their own state directly on the session
+            // object rather than in chat history. Restore/persist it explicitly so that state survives
+            // across requests the same way the chat messages do.
+            LoadSessionState = async ct => await _historyProvider.GetSessionStateAsync(id, ct),
+            SaveSessionState = async (state, ct) => await _historyProvider.SaveSessionStateAsync(id, state, ct),
         };
 
         var options = new AIAgentExecutionOptions

--- a/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/components/agent-status.element.ts
+++ b/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/components/agent-status.element.ts
@@ -77,7 +77,7 @@ export class UaiAgentStatusElement extends UmbLitElement {
             align-items: center;
             gap: var(--uui-size-space-2);
             padding: var(--uui-size-space-2) var(--uui-size-space-3);
-            background: var(--uui-color-surface-alt);
+            background: var(--uai-chat-surface-alt, var(--uui-color-surface-alt));
             color: var(--uui-color-text-alt);
             font-size: var(--uui-type-small-size);
             border-radius: var(--uui-border-radius);

--- a/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/components/approval/default.element.ts
+++ b/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/components/approval/default.element.ts
@@ -33,6 +33,8 @@ export class UaiAgentApprovalDefaultElement extends UmbLitElement implements Uai
     }
 
     override render() {
+        const title = (this.config.title as string) ?? (this.args.title as string);
+        const message = (this.config.message as string) ?? (this.args.message as string);
         const approveLabel = this.#localize.string(
             (this.config.approveLabel as string) ??
                 (this.args.approveLabel as string) ??
@@ -43,6 +45,8 @@ export class UaiAgentApprovalDefaultElement extends UmbLitElement implements Uai
         );
 
         return html`
+            ${title ? html`<div class="title">${title}</div>` : ""}
+            ${message ? html`<div class="message">${message}</div>` : ""}
             <div class="actions">
                 <uui-button look="primary" color="positive" @click=${this.#handleApprove}> ${approveLabel} </uui-button>
                 <uui-button look="primary" @click=${this.#handleDeny}> ${denyLabel} </uui-button>
@@ -53,6 +57,16 @@ export class UaiAgentApprovalDefaultElement extends UmbLitElement implements Uai
     static override styles = css`
         :host {
             display: block;
+        }
+
+        .title {
+            font-weight: bold;
+            margin-bottom: var(--uui-size-space-1);
+        }
+
+        .message {
+            margin-bottom: var(--uui-size-space-3);
+            color: var(--uui-color-text-alt);
         }
 
         .actions {

--- a/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/components/approval/default.element.ts
+++ b/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/components/approval/default.element.ts
@@ -1,6 +1,7 @@
-import { customElement, property, css, html } from "@umbraco-cms/backoffice/external/lit";
+import { customElement, property, state, css, html } from "@umbraco-cms/backoffice/external/lit";
 import { UmbLitElement } from "@umbraco-cms/backoffice/lit-element";
 import { UmbLocalizationController } from "@umbraco-cms/backoffice/localization-api";
+import type { UUIInputElement, UUIInputEvent } from "@umbraco-cms/backoffice/external/uui";
 import type { UaiAgentApprovalElement } from "../../extensions/uai-agent-approval-element.extension.js";
 
 /**
@@ -24,12 +25,24 @@ export class UaiAgentApprovalDefaultElement extends UmbLitElement implements Uai
     @property({ attribute: false })
     respond!: (result: unknown) => void;
 
+    /**
+     * What the approver has typed so far into the confirmation box, when {@link confirmPhrase} gates
+     * the Approve button. Reset implicitly since this element is recreated per interrupt.
+     */
+    @state()
+    private _typedConfirmation = "";
+
     #handleApprove() {
         this.respond({ approved: true });
     }
 
     #handleDeny() {
         this.respond({ approved: false });
+    }
+
+    #handleConfirmInput(event: UUIInputEvent) {
+        const target = event.composedPath()[0] as UUIInputElement;
+        this._typedConfirmation = target.value?.toString() ?? "";
     }
 
     override render() {
@@ -41,6 +54,9 @@ export class UaiAgentApprovalDefaultElement extends UmbLitElement implements Uai
         // latter through unchanged, so it's safe to call on either.
         const title = rawTitle ? this.#localize.string(rawTitle) : undefined;
         const message = rawMessage ? this.#localize.string(rawMessage) : undefined;
+        // Set only for calls that warrant more friction than a plain click (e.g. publish/delete) --
+        // a literal string (typically the target item's name), never a localization key.
+        const confirmPhrase = (this.config.confirmPhrase as string) ?? (this.args.confirmPhrase as string);
         const approveLabel = this.#localize.string(
             (this.config.approveLabel as string) ??
                 (this.args.approveLabel as string) ??
@@ -49,12 +65,34 @@ export class UaiAgentApprovalDefaultElement extends UmbLitElement implements Uai
         const denyLabel = this.#localize.string(
             (this.config.denyLabel as string) ?? (this.args.denyLabel as string) ?? "#uaiChat_approvalDeny",
         );
+        const approveDisabled = !!confirmPhrase && this._typedConfirmation !== confirmPhrase;
 
         return html`
             ${title ? html`<div class="title">${title}</div>` : ""}
             ${message ? html`<div class="message">${message}</div>` : ""}
-            <div class="actions ${title || message ? "" : "no-content-above"}">
-                <uui-button look="primary" color="positive" @click=${this.#handleApprove}> ${approveLabel} </uui-button>
+            ${confirmPhrase
+                ? html`
+                      <div class="confirm-phrase">
+                          <label for="confirm-input"
+                              >${this.#localize.term("uaiChat_approvalConfirmPhraseLabel", confirmPhrase)}</label
+                          >
+                          <uui-input
+                              id="confirm-input"
+                              .value=${this._typedConfirmation}
+                              @input=${this.#handleConfirmInput}
+                          ></uui-input>
+                      </div>
+                  `
+                : ""}
+            <div class="actions ${title || message || confirmPhrase ? "" : "no-content-above"}">
+                <uui-button
+                    look="primary"
+                    color="positive"
+                    ?disabled=${approveDisabled}
+                    @click=${this.#handleApprove}
+                >
+                    ${approveLabel}
+                </uui-button>
                 <uui-button look="primary" @click=${this.#handleDeny}> ${denyLabel} </uui-button>
             </div>
         `;
@@ -72,6 +110,22 @@ export class UaiAgentApprovalDefaultElement extends UmbLitElement implements Uai
 
         .message {
             color: var(--uui-color-text-alt);
+        }
+
+        .confirm-phrase {
+            margin-top: var(--uui-size-space-4);
+            display: flex;
+            flex-direction: column;
+            gap: var(--uui-size-space-1);
+        }
+
+        .confirm-phrase label {
+            font-size: var(--uui-type-small-size);
+            color: var(--uui-color-text-alt);
+        }
+
+        .confirm-phrase uui-input {
+            width: 100%;
         }
 
         .actions {

--- a/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/components/approval/default.element.ts
+++ b/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/components/approval/default.element.ts
@@ -33,8 +33,14 @@ export class UaiAgentApprovalDefaultElement extends UmbLitElement implements Uai
     }
 
     override render() {
-        const title = (this.config.title as string) ?? (this.args.title as string);
-        const message = (this.config.message as string) ?? (this.args.message as string);
+        const rawTitle = (this.config.title as string) ?? (this.args.title as string);
+        const rawMessage = (this.config.message as string) ?? (this.args.message as string);
+        // Title/message may be a localization key (e.g. "#uaiChat_approvalDefaultTitle") set by a
+        // frontend tool's approval config, or a literal string built server-side for a backend tool
+        // (e.g. "Set 'title' to 'New Title'."). #localize.string() resolves the former and passes the
+        // latter through unchanged, so it's safe to call on either.
+        const title = rawTitle ? this.#localize.string(rawTitle) : undefined;
+        const message = rawMessage ? this.#localize.string(rawMessage) : undefined;
         const approveLabel = this.#localize.string(
             (this.config.approveLabel as string) ??
                 (this.args.approveLabel as string) ??
@@ -47,7 +53,7 @@ export class UaiAgentApprovalDefaultElement extends UmbLitElement implements Uai
         return html`
             ${title ? html`<div class="title">${title}</div>` : ""}
             ${message ? html`<div class="message">${message}</div>` : ""}
-            <div class="actions">
+            <div class="actions ${title || message ? "" : "no-content-above"}">
                 <uui-button look="primary" color="positive" @click=${this.#handleApprove}> ${approveLabel} </uui-button>
                 <uui-button look="primary" @click=${this.#handleDeny}> ${denyLabel} </uui-button>
             </div>
@@ -65,13 +71,20 @@ export class UaiAgentApprovalDefaultElement extends UmbLitElement implements Uai
         }
 
         .message {
-            margin-bottom: var(--uui-size-space-3);
             color: var(--uui-color-text-alt);
         }
 
         .actions {
             display: flex;
             gap: var(--uui-size-space-2);
+            /* On the button row's own margin (not the title/message's) so the gap above the buttons
+               is consistent whether there's a title only, a message only, or both. Omitted entirely
+               (see .no-content-above) when neither is present, so the card doesn't reserve empty space. */
+            margin-top: var(--uui-size-space-4);
+        }
+
+        .actions.no-content-above {
+            margin-top: 0;
         }
     `;
 }

--- a/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/components/approval/default.element.ts
+++ b/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/components/approval/default.element.ts
@@ -74,10 +74,11 @@ export class UaiAgentApprovalDefaultElement extends UmbLitElement implements Uai
                 ? html`
                       <div class="confirm-phrase">
                           <label for="confirm-input"
-                              >${this.#localize.term("uaiChat_approvalConfirmPhraseLabel", confirmPhrase)}</label
+                              >${this.#localize.htmlString("#uaiChat_approvalConfirmPhraseLabel", confirmPhrase)}</label
                           >
                           <uui-input
                               id="confirm-input"
+                              label=${this.#localize.term("uaiChat_approvalConfirmPhraseLabelPlain", confirmPhrase)}
                               .value=${this._typedConfirmation}
                               @input=${this.#handleConfirmInput}
                           ></uui-input>

--- a/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/components/hitl-approval.element.ts
+++ b/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/components/hitl-approval.element.ts
@@ -120,8 +120,12 @@ export class UaiHitlApprovalElement extends UmbLitElement {
         .interrupt-card {
             display: inline-block;
             margin: 0 var(--uui-size-space-3);
-            padding: var(--uui-size-space-3);
-            background: var(--uui-color-surface-alt);
+            padding: var(--uui-size-space-5);
+            /* Shared with the tool-status/agent-status chips and the markdown response bubble
+               (--uai-chat-surface-alt) so all of chat's "alternate surface" elements look consistent
+               and a single consumer-side override (e.g. Copilot Workspace setting this to white on its
+               own grey canvas) affects all of them together, not just this card. */
+            background: var(--uai-chat-surface-alt, var(--uui-color-surface-alt));
             border-radius: var(--uui-border-radius);
         }
 

--- a/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/components/hitl-approval.element.ts
+++ b/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/components/hitl-approval.element.ts
@@ -61,6 +61,7 @@ export class UaiHitlApprovalElement extends UmbLitElement {
             config = {
                 title: this.interrupt.title,
                 message: this.interrupt.message,
+                confirmPhrase: this.interrupt.metadata?.confirmPhrase as string | undefined,
             };
             if (this.interrupt.options?.length) {
                 const approveOpt = this.interrupt.options.find((o) => o.variant === "positive" || o.value === "yes");

--- a/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/components/message.element.ts
+++ b/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/components/message.element.ts
@@ -256,7 +256,7 @@ export class UaiChatMessageElement extends UmbLitElement {
         }
 
         .markdown-content {
-            background: var(--uui-color-surface-alt);
+            background: var(--uai-chat-surface-alt, var(--uui-color-surface-alt));
             padding: var(--uui-size-space-3);
             border-radius: var(--uui-border-radius);
         }
@@ -346,7 +346,7 @@ export class UaiChatMessageElement extends UmbLitElement {
             align-items: center;
             gap: var(--uui-size-space-1);
             padding: var(--uui-size-space-1) var(--uui-size-space-2);
-            background: var(--uui-color-surface-alt);
+            background: var(--uai-chat-surface-alt, var(--uui-color-surface-alt));
             border: 1px solid var(--uui-color-border);
             border-radius: var(--uui-border-radius);
             font-size: 0.8rem;

--- a/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/components/tool-status.element.ts
+++ b/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/components/tool-status.element.ts
@@ -59,7 +59,7 @@ export class UaiAgentToolStatusElement extends UmbLitElement implements UaiAgent
             align-items: center;
             gap: var(--uui-size-space-2);
             padding: var(--uui-size-space-2) var(--uui-size-space-3);
-            background: var(--uui-color-surface-alt);
+            background: var(--uai-chat-surface-alt, var(--uui-color-surface-alt));
             border-radius: var(--uui-border-radius);
             font-size: var(--uui-type-small-size);
             color: var(--uui-color-text);

--- a/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/lang/en.ts
+++ b/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/lang/en.ts
@@ -10,6 +10,9 @@ export default {
         approvalSubmit: "Submit",
         approvalCancel: "Cancel",
         approvalInputPlaceholder: "Enter your response...",
-        approvalConfirmPhraseLabel: "Type %0% to confirm",
+        approvalConfirmPhraseLabel: "Type <strong>'%0%'</strong> to confirm",
+        // Plain-text twin of approvalConfirmPhraseLabel for the input's accessible name -- a screen
+        // reader shouldn't hear literal "<strong>" tag text.
+        approvalConfirmPhraseLabelPlain: "Type '%0%' to confirm",
     },
 } as UmbLocalizationDictionary;

--- a/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/lang/en.ts
+++ b/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/lang/en.ts
@@ -10,5 +10,6 @@ export default {
         approvalSubmit: "Submit",
         approvalCancel: "Cancel",
         approvalInputPlaceholder: "Enter your response...",
+        approvalConfirmPhraseLabel: "Type %0% to confirm",
     },
 } as UmbLocalizationDictionary;

--- a/Umbraco.AI.Agent/src/Umbraco.AI.AGUI/Streaming/AGUIEventEmitter.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.AGUI/Streaming/AGUIEventEmitter.cs
@@ -30,7 +30,7 @@ public sealed class AGUIEventEmitter
     private readonly string _runId;
     private readonly HashSet<string> _emittedToolCallIds = new();
     private readonly HashSet<string> _frontendToolCallIds = new();
-    private readonly List<(string InterruptId, string ToolCallId, string ToolName, string ArgsJson, string Title, string Message)> _approvalInterrupts = new();
+    private readonly List<(string InterruptId, string ToolCallId, string ToolName, string ArgsJson, string Title, string Message, string? ConfirmationPhrase)> _approvalInterrupts = new();
 
     private string _currentMessageId;
     private string? _lastGeneratedCallId;
@@ -233,12 +233,13 @@ public sealed class AGUIEventEmitter
     /// <param name="toolName">The name of the tool requesting approval.</param>
     /// <param name="argsJson">The serialized arguments JSON for display in the approval UI.</param>
     /// <remarks>
-    /// Registers with a generic title/message. Use the overload with <c>title</c> and <c>message</c>
-    /// parameters to show the approver what the call will actually do.
+    /// Registers with a generic title/message and no confirmation phrase. Use the overload with
+    /// <c>title</c>, <c>message</c>, and <c>confirmationPhrase</c> parameters to show the approver what
+    /// the call will actually do.
     /// </remarks>
-    [Obsolete("Use the overload with title and message parameters instead. Will be removed in v20.")]
+    [Obsolete("Use the overload with title, message, and confirmationPhrase parameters instead. Will be removed in v20.")]
     public void RegisterApprovalRequest(string interruptId, string toolCallId, string toolName, string argsJson)
-        => RegisterApprovalRequest(interruptId, toolCallId, toolName, argsJson, toolName, "This action requires approval.");
+        => RegisterApprovalRequest(interruptId, toolCallId, toolName, argsJson, toolName, "This action requires approval.", confirmationPhrase: null);
 
     /// <summary>
     /// Registers a pending backend tool approval request to be included in the next
@@ -255,8 +256,36 @@ public sealed class AGUIEventEmitter
     /// A human-readable description of what this specific call will do -- either a per-tool summary
     /// (e.g. "Set 'title' to 'New Title'") or a generic argument dump when the tool has no summary.
     /// </param>
+    /// <remarks>
+    /// Registers with no required typed confirmation. Use the overload with a <c>confirmationPhrase</c>
+    /// parameter for calls that warrant more friction than a plain Approve click.
+    /// </remarks>
+    [Obsolete("Use the overload with a confirmationPhrase parameter instead. Will be removed in v20.")]
     public void RegisterApprovalRequest(string interruptId, string toolCallId, string toolName, string argsJson, string title, string message)
-        => _approvalInterrupts.Add((interruptId, toolCallId, toolName, argsJson, title, message));
+        => RegisterApprovalRequest(interruptId, toolCallId, toolName, argsJson, title, message, confirmationPhrase: null);
+
+    /// <summary>
+    /// Registers a pending backend tool approval request to be included in the next
+    /// <see cref="EmitRunFinished"/> call as a <c>human_approval</c> interrupt.
+    /// </summary>
+    /// <param name="interruptId">
+    /// The AG-UI interrupt ID (opaque; typically built by <c>AGUIInterruptKind.ForApproval</c>).
+    /// </param>
+    /// <param name="toolCallId">The MEAI tool call ID for correlation with the resume entry.</param>
+    /// <param name="toolName">The name of the tool requesting approval.</param>
+    /// <param name="argsJson">The serialized arguments JSON for display in the approval UI.</param>
+    /// <param name="title">A human-readable title for the approval card (typically the tool's display name).</param>
+    /// <param name="message">
+    /// A human-readable description of what this specific call will do -- either a per-tool summary
+    /// (e.g. "Set 'title' to 'New Title'") or a generic argument dump when the tool has no summary.
+    /// </param>
+    /// <param name="confirmationPhrase">
+    /// When non-null, the exact phrase the approver must type to unlock the Approve button (typically
+    /// the target item's name) -- extra friction for calls where a plain click isn't enough (e.g.
+    /// publishing or deleting). Null keeps the plain Approve/Deny buttons.
+    /// </param>
+    public void RegisterApprovalRequest(string interruptId, string toolCallId, string toolName, string argsJson, string title, string message, string? confirmationPhrase)
+        => _approvalInterrupts.Add((interruptId, toolCallId, toolName, argsJson, title, message, confirmationPhrase));
 
     /// <summary>
     /// Emits a <see cref="RunFinishedEvent"/> with the appropriate outcome.
@@ -294,18 +323,28 @@ public sealed class AGUIEventEmitter
         // Backend tool approval interrupts — user must approve before execution. Message uses the
         // interrupt's own spec-defined field ("the universal fallback UI content" per AGUIInterruptInfo),
         // not Metadata -- title has no first-class field in the AG-UI schema, so it's vendor extension data.
-        interrupts.AddRange(_approvalInterrupts.Select(a => new AGUIInterruptInfo
+        interrupts.AddRange(_approvalInterrupts.Select(a =>
         {
-            Id = a.InterruptId,
-            Reason = "human_approval",
-            ToolCallId = a.ToolCallId,
-            Message = a.Message,
-            Metadata = new Dictionary<string, object?>
+            var metadata = new Dictionary<string, object?>
             {
                 ["toolName"] = a.ToolName,
                 ["args"] = a.ArgsJson,
                 ["title"] = a.Title,
-            },
+            };
+
+            if (a.ConfirmationPhrase is not null)
+            {
+                metadata["confirmPhrase"] = a.ConfirmationPhrase;
+            }
+
+            return new AGUIInterruptInfo
+            {
+                Id = a.InterruptId,
+                Reason = "human_approval",
+                ToolCallId = a.ToolCallId,
+                Message = a.Message,
+                Metadata = metadata,
+            };
         }));
 
         AGUIRunOutcome outcome = interrupts.Count > 0

--- a/Umbraco.AI.Agent/src/Umbraco.AI.AGUI/Streaming/AGUIEventEmitter.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.AGUI/Streaming/AGUIEventEmitter.cs
@@ -30,7 +30,7 @@ public sealed class AGUIEventEmitter
     private readonly string _runId;
     private readonly HashSet<string> _emittedToolCallIds = new();
     private readonly HashSet<string> _frontendToolCallIds = new();
-    private readonly List<(string InterruptId, string ToolCallId, string ToolName, string ArgsJson)> _approvalInterrupts = new();
+    private readonly List<(string InterruptId, string ToolCallId, string ToolName, string ArgsJson, string Title, string Message)> _approvalInterrupts = new();
 
     private string _currentMessageId;
     private string? _lastGeneratedCallId;
@@ -232,8 +232,31 @@ public sealed class AGUIEventEmitter
     /// <param name="toolCallId">The MEAI tool call ID for correlation with the resume entry.</param>
     /// <param name="toolName">The name of the tool requesting approval.</param>
     /// <param name="argsJson">The serialized arguments JSON for display in the approval UI.</param>
+    /// <remarks>
+    /// Registers with a generic title/message. Use the overload with <c>title</c> and <c>message</c>
+    /// parameters to show the approver what the call will actually do.
+    /// </remarks>
+    [Obsolete("Use the overload with title and message parameters instead. Will be removed in v20.")]
     public void RegisterApprovalRequest(string interruptId, string toolCallId, string toolName, string argsJson)
-        => _approvalInterrupts.Add((interruptId, toolCallId, toolName, argsJson));
+        => RegisterApprovalRequest(interruptId, toolCallId, toolName, argsJson, toolName, "This action requires approval.");
+
+    /// <summary>
+    /// Registers a pending backend tool approval request to be included in the next
+    /// <see cref="EmitRunFinished"/> call as a <c>human_approval</c> interrupt.
+    /// </summary>
+    /// <param name="interruptId">
+    /// The AG-UI interrupt ID (opaque; typically built by <c>AGUIInterruptKind.ForApproval</c>).
+    /// </param>
+    /// <param name="toolCallId">The MEAI tool call ID for correlation with the resume entry.</param>
+    /// <param name="toolName">The name of the tool requesting approval.</param>
+    /// <param name="argsJson">The serialized arguments JSON for display in the approval UI.</param>
+    /// <param name="title">A human-readable title for the approval card (typically the tool's display name).</param>
+    /// <param name="message">
+    /// A human-readable description of what this specific call will do -- either a per-tool summary
+    /// (e.g. "Set 'title' to 'New Title'") or a generic argument dump when the tool has no summary.
+    /// </param>
+    public void RegisterApprovalRequest(string interruptId, string toolCallId, string toolName, string argsJson, string title, string message)
+        => _approvalInterrupts.Add((interruptId, toolCallId, toolName, argsJson, title, message));
 
     /// <summary>
     /// Emits a <see cref="RunFinishedEvent"/> with the appropriate outcome.
@@ -268,16 +291,20 @@ public sealed class AGUIEventEmitter
             ToolCallId = toolCallId,
         }));
 
-        // Backend tool approval interrupts — user must approve before execution.
+        // Backend tool approval interrupts — user must approve before execution. Message uses the
+        // interrupt's own spec-defined field ("the universal fallback UI content" per AGUIInterruptInfo),
+        // not Metadata -- title has no first-class field in the AG-UI schema, so it's vendor extension data.
         interrupts.AddRange(_approvalInterrupts.Select(a => new AGUIInterruptInfo
         {
             Id = a.InterruptId,
             Reason = "human_approval",
             ToolCallId = a.ToolCallId,
+            Message = a.Message,
             Metadata = new Dictionary<string, object?>
             {
                 ["toolName"] = a.ToolName,
                 ["args"] = a.ArgsJson,
+                ["title"] = a.Title,
             },
         }));
 

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/AGUI/AGUIStreamingService.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/AGUI/AGUIStreamingService.cs
@@ -7,6 +7,7 @@ using Umbraco.AI.AGUI.Events.State;
 using Umbraco.AI.AGUI.Models;
 using Umbraco.AI.AGUI.Streaming;
 using Umbraco.AI.Core.Providers.Errors;
+using Umbraco.AI.Core.Tools;
 
 namespace Umbraco.AI.Agent.Core.AGUI;
 
@@ -24,6 +25,7 @@ internal sealed class AGUIStreamingService : IAGUIStreamingService
 {
     private readonly IAGUIMessageConverter _messageConverter;
     private readonly IAGUIFileProcessor _fileProcessor;
+    private readonly AIToolCollection _toolCollection;
     private readonly ILogger<AGUIStreamingService> _logger;
 
     /// <summary>
@@ -32,10 +34,12 @@ internal sealed class AGUIStreamingService : IAGUIStreamingService
     public AGUIStreamingService(
         IAGUIMessageConverter messageConverter,
         IAGUIFileProcessor fileProcessor,
+        AIToolCollection toolCollection,
         ILogger<AGUIStreamingService> logger)
     {
         _messageConverter = messageConverter;
         _fileProcessor = fileProcessor;
+        _toolCollection = toolCollection;
         _logger = logger;
     }
 
@@ -241,7 +245,12 @@ internal sealed class AGUIStreamingService : IAGUIStreamingService
                                 {
                                     yield return pendingEvent;
                                 }
-                                emitter.RegisterApprovalRequest(approvalInterruptId, pendingCall.CallId, pendingCall.Name, argsJson);
+
+                                var tool = _toolCollection.GetById(pendingCall.Name);
+                                var approvalTitle = tool?.Name ?? pendingCall.Name;
+                                var approvalMessage = tool?.DescribeInvocation(pendingCall.Arguments)
+                                    ?? FormatGenericArgsMessage(pendingCall.Arguments);
+                                emitter.RegisterApprovalRequest(approvalInterruptId, pendingCall.CallId, pendingCall.Name, argsJson, approvalTitle, approvalMessage);
                             }
                             break;
 
@@ -338,6 +347,22 @@ internal sealed class AGUIStreamingService : IAGUIStreamingService
         return string.IsNullOrEmpty(errorContent.ErrorCode)
             ? $"\n\n[Provider error: {message}]\n\n"
             : $"\n\n[Provider error {errorContent.ErrorCode}: {message}]\n\n";
+    }
+
+    /// <summary>
+    /// Builds a generic "what this call will do" message from raw arguments, for tools that haven't
+    /// implemented <see cref="IAITool.DescribeInvocation"/> -- a plain list of argument name/value pairs
+    /// is still far more informative to a human approving the call than the bare tool name alone.
+    /// </summary>
+    private static string FormatGenericArgsMessage(IDictionary<string, object?>? arguments)
+    {
+        if (arguments is null || arguments.Count == 0)
+        {
+            return "This action takes no arguments.";
+        }
+
+        var parts = arguments.Select(kvp => $"{kvp.Key}: {System.Text.Json.JsonSerializer.Serialize(kvp.Value)}");
+        return string.Join(", ", parts);
     }
 
 

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/AGUI/AGUIStreamingService.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/AGUI/AGUIStreamingService.cs
@@ -53,7 +53,7 @@ internal sealed class AGUIStreamingService : IAGUIStreamingService
         AGUIRunRequest request,
         IEnumerable<AITool>? frontendTools,
         AgentSession? session,
-        IReadOnlyDictionary<string, FunctionCallContent>? pendingApprovalCalls = null,
+        IReadOnlyDictionary<string, ToolApprovalRequestContent>? pendingApprovalCalls = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var emitter = new AGUIEventEmitter(request.ThreadId, request.RunId);
@@ -146,7 +146,7 @@ internal sealed class AGUIStreamingService : IAGUIStreamingService
         AGUIEventEmitter emitter,
         HashSet<string> frontendToolNames,
         AgentSession? session,
-        IReadOnlyDictionary<string, FunctionCallContent>? pendingApprovalCalls,
+        IReadOnlyDictionary<string, ToolApprovalRequestContent>? pendingApprovalCalls,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         // Process file content: store base64, resolve id references
@@ -174,7 +174,31 @@ internal sealed class AGUIStreamingService : IAGUIStreamingService
             // Promote FunctionCallContent → ToolApprovalRequestContent in the converted history
             // for any approval interrupt. FICC needs the original request present in the
             // replayed history to correlate the ToolApprovalResponseContent (spike Finding B).
-            PromoteApprovalRequestsInHistory(chatMessages, request.Resume);
+            //
+            // Only do this when NO persisted ChatHistoryProvider is bound (session is null). When a
+            // session IS bound (Copilot Workspace), MAF's ChatHistoryProvider.InvokingCoreAsync
+            // unconditionally CONCATENATES the provider's persisted history in front of whatever we
+            // pass here. The interrupted turn's assistant message was already persisted with the real
+            // ToolApprovalRequestContent (FICC's own output when the run paused), so the provider
+            // already supplies one copy. The client ALSO replays that same turn's tool call in
+            // chatMessages (Task 5's onToolCallStart/onToolCallArgsEnd capture — needed so a
+            // non-session, stateless resume can correlate it). Left in place for a session-bound run,
+            // that client copy becomes a SECOND copy of the same tool call once concatenated with
+            // persisted history: promoting it produces a duplicate ToolApprovalRequestContent (FICC
+            // throws "...that have no matching ToolApprovalResponseContent" on the one left over after
+            // a single response matches the other), and even without promoting it, the raw duplicate
+            // FunctionCallContent still reaches the wire as a second tool_use block with the same id,
+            // which the provider itself rejects (observed: Anthropic 400 "tool_use ids must be
+            // unique"). So for a session-bound run we don't promote AND we strip the client's copy
+            // outright, relying solely on the persisted-history copy MAF concatenates in.
+            if (session is null)
+            {
+                PromoteApprovalRequestsInHistory(chatMessages, request.Resume);
+            }
+            else if (pendingApprovalCalls is { Count: > 0 })
+            {
+                RemovePersistedApprovalCallsFromClientHistory(chatMessages, pendingApprovalCalls.Keys);
+            }
 
             var resumeMessages = ExtractToolResultsFromResume(chatMessages, request.Resume, pendingApprovalCalls, request.RunId);
             chatMessages.AddRange(resumeMessages);
@@ -392,6 +416,49 @@ internal sealed class AGUIStreamingService : IAGUIStreamingService
     }
 
     /// <summary>
+    /// Strips <see cref="FunctionCallContent"/> for the given <paramref name="callIds"/> out of the
+    /// client-resent <paramref name="chatMessages"/> in-place, dropping a message entirely once it has
+    /// no content left. Used on a session-bound resume: the caller has already recovered these exact
+    /// calls from the conversation's persisted history (<paramref name="callIds"/> is
+    /// <c>pendingApprovalCalls.Keys</c>), and that persisted copy is what MAF's bound
+    /// <c>ChatHistoryProvider</c> concatenates in ahead of these messages. Leaving the client's copy in
+    /// place would send the same tool call twice — the wire-level duplicate a real provider rejects
+    /// (Anthropic: "tool_use ids must be unique") even after <see cref="PromoteApprovalRequestsInHistory"/>
+    /// is skipped for this path.
+    /// </summary>
+    private static void RemovePersistedApprovalCallsFromClientHistory(
+        List<ChatMessage> chatMessages,
+        IEnumerable<string> callIds)
+    {
+        var ids = callIds as ICollection<string> ?? callIds.ToList();
+        if (ids.Count == 0) return;
+
+        for (var i = chatMessages.Count - 1; i >= 0; i--)
+        {
+            var msg = chatMessages[i];
+            if (msg.Role != ChatRole.Assistant || msg.Contents is null) continue;
+
+            var filtered = msg.Contents
+                .Where(c => c is not FunctionCallContent fc || !ids.Contains(fc.CallId))
+                .ToList();
+
+            if (filtered.Count == msg.Contents.Count) continue;
+
+            if (filtered.Count == 0)
+            {
+                chatMessages.RemoveAt(i);
+            }
+            else
+            {
+                chatMessages[i] = new ChatMessage(ChatRole.Assistant, filtered)
+                {
+                    MessageId = msg.MessageId
+                };
+            }
+        }
+    }
+
+    /// <summary>
     /// Converts AG-UI resume entries into M.E.AI chat messages.
     /// </summary>
     /// <remarks>
@@ -420,7 +487,7 @@ internal sealed class AGUIStreamingService : IAGUIStreamingService
     private List<ChatMessage> ExtractToolResultsFromResume(
         IReadOnlyList<ChatMessage> chatMessages,
         IReadOnlyList<AGUIResumeEntry> resume,
-        IReadOnlyDictionary<string, FunctionCallContent>? pendingApprovalCalls,
+        IReadOnlyDictionary<string, ToolApprovalRequestContent>? pendingApprovalCalls,
         string runId)
     {
         var results = new List<ChatMessage>();
@@ -443,23 +510,25 @@ internal sealed class AGUIStreamingService : IAGUIStreamingService
             if (AGUIInterruptKind.IsApproval(entry.InterruptId))
             {
                 // Backend tool approval interrupt: payload is { "approved": bool }.
-                // Build a ToolApprovalResponseContent so FICC executes (approved) or
-                // skips (denied) the wrapped ApprovalRequiredAIFunction.
                 var callId = AGUIInterruptKind.GetCallId(entry.InterruptId)!;
                 var approved = entry.Payload.Value.TryGetProperty("approved", out var ap)
                     && ap.ValueKind == System.Text.Json.JsonValueKind.True;
 
-                // Recover the ORIGINAL tool call (name + arguments) so FICC can execute the approved
-                // function — it recreates the call from THIS response, so an empty placeholder would make
-                // it invoke a nameless function. Look in the replayed client history first (in-flight
-                // resume), then the persisted history the provider will load (resume after a reload, B2).
-                var requestedToolCall = FindApprovalToolCall(chatMessages, callId);
-                if (requestedToolCall is null && pendingApprovalCalls is not null)
+                // Recover the ORIGINAL approval request (name + arguments, and — critically — FICC's own
+                // RequestId, e.g. "ficc_<callId>", NOT the callId itself) so the response is built via
+                // CreateResponse() below rather than hand-constructed with a guessed id. Microsoft.Agents.AI's
+                // ApprovalResponseBindingChatClient matches inbound responses against its session-recorded
+                // pending requests by RequestId and silently drops any response that doesn't match — a response
+                // built with the wrong id looks identical to a forged one. Look in the replayed client history
+                // first (in-flight resume), then the persisted history the provider will load (resume after a
+                // reload, B2).
+                var requestedApprovalRequest = FindApprovalToolCall(chatMessages, callId);
+                if (requestedApprovalRequest is null && pendingApprovalCalls is not null)
                 {
-                    pendingApprovalCalls.TryGetValue(callId, out requestedToolCall);
+                    pendingApprovalCalls.TryGetValue(callId, out requestedApprovalRequest);
                 }
 
-                if (requestedToolCall is null)
+                if (requestedApprovalRequest is null)
                 {
                     // Not correlatable to a pending tool call in client OR persisted history — a stale or
                     // duplicate resume entry (e.g. from a prior run). Skip it rather than synthesise an
@@ -471,8 +540,7 @@ internal sealed class AGUIStreamingService : IAGUIStreamingService
                     continue;
                 }
 
-                results.Add(new ChatMessage(ChatRole.User,
-                    [new ToolApprovalResponseContent(callId, approved, requestedToolCall)]));
+                results.Add(new ChatMessage(ChatRole.User, [requestedApprovalRequest.CreateResponse(approved)]));
                 continue;
             }
 
@@ -485,13 +553,12 @@ internal sealed class AGUIStreamingService : IAGUIStreamingService
     }
 
     /// <summary>
-    /// Finds the original <see cref="FunctionCallContent"/> for an approval <paramref name="callId"/> in the
-    /// replayed history (as an already-promoted <see cref="ToolApprovalRequestContent"/>), or null if absent.
+    /// Finds the original <see cref="ToolApprovalRequestContent"/> for an approval <paramref name="callId"/>
+    /// in the replayed history, or null if absent.
     /// </summary>
-    private static FunctionCallContent? FindApprovalToolCall(IReadOnlyList<ChatMessage> chatMessages, string callId)
+    private static ToolApprovalRequestContent? FindApprovalToolCall(IReadOnlyList<ChatMessage> chatMessages, string callId)
         => chatMessages
             .SelectMany(m => m.Contents ?? [])
             .OfType<ToolApprovalRequestContent>()
-            .FirstOrDefault(c => c.ToolCall.CallId == callId)
-            ?.ToolCall as FunctionCallContent;
+            .FirstOrDefault(c => c.ToolCall.CallId == callId);
 }

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/AGUI/AGUIStreamingService.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/AGUI/AGUIStreamingService.cs
@@ -250,7 +250,8 @@ internal sealed class AGUIStreamingService : IAGUIStreamingService
                                 var approvalTitle = tool?.Name ?? pendingCall.Name;
                                 var approvalMessage = tool?.DescribeInvocation(pendingCall.Arguments)
                                     ?? FormatGenericArgsMessage(pendingCall.Arguments);
-                                emitter.RegisterApprovalRequest(approvalInterruptId, pendingCall.CallId, pendingCall.Name, argsJson, approvalTitle, approvalMessage);
+                                var confirmationPhrase = tool?.ConfirmationPhrase(pendingCall.Arguments);
+                                emitter.RegisterApprovalRequest(approvalInterruptId, pendingCall.CallId, pendingCall.Name, argsJson, approvalTitle, approvalMessage, confirmationPhrase);
                             }
                             break;
 

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/AGUI/IAGUIStreamingService.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/AGUI/IAGUIStreamingService.cs
@@ -61,9 +61,14 @@ public interface IAGUIStreamingService
     /// behaviour).
     /// </param>
     /// <param name="pendingApprovalCalls">
-    /// Optional map of <c>callId → original tool call</c> reconstructed from persisted history, used to
-    /// correlate human-approval resume entries after a reload (when the original call is not in the
-    /// client-supplied messages). Null for the contextual Copilot.
+    /// Optional map of <c>callId → original approval request</c> reconstructed from persisted history,
+    /// used to correlate human-approval resume entries after a reload (when the original call is not in
+    /// the client-supplied messages). The full <see cref="ToolApprovalRequestContent"/> is kept (not just
+    /// its wrapped tool call) so the resume path can build its response via
+    /// <c>request.CreateResponse(approved)</c>, carrying forward FICC's own
+    /// <see cref="ToolApprovalRequestContent.RequestId"/> — required for
+    /// <c>Microsoft.Agents.AI</c>'s <c>ApprovalResponseBindingChatClient</c> to recognize the response as
+    /// tied to a request it actually surfaced. Null for the contextual Copilot.
     /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>An async enumerable of AG-UI events.</returns>
@@ -77,7 +82,7 @@ public interface IAGUIStreamingService
         AGUIRunRequest request,
         IEnumerable<AITool>? frontendTools,
         AgentSession? session,
-        IReadOnlyDictionary<string, FunctionCallContent>? pendingApprovalCalls = null,
+        IReadOnlyDictionary<string, ToolApprovalRequestContent>? pendingApprovalCalls = null,
         CancellationToken cancellationToken = default)
         => StreamAgentAsync(agent, request, frontendTools, cancellationToken);
 }

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Agents/AIAgentService.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Agents/AIAgentService.cs
@@ -500,10 +500,28 @@ internal sealed class AIAgentService : IAIAgentService
         // binding lives with the consumer's provider) so the attached ChatHistoryProvider loads/stores
         // against the right conversation. Non-persisted surfaces stream with a null session as before.
         AgentSession? session = null;
-        IReadOnlyDictionary<string, FunctionCallContent>? pendingApprovalCalls = null;
+        IReadOnlyDictionary<string, ToolApprovalRequestContent>? pendingApprovalCalls = null;
         if (options.ConversationHistory is { } historyBinding)
         {
-            session = await context.MafAgent.CreateSessionAsync(cancellationToken);
+            // A fresh session is created per HTTP request (Copilot Workspace persists conversation
+            // history in its own store rather than keeping a MAF session alive between requests — it
+            // wouldn't survive a restart anyway). But session-scoped decorators (e.g. the tool-approval-
+            // response binder introduced in Microsoft.Agents.AI 1.14) record their own state directly on
+            // the session object, not in chat history — so restore the prior run's state here rather than
+            // always starting bare, or that state silently never reaches the decorator. Confirmed
+            // empirically necessary: disabling that decorator instead (relying solely on our own
+            // persisted-history-based approval correlation) breaks a chained multi-approval turn — e.g.
+            // create_umbraco_content then publish_umbraco_content approved back-to-back in one
+            // conversation — because a prior turn's already-resolved approval request resurfaces as
+            // unmatched once a later turn's persisted history is reloaded. Keeping this decorator active
+            // (with its state correctly restored) avoids that; our own correlation layer stays in place
+            // too, since it's what supplies the correct request object for CreateResponse().
+            var persistedState = historyBinding.LoadSessionState is { } loadState
+                ? await loadState(cancellationToken)
+                : null;
+            session = persistedState is { } state
+                ? await context.MafAgent.DeserializeSessionAsync(state, cancellationToken: cancellationToken)
+                : await context.MafAgent.CreateSessionAsync(cancellationToken);
             historyBinding.BindSession(session);
 
             // For an approval resume after a reload, the original tool call may only exist in persisted
@@ -523,6 +541,14 @@ internal sealed class AIAgentService : IAIAgentService
         }
         finally
         {
+            // Persist session state (success or interrupt) so the next request's fresh session can
+            // restore it above — see the restore comment for why this matters.
+            if (options.ConversationHistory is { SaveSessionState: { } saveState } binding && session is not null)
+            {
+                var serialized = await context.MafAgent.SerializeSessionAsync(session, cancellationToken: cancellationToken);
+                await saveState(serialized, cancellationToken);
+            }
+
             await PublishExecutedNotificationAsync(context, streamCompleted);
         }
     }
@@ -826,7 +852,7 @@ internal sealed class AIAgentService : IAIAgentService
     /// callIds from persisted history (via the binding), so the streaming resume path can correlate a
     /// reloaded approval instead of skipping it. Returns null when there is nothing to resolve (B2).
     /// </summary>
-    private static async ValueTask<IReadOnlyDictionary<string, FunctionCallContent>?> ResolvePendingApprovalCallsAsync(
+    private static async ValueTask<IReadOnlyDictionary<string, ToolApprovalRequestContent>?> ResolvePendingApprovalCallsAsync(
         AIConversationHistoryBinding binding,
         AGUIRunRequest request,
         CancellationToken cancellationToken)

--- a/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Agents/AIConversationHistoryBinding.cs
+++ b/Umbraco.AI.Agent/src/Umbraco.AI.Agent.Core/Agents/AIConversationHistoryBinding.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 
@@ -33,10 +34,34 @@ public sealed record AIConversationHistoryBinding(
     Action<AgentSession> BindSession)
 {
     /// <summary>
-    /// Optional resolver that, given a set of approval <c>callId</c>s, returns the original tool calls
-    /// (name + arguments) recovered from persisted history — used to correlate human-approval resume
-    /// entries after a reload, when the original call is no longer in the client-supplied messages (B2).
-    /// The consumer closes this over its own conversation store; the Agent layer stays product-agnostic.
+    /// Optional resolver that, given a set of approval <c>callId</c>s, returns the original approval
+    /// requests recovered from persisted history — used to correlate human-approval resume entries after
+    /// a reload, when the original call is no longer in the client-supplied messages (B2). The consumer
+    /// closes this over its own conversation store; the Agent layer stays product-agnostic.
     /// </summary>
-    public Func<IReadOnlyCollection<string>, CancellationToken, ValueTask<IReadOnlyDictionary<string, FunctionCallContent>>>? ResolveApprovalToolCalls { get; init; }
+    /// <remarks>
+    /// Returns the full <see cref="ToolApprovalRequestContent"/>, not just its wrapped tool call, so the
+    /// resume path can build its response via <c>request.CreateResponse(approved)</c> — carrying forward
+    /// FICC's own <see cref="ToolApprovalRequestContent.RequestId"/> rather than guessing it from the
+    /// callId. <c>Microsoft.Agents.AI</c>'s <c>ApprovalResponseBindingChatClient</c> matches inbound
+    /// responses by that id and silently drops any built with the wrong one.
+    /// </remarks>
+    public Func<IReadOnlyCollection<string>, CancellationToken, ValueTask<IReadOnlyDictionary<string, ToolApprovalRequestContent>>>? ResolveApprovalToolCalls { get; init; }
+
+    /// <summary>
+    /// Optional loader for the conversation's persisted MAF session-state blob (previously captured by
+    /// <see cref="SaveSessionState"/>). When set and a blob is available, the agent layer restores the
+    /// run's session from it via <c>AIAgent.DeserializeSessionAsync</c> instead of creating a bare one —
+    /// required for session-scoped decorators (e.g. tool-approval-response binding) whose state lives on
+    /// the session object itself rather than in chat history, and therefore does not survive a fresh
+    /// session being created for every request. Returns null when there is nothing to restore.
+    /// </summary>
+    public Func<CancellationToken, ValueTask<JsonElement?>>? LoadSessionState { get; init; }
+
+    /// <summary>
+    /// Optional saver for the run's session state, called after streaming completes (success or
+    /// interrupt) so the next request can restore it via <see cref="LoadSessionState"/>. The consumer
+    /// closes this over its own conversation store.
+    /// </summary>
+    public Func<JsonElement, CancellationToken, ValueTask>? SaveSessionState { get; init; }
 }

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Integration/Agents/BackendToolApprovalFlowTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Integration/Agents/BackendToolApprovalFlowTests.cs
@@ -11,6 +11,7 @@ using Umbraco.AI.Agent.Core.Chat;
 using Umbraco.AI.AGUI.Events;
 using Umbraco.AI.AGUI.Events.Lifecycle;
 using Umbraco.AI.AGUI.Models;
+using Umbraco.AI.Core.Tools;
 using Xunit;
 using MsAIAgent = Microsoft.Agents.AI.AIAgent;
 
@@ -42,7 +43,7 @@ public class BackendToolApprovalFlowTests
             .ReturnsAsync((IEnumerable<AGUIMessage>? msgs, string _, CancellationToken _) =>
                 new AGUIFileProcessorResult { RewrittenMessages = msgs ?? [], ResolvedMessages = msgs ?? [] });
 
-        _service = new AGUIStreamingService(_converter.Object, _fileProcessor.Object, NullLogger<AGUIStreamingService>.Instance);
+        _service = new AGUIStreamingService(_converter.Object, _fileProcessor.Object, new AIToolCollection(() => []), NullLogger<AGUIStreamingService>.Instance);
     }
 
     [Fact]

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Integration/Agents/SessionBoundApprovalResumeTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Integration/Agents/SessionBoundApprovalResumeTests.cs
@@ -9,6 +9,7 @@ using Umbraco.AI.Agent.Core.AGUI;
 using Umbraco.AI.AGUI.Events;
 using Umbraco.AI.AGUI.Events.Lifecycle;
 using Umbraco.AI.AGUI.Models;
+using Umbraco.AI.Core.Tools;
 using Xunit;
 using MsAIAgent = Microsoft.Agents.AI.AIAgent;
 
@@ -97,7 +98,7 @@ public class SessionBoundApprovalResumeTests
             .ReturnsAsync((IEnumerable<AGUIMessage>? msgs, string _, CancellationToken _) =>
                 new AGUIFileProcessorResult { RewrittenMessages = msgs ?? [], ResolvedMessages = msgs ?? [] });
 
-        _service = new AGUIStreamingService(_converter.Object, _fileProcessor.Object, NullLogger<AGUIStreamingService>.Instance);
+        _service = new AGUIStreamingService(_converter.Object, _fileProcessor.Object, new AIToolCollection(() => []), NullLogger<AGUIStreamingService>.Instance);
     }
 
     [Fact]

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Integration/Agents/SessionBoundApprovalResumeTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Integration/Agents/SessionBoundApprovalResumeTests.cs
@@ -1,0 +1,316 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Shouldly;
+using Umbraco.AI.Agent.Core.AGUI;
+using Umbraco.AI.AGUI.Events;
+using Umbraco.AI.AGUI.Events.Lifecycle;
+using Umbraco.AI.AGUI.Models;
+using Xunit;
+using MsAIAgent = Microsoft.Agents.AI.AIAgent;
+
+namespace Umbraco.AI.Agent.Tests.Integration.Agents;
+
+/// <summary>
+/// Reproduces (and proves the fix for) the Copilot Workspace approval-resume crash: a REAL
+/// <see cref="ChatClientAgent"/> bound to a <see cref="ChatHistoryProvider"/> that persists messages
+/// through an actual JSON serialize/deserialize round trip (like <c>ConversationChatHistoryProvider</c>),
+/// driven through the real <see cref="AGUIStreamingService"/> exactly as
+/// <c>AIAgentService.StreamAgentAGUIAsync</c> and <c>StreamConversationAGUIController</c> compose it:
+/// a FRESH <see cref="AgentSession"/> is created per turn but RESTORED from the prior turn's serialized
+/// state (mirroring <c>CreateSessionAsync</c>/<c>DeserializeSessionAsync</c> being called once per HTTP
+/// request), and the resume request replays the pending tool call in the client-supplied history exactly
+/// as the real frontend does (Task 5 of the HITL approval plan).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two distinct bugs were found here, at two different layers:
+/// </para>
+/// <list type="number">
+///   <item><description>
+///   <b>Duplicate tool call on the wire</b> (fixed in application code — see
+///   <see cref="AGUIStreamingService"/>'s <c>RemovePersistedApprovalCallsFromClientHistory</c>):
+///   <see cref="ChatHistoryProvider"/>'s default <c>InvokingCoreAsync</c> unconditionally concatenates
+///   the bound provider's persisted history (which already contains the interrupted turn's tool call,
+///   stored verbatim by FICC's own output when the run paused) in front of whatever
+///   <see cref="AGUIStreamingService"/> passes to <c>RunStreamingAsync</c>. The client ALSO replays that
+///   same turn's pending tool call in the messages it resends on resume (Task 5's
+///   onToolCallStart/onToolCallArgsEnd capture — needed so a non-session, stateless resume can correlate
+///   it). Left unguarded that produces two copies of the same tool call once concatenated, which a real
+///   provider rejects outright (observed live: Anthropic 400 <c>"tool_use ids must be unique"</c>).
+///   <see cref="ScriptedApprovalChatClient"/> below asserts the same invariant so this test fails the
+///   same way a real provider would.
+///   </description></item>
+///   <item><description>
+///   <b>Approval silently never executes</b> (fixed by restoring session state — see
+///   <c>AIAgentService.StreamAgentAGUIAsync</c>'s use of <c>DeserializeSessionAsync</c>/
+///   <c>SerializeSessionAsync</c>): Microsoft.Agents.AI 1.14+ ships an
+///   <c>ApprovalResponseBindingChatClient</c> decorator that records every model-originated approval
+///   request directly in the live <see cref="AgentSession"/>'s <c>StateBag</c> — NOT in chat history —
+///   and only honors an inbound approval response tied to a request it recorded. Because Copilot
+///   Workspace creates a brand-new <see cref="AgentSession"/> per HTTP request (message-level history is
+///   persisted separately, in the conversation store), that recorded state never reached turn 2 under a
+///   bare <c>CreateSessionAsync()</c> — the decorator silently dropped the approval as unrecognized, no
+///   exception, tool never ran.
+///   </description></item>
+/// </list>
+/// <para>
+/// <b>Why the decorator is kept enabled rather than disabled</b> (a real alternative that was tried and
+/// reverted): our own resume path already recovers the original request from persisted history and never
+/// trusts client-supplied tool-call content, so it seemed like the framework's session-scoped check was
+/// redundant defense-in-depth. Disabling it (<c>ChatClientAgentOptions.DisableApprovalResponseBinding</c>)
+/// and dropping this test's session round trip in favor of a bare <c>CreateSessionAsync()</c> passed this
+/// single-approval test — but broke a chained scenario live (create a page, then immediately publish it,
+/// approving each in turn): the SECOND approval failed on the FIRST tool's already-resolved
+/// <see cref="ToolApprovalRequestContent"/>, still sitting in replayed history from an earlier turn. Once
+/// a <see cref="FunctionCallContent"/> is approved, the framework marks the copy embedded in the response
+/// as <see cref="FunctionCallContent.InformationalOnly"/> — "already handled, ignore me" — but the
+/// separately-stored ORIGINAL request message never gets that marker, since it's a distinct persisted
+/// JSON blob from an earlier turn. Re-derived from scratch on every turn (which is what a bare, unrestored
+/// session forces), that stale request has no reachable, still-"live" response to pair against, so FICC
+/// reports it unmatched — even though it really was resolved, and executed, turns ago. The decorator's
+/// session-scoped bookkeeping sidesteps this class of bug entirely: it tracks resolution by direct
+/// record-keeping instead of re-deriving it from replayed message content each time, so a genuinely
+/// stale, already-consumed request is never re-examined once removed from its own tracked list. That
+/// robustness is worth the extra persisted state; our own resolver (<c>ResolveApprovalToolCalls</c>)
+/// stays in place regardless, since it is what supplies the correct request object for
+/// <c>CreateResponse()</c> in the first place — the two are complementary, not duplicated, layers.
+/// </para>
+/// </remarks>
+public class SessionBoundApprovalResumeTests
+{
+    private const string ToolName = "delete_content";
+    private const string CallId = "call-1";
+    private const string ApprovalInterruptId = "approval:call-1";
+
+    private readonly Mock<IAGUIMessageConverter> _converter = new();
+    private readonly Mock<IAGUIFileProcessor> _fileProcessor = new();
+    private readonly AGUIStreamingService _service;
+
+    public SessionBoundApprovalResumeTests()
+    {
+        _fileProcessor
+            .Setup(x => x.ProcessInboundAsync(It.IsAny<IEnumerable<AGUIMessage>?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<AGUIMessage>? msgs, string _, CancellationToken _) =>
+                new AGUIFileProcessorResult { RewrittenMessages = msgs ?? [], ResolvedMessages = msgs ?? [] });
+
+        _service = new AGUIStreamingService(_converter.Object, _fileProcessor.Object, NullLogger<AGUIStreamingService>.Instance);
+    }
+
+    [Fact]
+    public async Task ApprovalResume_WithSessionBoundPersistedHistory_DoesNotThrow_AndExecutesOnApprove()
+    {
+        var executions = 0;
+        var historyProvider = new JsonRoundTrippingChatHistoryProvider();
+        var agent = CreateApprovalAgent(() => executions++, historyProvider);
+
+        // --- Turn 1: initial call, persisted via the real ChatHistoryProvider (real JSON round trip). ---
+        SetConverterHistory(new ChatMessage(ChatRole.User, "delete content 42"));
+        var session1 = await agent.CreateSessionAsync();
+
+        var firstRun = await CollectEvents(agent, CreateRequest(), session1);
+
+        firstRun.OfType<RunFinishedEvent>().Single()
+            .Outcome.ShouldBeOfType<AGUIRunOutcomeInterrupt>()
+            .Interrupts.Single(i => i.Reason == "human_approval").Id.ShouldBe(ApprovalInterruptId);
+        executions.ShouldBe(0);
+
+        // --- Turn 2: resume, approved. Mirrors production exactly:
+        //   - session1's state is serialized and a BRAND NEW session is restored from it
+        //     (StreamConversationAGUIController creates one per HTTP call via IAIAgentService ->
+        //     context.MafAgent.DeserializeSessionAsync each request when prior state exists) — this is
+        //     what carries ApprovalResponseBindingChatClient's own recorded pending-approval state (bug
+        //     #2 above) across the request boundary, exactly like AIAgentService.StreamAgentAGUIAsync;
+        //   - the client resends the pending tool call as part of its own history (Task 5's
+        //     onToolCallStart/onToolCallArgsEnd capture), which AGUIStreamingService may promote;
+        //   - pendingApprovalCalls is resolved from the SAME persisted store up front, exactly as
+        //     AIAgentService.ResolvePendingApprovalCallsAsync does before streaming starts.
+        var serializedState = await agent.SerializeSessionAsync(session1);
+        var session2 = await agent.DeserializeSessionAsync(serializedState);
+        historyProvider.BindConversation(session2);
+
+        var pendingApprovalCalls = await historyProvider.GetApprovalToolCallsAsync([CallId]);
+
+        SetConverterHistory(
+            new ChatMessage(ChatRole.User, "delete content 42"),
+            new ChatMessage(ChatRole.Assistant, [PendingToolCall()]));
+
+        var secondRun = await CollectEvents(agent, CreateResumeRequest(approved: true), session2, pendingApprovalCalls);
+
+        executions.ShouldBe(1);
+        secondRun.OfType<RunFinishedEvent>().Single()
+            .Outcome.ShouldBeOfType<AGUIRunOutcomeSuccess>();
+    }
+
+    // ---- Helpers ----
+
+    private static ChatClientAgent CreateApprovalAgent(Action onExecute, ChatHistoryProvider historyProvider)
+    {
+        var inner = AIFunctionFactory.Create(
+            (string id) => { onExecute(); return $"deleted {id}"; },
+            name: ToolName);
+        var approvalFn = new ApprovalRequiredAIFunction(inner);
+
+        return new ChatClientAgent(new ScriptedApprovalChatClient(), new ChatClientAgentOptions
+        {
+            ChatOptions = new ChatOptions { Tools = [approvalFn], AllowMultipleToolCalls = false },
+            ChatHistoryProvider = historyProvider,
+        });
+    }
+
+    private static FunctionCallContent PendingToolCall() =>
+        new(CallId, ToolName, new Dictionary<string, object?> { ["id"] = "42" });
+
+    private void SetConverterHistory(params ChatMessage[] messages) =>
+        _converter
+            .Setup(x => x.ConvertToChatMessages(It.IsAny<IEnumerable<AGUIMessage>?>()))
+            .Returns(messages.ToList());
+
+    private static AGUIRunRequest CreateRequest() => new()
+    {
+        ThreadId = "thread-approval",
+        RunId = "run-approval",
+        Messages = [new() { Id = Guid.NewGuid().ToString(), Role = AGUIMessageRole.User, Content = "delete content 42" }],
+    };
+
+    private static AGUIRunRequest CreateResumeRequest(bool approved)
+    {
+        var request = CreateRequest();
+        request.Resume =
+        [
+            new AGUIResumeEntry
+            {
+                InterruptId = ApprovalInterruptId,
+                Status = AGUIResumeStatus.Resolved,
+                Payload = JsonSerializer.SerializeToElement(new { approved }),
+            },
+        ];
+        return request;
+    }
+
+    private async Task<List<IAGUIEvent>> CollectEvents(
+        MsAIAgent agent,
+        AGUIRunRequest request,
+        AgentSession session,
+        IReadOnlyDictionary<string, ToolApprovalRequestContent>? pendingApprovalCalls = null)
+    {
+        var events = new List<IAGUIEvent>();
+        await foreach (var evt in _service.StreamAgentAsync(agent, request, frontendTools: null, session, pendingApprovalCalls, CancellationToken.None))
+        {
+            events.Add(evt);
+        }
+        return events;
+    }
+
+    /// <summary>
+    /// Stateless scripted chat client identical in spirit to <c>BackendToolApprovalFlowTests</c>'s: requests
+    /// the destructive tool until the conversation carries an approval response or function result.
+    /// </summary>
+    private sealed class ScriptedApprovalChatClient : IChatClient
+    {
+        public ChatClientMetadata Metadata { get; } = new("scripted-approval");
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken ct = default)
+            => throw new NotSupportedException("Agent uses the streaming path.");
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            await Task.Yield();
+
+            // Real providers reject a repeated tool_use id outright — observed live as Anthropic 400
+            // "tool_use ids must be unique" when the client's replayed pending call and the persisted
+            // history's copy of the same turn both reach the wire. Assert the same invariant here so
+            // this test fails the way a real provider does if either copy leaks through unstripped.
+            var duplicateCallId = messages
+                .SelectMany(m => m.Contents)
+                .OfType<FunctionCallContent>()
+                .GroupBy(c => c.CallId)
+                .FirstOrDefault(g => g.Count() > 1)?.Key;
+            if (duplicateCallId is not null)
+            {
+                throw new InvalidOperationException(
+                    $"Duplicate tool_use id '{duplicateCallId}' in request messages — a real provider would reject this.");
+            }
+
+            var resolved = messages.Any(m => m.Contents.Any(c =>
+                c is ToolApprovalResponseContent or FunctionResultContent));
+
+            if (resolved)
+            {
+                yield return new ChatResponseUpdate(ChatRole.Assistant, "done");
+                yield break;
+            }
+
+            yield return new ChatResponseUpdate(ChatRole.Assistant, new List<AIContent> { PendingToolCall() });
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose() { }
+    }
+
+    /// <summary>
+    /// Minimal stand-in for <c>ConversationChatHistoryProvider</c> that persists every message through a
+    /// REAL <see cref="JsonSerializer"/> serialize/then-deserialize round trip (using
+    /// <see cref="AIJsonUtilities.DefaultOptions"/>, same as the product code), so this test exercises the
+    /// same "does the polymorphic AIContent type survive storage" concern the product provider has,
+    /// rather than just reusing in-memory objects across turns. All sessions share one conversation
+    /// (single-conversation test); production scopes this per <c>conversationId</c> via session state.
+    /// </summary>
+    private sealed class JsonRoundTrippingChatHistoryProvider : ChatHistoryProvider
+    {
+        private readonly List<string> _persistedMessageJson = [];
+
+        // No-op: production binds a session to a conversation id via session state; this fake always
+        // targets its single in-memory store, so binding is just a marker call for readability at the
+        // call site (mirroring ConversationChatHistoryProvider.BindConversation's call shape).
+        public void BindConversation(AgentSession session) { }
+
+        protected override ValueTask<IEnumerable<ChatMessage>> ProvideChatHistoryAsync(
+            InvokingContext context, CancellationToken cancellationToken = default)
+        {
+            IEnumerable<ChatMessage> messages = _persistedMessageJson
+                .Select(json => JsonSerializer.Deserialize<ChatMessage>(json, AIJsonUtilities.DefaultOptions)!)
+                .ToList();
+            return new ValueTask<IEnumerable<ChatMessage>>(messages);
+        }
+
+        protected override ValueTask StoreChatHistoryAsync(
+            InvokedContext context, CancellationToken cancellationToken = default)
+        {
+            foreach (var message in context.RequestMessages.Concat(context.ResponseMessages ?? []))
+            {
+                _persistedMessageJson.Add(JsonSerializer.Serialize(message, AIJsonUtilities.DefaultOptions));
+            }
+            return default;
+        }
+
+        /// <summary>Mirrors <c>ConversationChatHistoryProvider.GetApprovalToolCallsAsync</c>.</summary>
+        public ValueTask<IReadOnlyDictionary<string, ToolApprovalRequestContent>> GetApprovalToolCallsAsync(
+            IReadOnlyCollection<string> callIds)
+        {
+            var wanted = callIds.ToHashSet(StringComparer.Ordinal);
+            var result = new Dictionary<string, ToolApprovalRequestContent>(StringComparer.Ordinal);
+
+            foreach (var json in _persistedMessageJson)
+            {
+                var message = JsonSerializer.Deserialize<ChatMessage>(json, AIJsonUtilities.DefaultOptions);
+                foreach (var content in message?.Contents ?? [])
+                {
+                    if (content is ToolApprovalRequestContent request && wanted.Contains(request.ToolCall.CallId))
+                    {
+                        result[request.ToolCall.CallId] = request;
+                    }
+                }
+            }
+
+            return new ValueTask<IReadOnlyDictionary<string, ToolApprovalRequestContent>>(result);
+        }
+    }
+}

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/AGUI/AGUIEventEmitterTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/AGUI/AGUIEventEmitterTests.cs
@@ -358,7 +358,7 @@ public class AGUIEventEmitterTests
     {
         // Arrange
         var emitter = new AGUIEventEmitter(TestThreadId, TestRunId);
-        emitter.RegisterApprovalRequest("approval:call-del", "call-del", "delete_thing", "{\"id\":\"42\"}", "Delete Thing", "Delete thing 42.");
+        emitter.RegisterApprovalRequest("approval:call-del", "call-del", "delete_thing", "{\"id\":\"42\"}", "Delete Thing", "Delete thing 42.", confirmationPhrase: null);
 
         // Act
         var evt = emitter.EmitRunFinished();
@@ -374,6 +374,24 @@ public class AGUIEventEmitterTests
         interrupt.Metadata.ShouldNotBeNull();
         interrupt.Metadata!["toolName"].ShouldBe("delete_thing");
         interrupt.Metadata!["title"].ShouldBe("Delete Thing");
+        interrupt.Metadata!.ContainsKey("confirmPhrase").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void EmitRunFinished_WithConfirmationPhrase_IncludesConfirmPhraseInMetadata()
+    {
+        // Arrange
+        var emitter = new AGUIEventEmitter(TestThreadId, TestRunId);
+        emitter.RegisterApprovalRequest("approval:call-pub", "call-pub", "publish_umbraco_content", "{}", "Publish Umbraco Content", "Publish this content item, making it live.", "Home");
+
+        // Act
+        var evt = emitter.EmitRunFinished();
+
+        // Assert
+        var interruptOutcome = evt.Outcome.ShouldBeOfType<AGUIRunOutcomeInterrupt>();
+        var interrupt = interruptOutcome.Interrupts[0];
+        interrupt.Metadata.ShouldNotBeNull();
+        interrupt.Metadata!["confirmPhrase"].ShouldBe("Home");
     }
 
     [Fact]
@@ -382,7 +400,7 @@ public class AGUIEventEmitterTests
         // Arrange
         var emitter = new AGUIEventEmitter(TestThreadId, TestRunId);
         emitter.EmitToolCall("call-frontend", "confirm", null, isFrontendTool: true);
-        emitter.RegisterApprovalRequest("approval:call-del", "call-del", "delete_thing", "{}", "Delete Thing", "Delete thing.");
+        emitter.RegisterApprovalRequest("approval:call-del", "call-del", "delete_thing", "{}", "Delete Thing", "Delete thing.", confirmationPhrase: null);
 
         // Act
         var interruptOutcome = emitter.EmitRunFinished().Outcome.ShouldBeOfType<AGUIRunOutcomeInterrupt>();
@@ -398,7 +416,7 @@ public class AGUIEventEmitterTests
     {
         // Arrange
         var emitter = new AGUIEventEmitter(TestThreadId, TestRunId);
-        emitter.RegisterApprovalRequest("approval:call-x", "call-x", "do_thing", "{}", "Do Thing", "Do the thing.");
+        emitter.RegisterApprovalRequest("approval:call-x", "call-x", "do_thing", "{}", "Do Thing", "Do the thing.", confirmationPhrase: null);
 
         // Act
         var outcome = emitter.EmitRunFinished().Outcome;

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/AGUI/AGUIEventEmitterTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/AGUI/AGUIEventEmitterTests.cs
@@ -358,7 +358,7 @@ public class AGUIEventEmitterTests
     {
         // Arrange
         var emitter = new AGUIEventEmitter(TestThreadId, TestRunId);
-        emitter.RegisterApprovalRequest("approval:call-del", "call-del", "delete_thing", "{\"id\":\"42\"}");
+        emitter.RegisterApprovalRequest("approval:call-del", "call-del", "delete_thing", "{\"id\":\"42\"}", "Delete Thing", "Delete thing 42.");
 
         // Act
         var evt = emitter.EmitRunFinished();
@@ -370,6 +370,10 @@ public class AGUIEventEmitterTests
         interrupt.Id.ShouldBe("approval:call-del");
         interrupt.Reason.ShouldBe("human_approval");
         interrupt.ToolCallId.ShouldBe("call-del");
+        interrupt.Message.ShouldBe("Delete thing 42.");
+        interrupt.Metadata.ShouldNotBeNull();
+        interrupt.Metadata!["toolName"].ShouldBe("delete_thing");
+        interrupt.Metadata!["title"].ShouldBe("Delete Thing");
     }
 
     [Fact]
@@ -378,7 +382,7 @@ public class AGUIEventEmitterTests
         // Arrange
         var emitter = new AGUIEventEmitter(TestThreadId, TestRunId);
         emitter.EmitToolCall("call-frontend", "confirm", null, isFrontendTool: true);
-        emitter.RegisterApprovalRequest("approval:call-del", "call-del", "delete_thing", "{}");
+        emitter.RegisterApprovalRequest("approval:call-del", "call-del", "delete_thing", "{}", "Delete Thing", "Delete thing.");
 
         // Act
         var interruptOutcome = emitter.EmitRunFinished().Outcome.ShouldBeOfType<AGUIRunOutcomeInterrupt>();
@@ -394,7 +398,7 @@ public class AGUIEventEmitterTests
     {
         // Arrange
         var emitter = new AGUIEventEmitter(TestThreadId, TestRunId);
-        emitter.RegisterApprovalRequest("approval:call-x", "call-x", "do_thing", "{}");
+        emitter.RegisterApprovalRequest("approval:call-x", "call-x", "do_thing", "{}", "Do Thing", "Do the thing.");
 
         // Act
         var outcome = emitter.EmitRunFinished().Outcome;

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/AGUI/AGUIStreamingServiceTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/AGUI/AGUIStreamingServiceTests.cs
@@ -14,6 +14,7 @@ using Umbraco.AI.AGUI.Events.State;
 using Umbraco.AI.AGUI.Events.Tools;
 using Umbraco.AI.AGUI.Models;
 using Umbraco.AI.Core.Providers.Errors;
+using Umbraco.AI.Core.Tools;
 using Xunit;
 
 namespace Umbraco.AI.Agent.Tests.Unit.AGUI;
@@ -33,6 +34,7 @@ public class AGUIStreamingServiceTests
         _service = new AGUIStreamingService(
             _mockConverter.Object,
             _mockFileProcessor.Object,
+            new AIToolCollection(() => []),
             _logger);
 
         // Default converter setup
@@ -291,6 +293,13 @@ public class AGUIStreamingServiceTests
         interrupt.Id.ShouldBe("approval:call-del");
         interrupt.Reason.ShouldBe("human_approval");
         interrupt.ToolCallId.ShouldBe("call-del");
+
+        // Assert — no matching tool in the (empty) collection, so falls back to a generic
+        // title/message built from the tool name and raw arguments.
+        interrupt.Metadata.ShouldNotBeNull();
+        interrupt.Metadata!["title"].ShouldBe("delete_thing");
+        interrupt.Message.ShouldContain("id");
+        interrupt.Message.ShouldContain("42");
     }
 
     #endregion

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/AGUI/AGUIStreamingServiceTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/AGUI/AGUIStreamingServiceTests.cs
@@ -611,7 +611,8 @@ public class AGUIStreamingServiceTests
 
         var realCall = new FunctionCallContent("call-del", "delete_thing",
             new Dictionary<string, object?> { ["id"] = "42" });
-        var pending = new Dictionary<string, FunctionCallContent>(StringComparer.Ordinal) { ["call-del"] = realCall };
+        var realRequest = new ToolApprovalRequestContent("ficc_call-del", realCall);
+        var pending = new Dictionary<string, ToolApprovalRequestContent>(StringComparer.Ordinal) { ["call-del"] = realRequest };
 
         var request = new AGUIRunRequest
         {
@@ -660,7 +661,7 @@ public class AGUIStreamingServiceTests
     private async Task<List<IAGUIEvent>> CollectEvents(
         AIAgent agent,
         AGUIRunRequest request,
-        IReadOnlyDictionary<string, FunctionCallContent> pendingApprovalCalls)
+        IReadOnlyDictionary<string, ToolApprovalRequestContent> pendingApprovalCalls)
     {
         var events = new List<IAGUIEvent>();
         await foreach (var evt in _service.StreamAgentAsync(agent, request, null, session: null, pendingApprovalCalls, CancellationToken.None))

--- a/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/Agents/AIAgentServiceExecutionTests.cs
+++ b/Umbraco.AI.Agent/tests/Umbraco.AI.Agent.Tests.Unit/Agents/AIAgentServiceExecutionTests.cs
@@ -138,7 +138,7 @@ public class AIAgentServiceExecutionTests
                 It.IsAny<AGUIRunRequest>(),
                 It.IsAny<IEnumerable<AITool>?>(),
                 It.IsAny<AgentSession?>(),
-                It.IsAny<IReadOnlyDictionary<string, FunctionCallContent>?>(),
+                It.IsAny<IReadOnlyDictionary<string, ToolApprovalRequestContent>?>(),
                 It.IsAny<CancellationToken>()))
             .Returns(EmptyEvents());
 

--- a/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Tools/RunAutomationTool.cs
+++ b/Umbraco.AI.Automate/src/Umbraco.AI.Automate/Tools/RunAutomationTool.cs
@@ -125,6 +125,12 @@ public class RunAutomationTool : AIToolBase<RunAutomationArgs>
 
         return new RunAutomationResult(true, runId, automation.Name, $"Automation '{automation.Name}' has been triggered.");
     }
+
+    /// <inheritdoc />
+    protected override string? DescribeInvocation(RunAutomationArgs args)
+        => string.IsNullOrWhiteSpace(args.Message)
+            ? "Trigger this automation to run."
+            : $"Trigger this automation to run, passing message: '{args.Message}'.";
 }
 
 /// <summary>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.cs
@@ -41,6 +41,7 @@ using Umbraco.AI.Core.Tests;
 using Umbraco.AI.Core.Tests.Graders;
 using Umbraco.AI.Core.Tools;
 using Umbraco.AI.Core.Tools.Scopes;
+using Umbraco.AI.Core.Tools.Umbraco;
 using Umbraco.AI.Core.Tools.Web;
 using Umbraco.AI.Core.Media;
 using Umbraco.AI.Core.Versioning;
@@ -138,6 +139,11 @@ public static partial class UmbracoBuilderExtensions
         // Tool infrastructure - auto-discover tools via [AITool] attribute
         builder.AITools()
             .Add(() => builder.TypeLoader.GetTypesWithAttribute<IAITool, AIToolAttribute>(cache: true));
+
+        // Content/media write tool authorization - every backend write tool (content-write/media-write
+        // scopes) calls this before touching IContentEditingService/IContentPublishingService/
+        // IMediaEditingService/IAIPropertyValueDispatcher, none of which self-authorize.
+        services.AddSingleton<IUmbracoWriteAuthorizer, UmbracoWriteAuthorizer>();
 
         // Property value operation infrastructure - dispatcher + handler discovery
         services.AddSingleton<IAIPropertyDefaultValueProvider, AIPropertyDefaultValueProvider>();

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/AIToolBase.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/AIToolBase.cs
@@ -151,11 +151,65 @@ public abstract class AIToolBase<TArgs> : AIToolBasic, IAITool
     protected virtual string? DescribeInvocation(TArgs args) => null;
 
     /// <summary>
+    /// Produces the exact phrase a human must type to unlock the Approve button for this specific call.
+    /// Override for calls that warrant more friction than a plain click (e.g. publishing or deleting a
+    /// content item) -- typically by looking up the target item and returning its display name. Unlike
+    /// <see cref="DescribeInvocation(TArgs)"/>, this may perform a lookup. Returns null by default, which
+    /// keeps the plain Approve/Deny buttons with no typed confirmation.
+    /// </summary>
+    /// <param name="args">The strongly-typed arguments for this call.</param>
+    protected virtual string? ConfirmationPhrase(TArgs args) => null;
+
+    /// <summary>
     /// Explicit interface implementation - deserializes args to <typeparamref name="TArgs"/> and
     /// delegates to <see cref="DescribeInvocation(TArgs)"/>. Never throws: description generation must
-    /// not break the approval flow, so any deserialization failure falls back to null.
+    /// not break the approval flow, so any deserialization or generation failure falls back to null.
     /// </summary>
     string? IAITool.DescribeInvocation(object? args)
+    {
+        if (TryDeserializeArgs(args) is not { } typedArgs)
+        {
+            return null;
+        }
+
+        try
+        {
+            return DescribeInvocation(typedArgs);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Explicit interface implementation - deserializes args to <typeparamref name="TArgs"/> and
+    /// delegates to <see cref="ConfirmationPhrase(TArgs)"/>. Never throws: a lookup failure falls back to
+    /// null (no confirmation gate) rather than blocking the approval flow.
+    /// </summary>
+    string? IAITool.ConfirmationPhrase(object? args)
+    {
+        if (TryDeserializeArgs(args) is not { } typedArgs)
+        {
+            return null;
+        }
+
+        try
+        {
+            return ConfirmationPhrase(typedArgs);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Deserializes raw call arguments (a <typeparamref name="TArgs"/> instance, a JSON element, or an
+    /// arbitrary object) to <typeparamref name="TArgs"/>, or null on any failure -- shared by the
+    /// approval-UI hooks above, both of which must degrade gracefully rather than throw.
+    /// </summary>
+    private static TArgs? TryDeserializeArgs(object? args)
     {
         if (args is null)
         {
@@ -164,7 +218,7 @@ public abstract class AIToolBase<TArgs> : AIToolBasic, IAITool
 
         try
         {
-            var typedArgs = args switch
+            return args switch
             {
                 TArgs t => t,
                 System.Text.Json.JsonElement jsonElement =>
@@ -173,8 +227,6 @@ public abstract class AIToolBase<TArgs> : AIToolBasic, IAITool
                     System.Text.Json.JsonSerializer.SerializeToElement(args, Constants.DefaultJsonSerializerOptions),
                     Constants.DefaultJsonSerializerOptions),
             };
-
-            return typedArgs is null ? null : DescribeInvocation(typedArgs);
         }
         catch
         {

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/AIToolBase.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/AIToolBase.cs
@@ -140,4 +140,45 @@ public abstract class AIToolBase<TArgs> : AIToolBasic, IAITool
             $"Expected {typeof(TArgs).Name} or JsonElement. " +
             $"Value: {System.Text.Json.JsonSerializer.Serialize(args)}");
     }
+
+    /// <summary>
+    /// Produces a short, human-readable description of what this specific call will do, given its
+    /// strongly-typed arguments. Override for destructive tools where the raw argument values alone
+    /// aren't clear on their own (e.g. a bare content key, or a property path with no context). Returns
+    /// null by default, which falls back to a generic argument-by-argument display in the approval UI.
+    /// </summary>
+    /// <param name="args">The strongly-typed arguments for this call.</param>
+    protected virtual string? DescribeInvocation(TArgs args) => null;
+
+    /// <summary>
+    /// Explicit interface implementation - deserializes args to <typeparamref name="TArgs"/> and
+    /// delegates to <see cref="DescribeInvocation(TArgs)"/>. Never throws: description generation must
+    /// not break the approval flow, so any deserialization failure falls back to null.
+    /// </summary>
+    string? IAITool.DescribeInvocation(object? args)
+    {
+        if (args is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var typedArgs = args switch
+            {
+                TArgs t => t,
+                System.Text.Json.JsonElement jsonElement =>
+                    System.Text.Json.JsonSerializer.Deserialize<TArgs>(jsonElement, Constants.DefaultJsonSerializerOptions),
+                _ => System.Text.Json.JsonSerializer.Deserialize<TArgs>(
+                    System.Text.Json.JsonSerializer.SerializeToElement(args, Constants.DefaultJsonSerializerOptions),
+                    Constants.DefaultJsonSerializerOptions),
+            };
+
+            return typedArgs is null ? null : DescribeInvocation(typedArgs);
+        }
+        catch
+        {
+            return null;
+        }
+    }
 }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/AIToolBase.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/AIToolBase.cs
@@ -109,7 +109,7 @@ public abstract class AIToolBase<TArgs> : AIToolBasic, IAITool
         {
             try
             {
-                var deserializedArgs = System.Text.Json.JsonSerializer.Deserialize<TArgs>(jsonElement, Constants.DefaultJsonSerializerOptions);
+                var deserializedArgs = TryConvertDirectOrJson(jsonElement);
                 if (deserializedArgs is null)
                 {
                     throw new ArgumentException(
@@ -130,7 +130,10 @@ public abstract class AIToolBase<TArgs> : AIToolBasic, IAITool
             }
         }
 
-        if (args is TArgs typedArgs)
+        // Deliberately does NOT fall back to the lenient serialize-round-trip conversion the
+        // approval-UI hooks below use: an unexpected argument shape reaching actual execution is a
+        // caller bug worth surfacing loudly, not something to paper over.
+        if (TryConvertDirectOrJson(args) is { } typedArgs)
         {
             return ExecuteAsync(typedArgs, cancellationToken);
         }
@@ -207,7 +210,10 @@ public abstract class AIToolBase<TArgs> : AIToolBasic, IAITool
     /// <summary>
     /// Deserializes raw call arguments (a <typeparamref name="TArgs"/> instance, a JSON element, or an
     /// arbitrary object) to <typeparamref name="TArgs"/>, or null on any failure -- shared by the
-    /// approval-UI hooks above, both of which must degrade gracefully rather than throw.
+    /// approval-UI hooks above, both of which must degrade gracefully rather than throw. Unlike
+    /// <see cref="TryConvertDirectOrJson"/> (used by actual execution), this also falls back to a
+    /// serialize-round-trip for an arbitrary object shape, since a best-effort UI hint failing outright
+    /// on an unusual-but-convertible shape would be a worse outcome than the fallback conversion.
     /// </summary>
     private static TArgs? TryDeserializeArgs(object? args)
     {
@@ -218,19 +224,28 @@ public abstract class AIToolBase<TArgs> : AIToolBasic, IAITool
 
         try
         {
-            return args switch
-            {
-                TArgs t => t,
-                System.Text.Json.JsonElement jsonElement =>
-                    System.Text.Json.JsonSerializer.Deserialize<TArgs>(jsonElement, Constants.DefaultJsonSerializerOptions),
-                _ => System.Text.Json.JsonSerializer.Deserialize<TArgs>(
-                    System.Text.Json.JsonSerializer.SerializeToElement(args, Constants.DefaultJsonSerializerOptions),
-                    Constants.DefaultJsonSerializerOptions),
-            };
+            return TryConvertDirectOrJson(args) ?? System.Text.Json.JsonSerializer.Deserialize<TArgs>(
+                System.Text.Json.JsonSerializer.SerializeToElement(args, Constants.DefaultJsonSerializerOptions),
+                Constants.DefaultJsonSerializerOptions);
         }
         catch
         {
             return null;
         }
     }
+
+    /// <summary>
+    /// Converts raw call arguments to <typeparamref name="TArgs"/> via the two "cheap" shapes: an
+    /// already-typed instance, or a JSON element to deserialize. Returns null for any other shape --
+    /// shared by <see cref="IAITool.ExecuteAsync"/> and <see cref="TryDeserializeArgs"/>, which then
+    /// apply their own, deliberately different, policy for what to do with an unrecognized shape (throw
+    /// vs. attempt a lenient fallback).
+    /// </summary>
+    private static TArgs? TryConvertDirectOrJson(object? args) => args switch
+    {
+        TArgs t => t,
+        System.Text.Json.JsonElement jsonElement =>
+            System.Text.Json.JsonSerializer.Deserialize<TArgs>(jsonElement, Constants.DefaultJsonSerializerOptions),
+        _ => null,
+    };
 }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/IAITool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/IAITool.cs
@@ -52,4 +52,18 @@ public interface IAITool : IDiscoverable
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The result of the tool execution.</returns>
     Task<object> ExecuteAsync(object? args, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Produces a short, human-readable description of what a specific call will do, given its raw
+    /// arguments (e.g. "Set 'title' to 'New Title'") -- shown to a human approving a destructive call,
+    /// in addition to the tool's general <see cref="Description"/>. Returns null when the tool hasn't
+    /// implemented one; callers fall back to a generic display of the raw arguments in that case. Must
+    /// be pure -- never perform the actual operation, a lookup, or any other side effect.
+    /// </summary>
+    /// <remarks>
+    /// Default interface implementation returns null, so existing <see cref="IAITool"/> implementers
+    /// (e.g. test fakes) that predate this member don't need updating to keep compiling.
+    /// </remarks>
+    /// <param name="args">The raw arguments for this call (a JSON element, an argument dictionary, or the tool's typed args).</param>
+    string? DescribeInvocation(object? args) => null;
 }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/IAITool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/IAITool.cs
@@ -66,4 +66,20 @@ public interface IAITool : IDiscoverable
     /// </remarks>
     /// <param name="args">The raw arguments for this call (a JSON element, an argument dictionary, or the tool's typed args).</param>
     string? DescribeInvocation(object? args) => null;
+
+    /// <summary>
+    /// Produces the exact phrase a human must type to unlock the Approve button for this specific call,
+    /// for destructive calls that warrant more friction than a plain click (e.g. publishing or deleting
+    /// a content item) -- typically the target item's display name. Returns null (the default) for
+    /// ordinary destructive calls, which keep the plain Approve/Deny buttons with no typed confirmation.
+    /// Unlike <see cref="DescribeInvocation"/>, this MAY perform a lookup (e.g. resolving a content key
+    /// to its name): it runs once, synchronously, while the approval interrupt is built -- not on every
+    /// render.
+    /// </summary>
+    /// <remarks>
+    /// Default interface implementation returns null, so existing <see cref="IAITool"/> implementers
+    /// (e.g. test fakes) that predate this member don't need updating to keep compiling.
+    /// </remarks>
+    /// <param name="args">The raw arguments for this call (a JSON element, an argument dictionary, or the tool's typed args).</param>
+    string? ConfirmationPhrase(object? args) => null;
 }

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/AddUmbracoContentItemTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/AddUmbracoContentItemTool.cs
@@ -1,0 +1,113 @@
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+using Umbraco.AI.Core.PropertyValueOperations;
+using Umbraco.AI.Core.Tools.Scopes;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.AI.Core.Tools.Umbraco;
+
+/// <summary>
+/// Arguments for the AddUmbracoContentItem tool.
+/// </summary>
+public record AddUmbracoContentItemArgs(
+    [property: Description("The unique key (GUID) of the content item to update.")]
+    Guid Key,
+
+    [property: Description("Path identifying the collection-shaped property (Block List, Block Grid, etc.) to add the item to, potentially nested inside another block. Must start and end with an alias segment.")]
+    IReadOnlyList<UmbracoPropertyPathSegmentArg> Path,
+
+    [property: Description("The element type alias or key identifying the kind of item to add (required for Block List/Block Grid, which can allow multiple element types — see x-allowedElementTypes from get_content_type_schema). Ignored for editors with a single shape.")]
+    string? ElementType,
+
+    [property: Description("Initial values for the new item's own properties, keyed by property alias. Call get_content_type_schema with the element type to see valid aliases and value shapes. Properties not supplied are left empty (there is currently no automatic default-value filling).")]
+    Dictionary<string, JsonElement>? Values,
+
+    [property: Description("Initial values for the new item's settings element (Block List/Block Grid only), keyed by property alias.")]
+    Dictionary<string, JsonElement>? SettingsValues,
+
+    [property: Description("Optional zero-based insertion position. Omit to append to the end of the collection.")]
+    int? Position,
+
+    [property: Description("Optional culture code (e.g., 'en-US') when the content item varies by culture.")]
+    string? Culture = null,
+
+    [property: Description("Optional segment identifier when the content item is segmented.")]
+    string? Segment = null);
+
+/// <summary>
+/// Tool that adds a new item to a collection-shaped content property (Block List, Block Grid, etc.),
+/// including nested inside another block. Returns the new item's key, which can be used as a
+/// BlockKey path segment in a follow-up call to populate a nested property inside it, or to
+/// remove_umbraco_content_item / move_umbraco_content_item it later.
+/// </summary>
+[AITool("add_umbraco_content_item", "Add Umbraco Content Item", ScopeId = ContentWriteScope.ScopeId, IsDestructive = true)]
+public class AddUmbracoContentItemTool(
+    IContentEditingService contentEditingService,
+    IAIPropertyValueDispatcher dispatcher,
+    IUmbracoWriteAuthorizer authorizer)
+    : AIToolBase<AddUmbracoContentItemArgs>
+{
+    private static readonly JsonSerializerOptions AddItemArgsSerializerOptions = new(JsonSerializerDefaults.Web);
+
+    /// <inheritdoc />
+    public override string Description =>
+        "Adds a new item to a collection-shaped content property (Block List, Block Grid, etc.), " +
+        "including nested inside another block — for a Block List inside a block, chain calls: first " +
+        "add_umbraco_content_item on the outer property, then a second call whose Path descends into the " +
+        "returned BlockKey. NOTE: rich text properties reject this operation — embed a block into rich " +
+        "text by set_umbraco_content_value-ing a markup placeholder first, then targeting the embedded " +
+        "block's properties via Path. Call get_content_type_schema first to discover valid element types " +
+        "and property shapes. Persists immediately as a draft — call publish_umbraco_content afterward to " +
+        "make the change live.";
+
+    /// <inheritdoc />
+    protected override async Task<object> ExecuteAsync(AddUmbracoContentItemArgs args, CancellationToken cancellationToken = default)
+    {
+        var addItemArgs = new AIAddItemArgs(
+            ElementType: args.ElementType,
+            Values: ToJsonObject(args.Values),
+            SettingsValues: ToJsonObject(args.SettingsValues),
+            Position: args.Position);
+        var dispatchArgs = JsonSerializer.SerializeToNode(addItemArgs, AddItemArgsSerializerOptions);
+
+        var outcome = await ContentPropertyValueOperationHelper.ExecuteAsync(
+            authorizer,
+            contentEditingService,
+            dispatcher,
+            args.Key,
+            args.Path,
+            AIPropertyOperation.AddItem,
+            dispatchArgs,
+            args.Culture,
+            args.Segment,
+            cancellationToken);
+
+        return new AddUmbracoContentItemResult(outcome.Success, outcome.BlockKey, outcome.Message);
+    }
+
+    private static JsonObject? ToJsonObject(Dictionary<string, JsonElement>? values)
+    {
+        if (values is null)
+        {
+            return null;
+        }
+
+        var obj = new JsonObject();
+        foreach (var (key, value) in values)
+        {
+            obj[key] = JsonNode.Parse(value.GetRawText());
+        }
+
+        return obj;
+    }
+}
+
+/// <summary>
+/// Result of the add Umbraco content item tool.
+/// </summary>
+public record AddUmbracoContentItemResult(
+    bool Success,
+    Guid? BlockKey,
+    string? Message);

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/AddUmbracoContentItemTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/AddUmbracoContentItemTool.cs
@@ -87,6 +87,20 @@ public class AddUmbracoContentItemTool(
         return new AddUmbracoContentItemResult(outcome.Success, outcome.BlockKey, outcome.Message);
     }
 
+    /// <inheritdoc />
+    protected override string? DescribeInvocation(AddUmbracoContentItemArgs args)
+    {
+        var propertyAlias = args.Path.LastOrDefault()?.Alias;
+        if (propertyAlias is null)
+        {
+            return null;
+        }
+
+        return args.ElementType is { Length: > 0 }
+            ? $"Add a new '{args.ElementType}' item to '{propertyAlias}'."
+            : $"Add a new item to '{propertyAlias}'.";
+    }
+
     private static JsonObject? ToJsonObject(Dictionary<string, JsonElement>? values)
     {
         if (values is null)

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/ClearUmbracoContentValueTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/ClearUmbracoContentValueTool.cs
@@ -1,0 +1,66 @@
+using System.ComponentModel;
+
+using Umbraco.AI.Core.PropertyValueOperations;
+using Umbraco.AI.Core.Tools.Scopes;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.AI.Core.Tools.Umbraco;
+
+/// <summary>
+/// Arguments for the ClearUmbracoContentValue tool.
+/// </summary>
+public record ClearUmbracoContentValueArgs(
+    [property: Description("The unique key (GUID) of the content item to update.")]
+    Guid Key,
+
+    [property: Description("Path identifying the property to clear, potentially nested inside a block. An array alternating property-alias segments and block-key segments. Must start and end with an alias segment.")]
+    IReadOnlyList<UmbracoPropertyPathSegmentArg> Path,
+
+    [property: Description("Optional culture code (e.g., 'en-US') when the content item varies by culture.")]
+    string? Culture = null,
+
+    [property: Description("Optional segment identifier when the content item is segmented.")]
+    string? Segment = null);
+
+/// <summary>
+/// Tool that clears a content property's value back to the editor's empty/null state, including
+/// properties nested inside blocks.
+/// </summary>
+[AITool("clear_umbraco_content_value", "Clear Umbraco Content Value", ScopeId = ContentWriteScope.ScopeId, IsDestructive = true)]
+public class ClearUmbracoContentValueTool(
+    IContentEditingService contentEditingService,
+    IAIPropertyValueDispatcher dispatcher,
+    IUmbracoWriteAuthorizer authorizer)
+    : AIToolBase<ClearUmbracoContentValueArgs>
+{
+    /// <inheritdoc />
+    public override string Description =>
+        "Clears a content property's value back to the editor's empty/null state, including properties " +
+        "nested inside blocks (identify the nesting via Path). Persists immediately as a draft — call " +
+        "publish_umbraco_content afterward to make the change live.";
+
+    /// <inheritdoc />
+    protected override async Task<object> ExecuteAsync(ClearUmbracoContentValueArgs args, CancellationToken cancellationToken = default)
+    {
+        var outcome = await ContentPropertyValueOperationHelper.ExecuteAsync(
+            authorizer,
+            contentEditingService,
+            dispatcher,
+            args.Key,
+            args.Path,
+            AIPropertyOperation.ClearValue,
+            args: null,
+            args.Culture,
+            args.Segment,
+            cancellationToken);
+
+        return new ClearUmbracoContentValueResult(outcome.Success, outcome.Message);
+    }
+}
+
+/// <summary>
+/// Result of the clear Umbraco content value tool.
+/// </summary>
+public record ClearUmbracoContentValueResult(
+    bool Success,
+    string? Message);

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/ClearUmbracoContentValueTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/ClearUmbracoContentValueTool.cs
@@ -56,6 +56,13 @@ public class ClearUmbracoContentValueTool(
 
         return new ClearUmbracoContentValueResult(outcome.Success, outcome.Message);
     }
+
+    /// <inheritdoc />
+    protected override string? DescribeInvocation(ClearUmbracoContentValueArgs args)
+    {
+        var propertyAlias = args.Path.LastOrDefault()?.Alias;
+        return propertyAlias is null ? null : $"Clear the '{propertyAlias}' property.";
+    }
 }
 
 /// <summary>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/ContentPropertyValueOperationHelper.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/ContentPropertyValueOperationHelper.cs
@@ -1,0 +1,178 @@
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+using Umbraco.AI.Core.PropertyValueOperations;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.AI.Core.Tools.Umbraco;
+
+/// <summary>
+/// One segment of a property value path, in the schema-friendly shape exposed to the LLM. Exactly one
+/// of <see cref="Alias"/> or <see cref="BlockKey"/> must be set.
+/// </summary>
+/// <remarks>
+/// The dispatcher's own <c>AIPropertyPathSegment</c> is an abstract record with a custom
+/// <see cref="System.Text.Json.Serialization.JsonConverter"/> — reusing it directly as a tool argument
+/// type risks the same unconstrained-schema problem that broke OpenAI's strict structured-output mode
+/// for the AI Prompt wand on rich-text/block properties. This flat, two-field shape has a clean,
+/// unambiguous JSON schema and is converted internally before calling the dispatcher.
+/// </remarks>
+public record UmbracoPropertyPathSegmentArg(
+    [property: Description("Set this when the segment identifies a property by alias (e.g. 'contentBlocks'). Leave null when BlockKey is set instead.")]
+    string? Alias,
+
+    [property: Description("Set this when the segment identifies a block within a collection property, by its key (from a prior add_umbraco_content_item call). Leave null when Alias is set instead.")]
+    Guid? BlockKey);
+
+/// <summary>
+/// Outcome of a property value operation, before being mapped into a tool-specific result record.
+/// </summary>
+internal sealed record ContentPropertyValueOperationOutcome(bool Success, Guid? BlockKey, string? Message)
+{
+    public static ContentPropertyValueOperationOutcome Fail(string message) => new(false, null, message);
+
+    public static ContentPropertyValueOperationOutcome Ok(Guid? blockKey = null) => new(true, blockKey, null);
+}
+
+/// <summary>
+/// Shared orchestration for the five content property-value tools (set/add/remove/move/clear). Each
+/// tool authorizes, loads the persisted content item, reads the target property's current value,
+/// dispatches the requested operation through <see cref="IAIPropertyValueDispatcher"/> — the same
+/// engine the frontend's block-editing tools use, reused in-process here rather than reimplemented —
+/// and persists the result. Consolidated into one helper so the five tools can't drift out of sync
+/// with each other on this multi-step recipe.
+/// </summary>
+internal static class ContentPropertyValueOperationHelper
+{
+    public static async Task<ContentPropertyValueOperationOutcome> ExecuteAsync(
+        IUmbracoWriteAuthorizer authorizer,
+        IContentEditingService contentEditingService,
+        IAIPropertyValueDispatcher dispatcher,
+        Guid contentKey,
+        IReadOnlyList<UmbracoPropertyPathSegmentArg>? path,
+        AIPropertyOperation operation,
+        JsonNode? args,
+        string? culture,
+        string? segment,
+        CancellationToken cancellationToken)
+    {
+        if (contentKey == Guid.Empty)
+        {
+            return ContentPropertyValueOperationOutcome.Fail("Content key cannot be empty.");
+        }
+
+        if (path is null || path.Count == 0)
+        {
+            return ContentPropertyValueOperationOutcome.Fail("Path must contain at least one segment.");
+        }
+
+        if (path[0].Alias is not { } rootAlias || path[0].BlockKey is not null)
+        {
+            return ContentPropertyValueOperationOutcome.Fail("Path must begin with a property alias segment (Alias set, BlockKey null).");
+        }
+
+        AIPropertyPathSegment[] segments;
+        try
+        {
+            segments = path.Select(ToSegment).ToArray();
+        }
+        catch (ArgumentException ex)
+        {
+            return ContentPropertyValueOperationOutcome.Fail(ex.Message);
+        }
+
+        var authResult = await authorizer.AuthorizeContentAsync(ActionUpdate.ActionLetter, contentKey);
+        if (!authResult.IsAuthorized)
+        {
+            return ContentPropertyValueOperationOutcome.Fail(authResult.Message!);
+        }
+
+        var content = await contentEditingService.GetAsync(contentKey);
+        if (content is null)
+        {
+            return ContentPropertyValueOperationOutcome.Fail($"Content with key '{contentKey}' was not found.");
+        }
+
+        var documentMetadata = new AIDocumentMetadata(
+            content.ContentType.Key,
+            [culture is not null || segment is not null ? new AIVariantId(culture, segment) : AIVariantId.Invariant],
+            content.ContentType.Variations.HasFlag(ContentVariation.Culture),
+            content.ContentType.Variations.HasFlag(ContentVariation.Segment),
+            content.Name);
+
+        var rootValue = ToJsonNode(content.GetValue(rootAlias, culture, segment));
+
+        var request = new AIPropertyValueDispatchRequest(segments, operation, args, rootValue, documentMetadata);
+        var dispatchResult = await dispatcher.DispatchAsync(request, cancellationToken);
+        if (!dispatchResult.Success)
+        {
+            return ContentPropertyValueOperationOutcome.Fail(dispatchResult.Error!.Message);
+        }
+
+        var updateModel = new ContentUpdateModel
+        {
+            Properties =
+            [
+                new PropertyValueModel
+                {
+                    Alias = rootAlias,
+                    Value = dispatchResult.NewRootValue?.Deserialize<JsonElement>(),
+                    Culture = culture,
+                    Segment = segment,
+                },
+            ],
+            // ContentEditingServiceBase.TryGetAndValidateContentType requires at least one Variants entry
+            // matching the content type's own variance — an invariant type demands one with
+            // Culture/Segment both null, otherwise it fails with ContentTypeCultureVarianceMismatch even
+            // though nothing here is actually changing the name. Reuse the current name unchanged.
+            Variants = [new VariantModel { Name = content.Name ?? string.Empty, Culture = culture, Segment = segment }],
+        };
+
+        var updateAttempt = await contentEditingService.UpdateAsync(contentKey, updateModel, authResult.UserKey!.Value);
+        if (!updateAttempt.Success)
+        {
+            return ContentPropertyValueOperationOutcome.Fail(updateAttempt.Status.ToMessage());
+        }
+
+        return ContentPropertyValueOperationOutcome.Ok(dispatchResult.BlockKey);
+    }
+
+    private static AIPropertyPathSegment ToSegment(UmbracoPropertyPathSegmentArg segment) => segment switch
+    {
+        { Alias: { } alias, BlockKey: null } => AIPropertyPathSegment.ForProperty(alias),
+        { Alias: null, BlockKey: { } blockKey } => AIPropertyPathSegment.ForBlock(blockKey),
+        _ => throw new ArgumentException("Each path segment must set exactly one of Alias or BlockKey."),
+    };
+
+    /// <summary>
+    /// Converts a raw stored property value into a <see cref="JsonNode"/> for the dispatcher. A block
+    /// editor's stored value is a JSON string (the envelope) and parses directly; a scalar editor's
+    /// stored value is often a plain, non-JSON string (e.g. "Hello World" from a text box) that would
+    /// throw if parsed as JSON, so it falls back to wrapping it as a JSON string value instead.
+    /// </summary>
+    private static JsonNode? ToJsonNode(object? value)
+    {
+        switch (value)
+        {
+            case null:
+                return null;
+            case JsonNode node:
+                return node;
+            case string s:
+                try
+                {
+                    return JsonNode.Parse(s);
+                }
+                catch (JsonException)
+                {
+                    return JsonValue.Create(s);
+                }
+            default:
+                return JsonSerializer.SerializeToNode(value);
+        }
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/ContentToolHelpers.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/ContentToolHelpers.cs
@@ -1,4 +1,6 @@
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Extensions;
 
 namespace Umbraco.AI.Core.Tools.Umbraco;
@@ -48,4 +50,134 @@ internal static class ContentToolHelpers
             parentInfo,
             properties);
     }
+
+    /// <summary>
+    /// Builds an <see cref="UmbracoContentItem"/> from a draft/business-layer content item — the shape
+    /// returned by <c>IContentEditingService.CreateAsync</c>/<c>UpdateAsync</c>, which may not be
+    /// published yet. Unlike the <see cref="IPublishedContent"/> overload, this never has a resolvable
+    /// URL, and its <c>Path</c> is the raw comma-separated id path (e.g. <c>"-1,1063,1064"</c>) rather
+    /// than a friendly breadcrumb — resolving ancestor names would need extra content-service lookups
+    /// this static helper has no way to make, and the confirmation payload a write tool returns doesn't
+    /// need it. Parent info is omitted (the caller already knows the parent key it just passed in).
+    /// </summary>
+    /// <param name="content">The draft content item.</param>
+    /// <param name="culture">Optional culture for variant content.</param>
+    /// <returns>A content item populated from the draft/business-layer model.</returns>
+    public static UmbracoContentItem BuildContentItem(IContent content, string? culture = null)
+    {
+        var properties = ExtractDraftProperties(content, culture);
+
+        return new UmbracoContentItem(
+            content.Key,
+            content.GetCultureName(culture) ?? content.Name ?? string.Empty,
+            content.ContentType.Alias,
+            null,
+            content.CreateDate,
+            content.UpdateDate,
+            content.Level,
+            content.Path,
+            null,
+            properties);
+    }
+
+    /// <summary>
+    /// Builds an <see cref="UmbracoMediaItem"/> from a media business-layer model — the shape returned
+    /// by <c>IMediaEditingService.CreateAsync</c>/<c>UpdateAsync</c>. Media has no culture/publish
+    /// concept, so this is simpler than the content overloads.
+    /// </summary>
+    /// <param name="media">The media item.</param>
+    /// <returns>A media item populated from the business-layer model.</returns>
+    public static UmbracoMediaItem BuildMediaItem(IMedia media)
+    {
+        var properties = ExtractDraftProperties(media, culture: null);
+
+        return new UmbracoMediaItem(
+            media.Key,
+            media.Name ?? string.Empty,
+            media.ContentType.Alias,
+            media.CreateDate,
+            media.UpdateDate,
+            properties);
+    }
+
+    /// <summary>
+    /// Extracts raw property values from a draft/business-layer content or media item. Unlike
+    /// <see cref="PropertyValueFormatter.ExtractProperties(IPublishedContent, string?)"/>, this does
+    /// not resolve media pickers/content pickers/blocks into friendly nested shapes — those resolutions
+    /// depend on the published cache, which a draft item may never have been through. Values are
+    /// returned as stored (e.g. a block property's raw JSON envelope, a media picker's raw UDI list).
+    /// </summary>
+    private static IReadOnlyList<ContentPropertyItem> ExtractDraftProperties(IContentBase content, string? culture)
+    {
+        var properties = new List<ContentPropertyItem>();
+
+        foreach (var property in content.Properties)
+        {
+            properties.Add(new ContentPropertyItem(
+                property.Alias,
+                property.PropertyType.PropertyEditorAlias,
+                property.GetValue(culture)));
+        }
+
+        return properties;
+    }
+
+    /// <summary>
+    /// Maps a content/media editing failure status to a human-readable message for a tool result.
+    /// </summary>
+    public static string ToMessage(this ContentEditingOperationStatus status) => status switch
+    {
+        ContentEditingOperationStatus.ContentTypeNotFound => "The specified content type was not found.",
+        ContentEditingOperationStatus.ParentNotFound => "The specified parent item was not found.",
+        ContentEditingOperationStatus.ParentInvalid => "The specified parent is not valid for this operation.",
+        ContentEditingOperationStatus.NotFound => "The specified item was not found.",
+        ContentEditingOperationStatus.NotAllowed => "This operation is not allowed here (permission or structural constraint).",
+        ContentEditingOperationStatus.PropertyTypeNotFound => "One of the supplied property aliases does not exist on this content type.",
+        ContentEditingOperationStatus.PropertyValidationError => "One or more property values failed validation.",
+        ContentEditingOperationStatus.InvalidCulture => "The specified culture is invalid or not configured.",
+        ContentEditingOperationStatus.InTrash => "This item is in the recycle bin and cannot be edited.",
+        ContentEditingOperationStatus.NotInTrash => "This item is not in the recycle bin.",
+        ContentEditingOperationStatus.DuplicateKey => "An item with the same key already exists.",
+        ContentEditingOperationStatus.DuplicateName => "An item with the same name already exists at this level.",
+        ContentEditingOperationStatus.CannotDeleteWhenReferenced => "This item cannot be deleted because it is referenced by other items.",
+        ContentEditingOperationStatus.CannotMoveToRecycleBinWhenReferenced => "This item cannot be deleted because it is referenced by other items.",
+        ContentEditingOperationStatus.CancelledByNotification => "The operation was cancelled by a notification handler.",
+        _ => $"Operation failed: {status}.",
+    };
+
+    /// <summary>
+    /// Maps a content publishing failure status to a human-readable message for a tool result.
+    /// </summary>
+    public static string ToMessage(this ContentPublishingOperationStatus status) => status switch
+    {
+        ContentPublishingOperationStatus.ContentNotFound => "The specified content item was not found.",
+        ContentPublishingOperationStatus.ContentInvalid => "This content item is invalid and cannot be published.",
+        ContentPublishingOperationStatus.NothingToPublish => "There is nothing to publish for this content item.",
+        ContentPublishingOperationStatus.MandatoryCultureMissing => "A mandatory culture is missing from this content item.",
+        ContentPublishingOperationStatus.InvalidCulture => "The specified culture is invalid or not configured.",
+        ContentPublishingOperationStatus.CultureMissing => "The specified culture is missing from this content item.",
+        ContentPublishingOperationStatus.InTrash => "This item is in the recycle bin and cannot be published.",
+        ContentPublishingOperationStatus.PathNotPublished => "The parent content must be published before this item can be published.",
+        ContentPublishingOperationStatus.UnsavedChanges => "This item has unsaved changes that must be saved before publishing.",
+        ContentPublishingOperationStatus.CannotUnpublishWhenReferenced => "This item cannot be unpublished because it is referenced by other items.",
+        ContentPublishingOperationStatus.CancelledByEvent => "The operation was cancelled by an event handler.",
+        _ => $"Operation failed: {status}.",
+    };
 }
+
+/// <summary>
+/// A media item, as returned by the media write tools.
+/// </summary>
+/// <param name="Key">The unique key of the media item.</param>
+/// <param name="Name">The name of the media item.</param>
+/// <param name="MediaType">The media type alias.</param>
+/// <param name="CreateDate">The creation date.</param>
+/// <param name="UpdateDate">The last update date.</param>
+/// <param name="Properties">The media item's properties with their raw stored values.</param>
+public record UmbracoMediaItem(
+    Guid Key,
+    string Name,
+    string MediaType,
+    DateTime CreateDate,
+    DateTime UpdateDate,
+    IReadOnlyList<ContentPropertyItem> Properties);

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/ContentToolHelpers.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/ContentToolHelpers.cs
@@ -1,6 +1,8 @@
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Core.Web;
 using Umbraco.Extensions;
 
 namespace Umbraco.AI.Core.Tools.Umbraco;
@@ -58,7 +60,8 @@ internal static class ContentToolHelpers
     /// URL, and its <c>Path</c> is the raw comma-separated id path (e.g. <c>"-1,1063,1064"</c>) rather
     /// than a friendly breadcrumb — resolving ancestor names would need extra content-service lookups
     /// this static helper has no way to make, and the confirmation payload a write tool returns doesn't
-    /// need it. Parent info is omitted (the caller already knows the parent key it just passed in).
+    /// need it. Parent info is omitted (the caller already knows the parent key it just passed in). Use
+    /// <see cref="BuildEnrichedContentItem"/> instead for an ad-hoc lookup that doesn't already know these.
     /// </summary>
     /// <param name="content">The draft content item.</param>
     /// <param name="culture">Optional culture for variant content.</param>
@@ -77,6 +80,56 @@ internal static class ContentToolHelpers
             content.Level,
             content.Path,
             null,
+            properties);
+    }
+
+    /// <summary>
+    /// Builds an <see cref="UmbracoContentItem"/> from a draft/business-layer content item for an ad-hoc
+    /// lookup (e.g. <c>get_umbraco_content</c>), where — unlike a write tool — the caller doesn't already
+    /// know the item's parent or location. Resolves a friendly breadcrumb and parent info via
+    /// <see cref="IContentService.GetAncestors(IContent)"/>, which works regardless of publish state, and
+    /// resolves a live <see cref="UmbracoContentItem.Url"/> from the published cache when the item (and
+    /// requested culture) is actually published — null otherwise, since an unpublished item has no live URL.
+    /// </summary>
+    /// <param name="content">The draft content item.</param>
+    /// <param name="contentService">Used to resolve ancestors for the breadcrumb and parent info.</param>
+    /// <param name="umbracoContextAccessor">Used to resolve a live URL when the item is published.</param>
+    /// <param name="culture">Optional culture for variant content.</param>
+    /// <returns>A fully populated content item, enriched with breadcrumb/parent/URL where resolvable.</returns>
+    public static UmbracoContentItem BuildEnrichedContentItem(
+        IContent content,
+        IContentService contentService,
+        IUmbracoContextAccessor umbracoContextAccessor,
+        string? culture = null)
+    {
+        var properties = ExtractDraftProperties(content, culture);
+
+        var ancestors = contentService.GetAncestors(content).OrderBy(a => a.Level).ToList();
+
+        var parentInfo = ancestors.Count > 0
+            ? new ContentParentItem(ancestors[^1].Key, ancestors[^1].GetCultureName(culture) ?? ancestors[^1].Name ?? string.Empty)
+            : null;
+
+        var pathParts = ancestors.Select(a => a.GetCultureName(culture) ?? a.Name ?? string.Empty).ToList();
+        pathParts.Add(content.GetCultureName(culture) ?? content.Name ?? string.Empty);
+        var breadcrumb = string.Join(" > ", pathParts);
+
+        string? url = null;
+        if (umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext))
+        {
+            url = umbracoContext.Content?.GetById(content.Key)?.Url(culture);
+        }
+
+        return new UmbracoContentItem(
+            content.Key,
+            content.GetCultureName(culture) ?? content.Name ?? string.Empty,
+            content.ContentType.Alias,
+            url,
+            content.CreateDate,
+            content.UpdateDate,
+            content.Level,
+            breadcrumb,
+            parentInfo,
             properties);
     }
 

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/ContentToolHelpers.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/ContentToolHelpers.cs
@@ -86,14 +86,24 @@ internal static class ContentToolHelpers
     /// <summary>
     /// Builds an <see cref="UmbracoContentItem"/> from a draft/business-layer content item for an ad-hoc
     /// lookup (e.g. <c>get_umbraco_content</c>), where — unlike a write tool — the caller doesn't already
-    /// know the item's parent or location. Resolves a friendly breadcrumb and parent info via
-    /// <see cref="IContentService.GetAncestors(IContent)"/>, which works regardless of publish state, and
-    /// resolves a live <see cref="UmbracoContentItem.Url"/> from the published cache when the item (and
-    /// requested culture) is actually published — null otherwise, since an unpublished item has no live URL.
+    /// know the item's parent or location, and where consistency with <see cref="BuildContentItem(IPublishedContent, string?)"/>
+    /// matters: a model calling <c>get_content_by_route</c> and <c>get_umbraco_content</c> for the same
+    /// item should see the same property representation either way.
     /// </summary>
+    /// <remarks>
+    /// Fetches the item from the published cache in <b>preview</b> mode
+    /// (<c>IPublishedCache.GetById(bool preview, Guid contentId)</c> with <c>preview: true</c>), which resolves the
+    /// same friendly, nested property values (media/content pickers, blocks) as the non-preview overload
+    /// — and, unlike the non-preview default, is populated for any saved content regardless of publish
+    /// state (Umbraco's nucache covers drafts too). <see cref="UmbracoContentItem.Url"/> is still nulled
+    /// out unless the item (and requested culture) is actually published, since preview-fetching alone
+    /// doesn't mean there's a live URL. Falls back to raw stored property values, with a breadcrumb/parent
+    /// resolved via <see cref="IContentService.GetAncestors(IContent)"/> instead, only for the rare case
+    /// where the item isn't in the nucache at all yet.
+    /// </remarks>
     /// <param name="content">The draft content item.</param>
-    /// <param name="contentService">Used to resolve ancestors for the breadcrumb and parent info.</param>
-    /// <param name="umbracoContextAccessor">Used to resolve a live URL when the item is published.</param>
+    /// <param name="contentService">Used to resolve ancestors for the breadcrumb/parent info in the fallback path.</param>
+    /// <param name="umbracoContextAccessor">Used to resolve the item from the published cache in preview mode.</param>
     /// <param name="culture">Optional culture for variant content.</param>
     /// <returns>A fully populated content item, enriched with breadcrumb/parent/URL where resolvable.</returns>
     public static UmbracoContentItem BuildEnrichedContentItem(
@@ -102,6 +112,20 @@ internal static class ContentToolHelpers
         IUmbracoContextAccessor umbracoContextAccessor,
         string? culture = null)
     {
+        IPublishedContent? previewContent = umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext)
+            ? umbracoContext.Content?.GetById(true, content.Key)
+            : null;
+
+        if (previewContent is not null)
+        {
+            var isPublished = culture is null ? content.Published : content.IsCulturePublished(culture);
+            var item = BuildContentItem(previewContent, culture);
+            return isPublished ? item : item with { Url = null };
+        }
+
+        // Fallback: the item isn't in the nucache yet (e.g. created moments ago and the cache hasn't
+        // caught up). Raw stored values, but the breadcrumb/parent still come from the business layer
+        // rather than being omitted, since IContentService.GetAncestors doesn't depend on the cache.
         var properties = ExtractDraftProperties(content, culture);
 
         var ancestors = contentService.GetAncestors(content).OrderBy(a => a.Level).ToList();
@@ -114,17 +138,11 @@ internal static class ContentToolHelpers
         pathParts.Add(content.GetCultureName(culture) ?? content.Name ?? string.Empty);
         var breadcrumb = string.Join(" > ", pathParts);
 
-        string? url = null;
-        if (umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext))
-        {
-            url = umbracoContext.Content?.GetById(content.Key)?.Url(culture);
-        }
-
         return new UmbracoContentItem(
             content.Key,
             content.GetCultureName(culture) ?? content.Name ?? string.Empty,
             content.ContentType.Alias,
-            url,
+            null,
             content.CreateDate,
             content.UpdateDate,
             content.Level,

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/CreateUmbracoContentTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/CreateUmbracoContentTool.cs
@@ -95,6 +95,11 @@ public class CreateUmbracoContentTool(
             ContentToolHelpers.BuildContentItem(attempt.Result.Content, args.Culture),
             null);
     }
+
+    /// <inheritdoc />
+    protected override string? DescribeInvocation(CreateUmbracoContentArgs args)
+        => $"Create a new '{args.ContentTypeAlias}' content item named '{args.Name}'" +
+           (args.ParentKey is { } parentKey ? $" under parent {parentKey}." : " at the root.");
 }
 
 /// <summary>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/CreateUmbracoContentTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/CreateUmbracoContentTool.cs
@@ -1,0 +1,106 @@
+using System.ComponentModel;
+using System.Text.Json;
+
+using Umbraco.AI.Core.Tools.Scopes;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.AI.Core.Tools.Umbraco;
+
+/// <summary>
+/// Arguments for the CreateUmbracoContent tool.
+/// </summary>
+public record CreateUmbracoContentArgs(
+    [property: Description("The unique key (GUID) of the parent content item, or omit/null to create at the root.")]
+    Guid? ParentKey,
+
+    [property: Description("The alias of the content type to create (e.g., 'blogPost'). Use get_content_type_schema to discover valid aliases and their property schemas first.")]
+    string ContentTypeAlias,
+
+    [property: Description("The name of the new content item.")]
+    string Name,
+
+    [property: Description("Optional simple/scalar property values, keyed by property alias (e.g., text, number, date, toggle, dropdown, single pickers). NOT suitable for Block List, Block Grid, or other structured properties — use add_umbraco_content_item after creation for those instead. Call get_content_type_schema first to see each property's expected value shape.")]
+    Dictionary<string, JsonElement>? PropertyValues,
+
+    [property: Description("Optional culture code for variant content (e.g., 'en-US', 'da-DK'). Omit for invariant content.")]
+    string? Culture = null);
+
+/// <summary>
+/// Tool that creates a new Umbraco content item as a draft (unpublished). Use publish_umbraco_content
+/// afterward to make it live.
+/// </summary>
+[AITool("create_umbraco_content", "Create Umbraco Content", ScopeId = ContentWriteScope.ScopeId, IsDestructive = true)]
+public class CreateUmbracoContentTool(
+    IContentEditingService contentEditingService,
+    IContentTypeService contentTypeService,
+    IUmbracoWriteAuthorizer authorizer)
+    : AIToolBase<CreateUmbracoContentArgs>
+{
+    /// <inheritdoc />
+    public override string Description =>
+        "Creates a new Umbraco content item as a draft (not published). Returns the created item's key, " +
+        "which you'll need for further edits, add_umbraco_content_item calls, or publish_umbraco_content. " +
+        "Call get_content_type_schema first to discover the content type's valid property aliases and value " +
+        "shapes. Only simple/scalar property values can be set here — for Block List, Block Grid, or other " +
+        "structured properties, create the item first (with or without other property values) and then use " +
+        "add_umbraco_content_item to populate them.";
+
+    /// <inheritdoc />
+    protected override async Task<object> ExecuteAsync(CreateUmbracoContentArgs args, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(args.ContentTypeAlias))
+        {
+            return new CreateUmbracoContentResult(false, null, "Content type alias cannot be empty.");
+        }
+
+        if (string.IsNullOrWhiteSpace(args.Name))
+        {
+            return new CreateUmbracoContentResult(false, null, "Name cannot be empty.");
+        }
+
+        var authResult = await authorizer.AuthorizeContentAsync(ActionNew.ActionLetter, args.ParentKey);
+        if (!authResult.IsAuthorized)
+        {
+            return new CreateUmbracoContentResult(false, null, authResult.Message);
+        }
+
+        var contentType = contentTypeService.Get(args.ContentTypeAlias);
+        if (contentType is null)
+        {
+            return new CreateUmbracoContentResult(false, null, $"Content type '{args.ContentTypeAlias}' was not found.");
+        }
+
+        var properties = (args.PropertyValues ?? [])
+            .Select(kvp => new PropertyValueModel { Alias = kvp.Key, Value = kvp.Value, Culture = args.Culture })
+            .ToList();
+
+        var createModel = new ContentCreateModel
+        {
+            ContentTypeKey = contentType.Key,
+            ParentKey = args.ParentKey,
+            Properties = properties,
+            Variants = [new VariantModel { Name = args.Name, Culture = args.Culture }],
+        };
+
+        var attempt = await contentEditingService.CreateAsync(createModel, authResult.UserKey!.Value);
+        if (!attempt.Success || attempt.Result.Content is null)
+        {
+            return new CreateUmbracoContentResult(false, null, attempt.Status.ToMessage());
+        }
+
+        return new CreateUmbracoContentResult(
+            true,
+            ContentToolHelpers.BuildContentItem(attempt.Result.Content, args.Culture),
+            null);
+    }
+}
+
+/// <summary>
+/// Result of the create Umbraco content tool.
+/// </summary>
+public record CreateUmbracoContentResult(
+    bool Success,
+    UmbracoContentItem? Content,
+    string? Message);

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/CreateUmbracoMediaTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/CreateUmbracoMediaTool.cs
@@ -1,0 +1,95 @@
+using System.ComponentModel;
+using System.Text.Json;
+
+using Umbraco.AI.Core.Tools.Scopes;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.AI.Core.Tools.Umbraco;
+
+/// <summary>
+/// Arguments for the CreateUmbracoMedia tool.
+/// </summary>
+public record CreateUmbracoMediaArgs(
+    [property: Description("The unique key (GUID) of the parent media folder/item, or omit/null to create at the root.")]
+    Guid? ParentKey,
+
+    [property: Description("The alias of the media type to create (e.g., 'image', 'file', 'folder'). Use get_content_type_schema to discover valid aliases and their property schemas first.")]
+    string MediaTypeAlias,
+
+    [property: Description("The name of the new media item.")]
+    string Name,
+
+    [property: Description("Optional simple/scalar property values, keyed by property alias. Call get_content_type_schema first to see each property's expected value shape.")]
+    Dictionary<string, JsonElement>? PropertyValues);
+
+/// <summary>
+/// Tool that creates a new Umbraco media item (e.g. a folder, or a file/image record — note this does
+/// not upload binary file content; it creates the media item's metadata).
+/// </summary>
+[AITool("create_umbraco_media", "Create Umbraco Media", ScopeId = MediaWriteScope.ScopeId, IsDestructive = true)]
+public class CreateUmbracoMediaTool(
+    IMediaEditingService mediaEditingService,
+    IMediaTypeService mediaTypeService,
+    IUmbracoWriteAuthorizer authorizer)
+    : AIToolBase<CreateUmbracoMediaArgs>
+{
+    /// <inheritdoc />
+    public override string Description =>
+        "Creates a new Umbraco media item (e.g. a folder). Returns the created item's key. Call " +
+        "get_content_type_schema first to discover the media type's valid property aliases and value shapes.";
+
+    /// <inheritdoc />
+    protected override async Task<object> ExecuteAsync(CreateUmbracoMediaArgs args, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(args.MediaTypeAlias))
+        {
+            return new CreateUmbracoMediaResult(false, null, "Media type alias cannot be empty.");
+        }
+
+        if (string.IsNullOrWhiteSpace(args.Name))
+        {
+            return new CreateUmbracoMediaResult(false, null, "Name cannot be empty.");
+        }
+
+        var authResult = await authorizer.AuthorizeMediaAsync(args.ParentKey);
+        if (!authResult.IsAuthorized)
+        {
+            return new CreateUmbracoMediaResult(false, null, authResult.Message);
+        }
+
+        var mediaType = mediaTypeService.Get(args.MediaTypeAlias);
+        if (mediaType is null)
+        {
+            return new CreateUmbracoMediaResult(false, null, $"Media type '{args.MediaTypeAlias}' was not found.");
+        }
+
+        var properties = (args.PropertyValues ?? [])
+            .Select(kvp => new PropertyValueModel { Alias = kvp.Key, Value = kvp.Value })
+            .ToList();
+
+        var createModel = new MediaCreateModel
+        {
+            ContentTypeKey = mediaType.Key,
+            ParentKey = args.ParentKey,
+            Properties = properties,
+            Variants = [new VariantModel { Name = args.Name }],
+        };
+
+        var attempt = await mediaEditingService.CreateAsync(createModel, authResult.UserKey!.Value);
+        if (!attempt.Success || attempt.Result.Content is null)
+        {
+            return new CreateUmbracoMediaResult(false, null, attempt.Status.ToMessage());
+        }
+
+        return new CreateUmbracoMediaResult(true, ContentToolHelpers.BuildMediaItem(attempt.Result.Content), null);
+    }
+}
+
+/// <summary>
+/// Result of the create Umbraco media tool.
+/// </summary>
+public record CreateUmbracoMediaResult(
+    bool Success,
+    UmbracoMediaItem? Media,
+    string? Message);

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/CreateUmbracoMediaTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/CreateUmbracoMediaTool.cs
@@ -84,6 +84,11 @@ public class CreateUmbracoMediaTool(
 
         return new CreateUmbracoMediaResult(true, ContentToolHelpers.BuildMediaItem(attempt.Result.Content), null);
     }
+
+    /// <inheritdoc />
+    protected override string? DescribeInvocation(CreateUmbracoMediaArgs args)
+        => $"Create a new '{args.MediaTypeAlias}' media item named '{args.Name}'" +
+           (args.ParentKey is { } parentKey ? $" under parent {parentKey}." : " at the root.");
 }
 
 /// <summary>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/DeleteUmbracoContentTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/DeleteUmbracoContentTool.cs
@@ -1,0 +1,58 @@
+using System.ComponentModel;
+
+using Umbraco.AI.Core.Tools.Scopes;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.AI.Core.Tools.Umbraco;
+
+/// <summary>
+/// Arguments for the DeleteUmbracoContent tool.
+/// </summary>
+public record DeleteUmbracoContentArgs(
+    [property: Description("The unique key (GUID) of the content item to delete.")]
+    Guid Key);
+
+/// <summary>
+/// Tool that moves a content item to the recycle bin (soft delete, reversible) — the same behavior as
+/// a human editor's Delete action. Does not permanently remove the item.
+/// </summary>
+[AITool("delete_umbraco_content", "Delete Umbraco Content", ScopeId = ContentWriteScope.ScopeId, IsDestructive = true)]
+public class DeleteUmbracoContentTool(
+    IContentEditingService contentEditingService,
+    IUmbracoWriteAuthorizer authorizer)
+    : AIToolBase<DeleteUmbracoContentArgs>
+{
+    /// <inheritdoc />
+    public override string Description =>
+        "Moves an Umbraco content item to the recycle bin. This is a soft delete (reversible), the same " +
+        "as a human editor's Delete action — it does not permanently remove the item.";
+
+    /// <inheritdoc />
+    protected override async Task<object> ExecuteAsync(DeleteUmbracoContentArgs args, CancellationToken cancellationToken = default)
+    {
+        if (args.Key == Guid.Empty)
+        {
+            return new DeleteUmbracoContentResult(false, "Content key cannot be empty.");
+        }
+
+        var authResult = await authorizer.AuthorizeContentAsync(ActionDelete.ActionLetter, args.Key);
+        if (!authResult.IsAuthorized)
+        {
+            return new DeleteUmbracoContentResult(false, authResult.Message);
+        }
+
+        var attempt = await contentEditingService.MoveToRecycleBinAsync(args.Key, authResult.UserKey!.Value);
+
+        return attempt.Success
+            ? new DeleteUmbracoContentResult(true, null)
+            : new DeleteUmbracoContentResult(false, attempt.Status.ToMessage());
+    }
+}
+
+/// <summary>
+/// Result of the delete Umbraco content tool.
+/// </summary>
+public record DeleteUmbracoContentResult(
+    bool Success,
+    string? Message);

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/DeleteUmbracoContentTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/DeleteUmbracoContentTool.cs
@@ -48,6 +48,10 @@ public class DeleteUmbracoContentTool(
             ? new DeleteUmbracoContentResult(true, null)
             : new DeleteUmbracoContentResult(false, attempt.Status.ToMessage());
     }
+
+    /// <inheritdoc />
+    protected override string? DescribeInvocation(DeleteUmbracoContentArgs args)
+        => "Move this content item to the recycle bin (reversible).";
 }
 
 /// <summary>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/DeleteUmbracoContentTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/DeleteUmbracoContentTool.cs
@@ -20,6 +20,7 @@ public record DeleteUmbracoContentArgs(
 [AITool("delete_umbraco_content", "Delete Umbraco Content", ScopeId = ContentWriteScope.ScopeId, IsDestructive = true)]
 public class DeleteUmbracoContentTool(
     IContentEditingService contentEditingService,
+    IContentService contentService,
     IUmbracoWriteAuthorizer authorizer)
     : AIToolBase<DeleteUmbracoContentArgs>
 {
@@ -52,6 +53,10 @@ public class DeleteUmbracoContentTool(
     /// <inheritdoc />
     protected override string? DescribeInvocation(DeleteUmbracoContentArgs args)
         => "Move this content item to the recycle bin (reversible).";
+
+    /// <inheritdoc />
+    protected override string? ConfirmationPhrase(DeleteUmbracoContentArgs args)
+        => contentService.GetById(args.Key)?.Name;
 }
 
 /// <summary>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/DeleteUmbracoMediaTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/DeleteUmbracoMediaTool.cs
@@ -1,0 +1,57 @@
+using System.ComponentModel;
+
+using Umbraco.AI.Core.Tools.Scopes;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.AI.Core.Tools.Umbraco;
+
+/// <summary>
+/// Arguments for the DeleteUmbracoMedia tool.
+/// </summary>
+public record DeleteUmbracoMediaArgs(
+    [property: Description("The unique key (GUID) of the media item to delete.")]
+    Guid Key);
+
+/// <summary>
+/// Tool that moves a media item to the recycle bin (soft delete, reversible) — the same behavior as
+/// a human editor's Delete action. Does not permanently remove the item.
+/// </summary>
+[AITool("delete_umbraco_media", "Delete Umbraco Media", ScopeId = MediaWriteScope.ScopeId, IsDestructive = true)]
+public class DeleteUmbracoMediaTool(
+    IMediaEditingService mediaEditingService,
+    IUmbracoWriteAuthorizer authorizer)
+    : AIToolBase<DeleteUmbracoMediaArgs>
+{
+    /// <inheritdoc />
+    public override string Description =>
+        "Moves an Umbraco media item to the recycle bin. This is a soft delete (reversible), the same " +
+        "as a human editor's Delete action — it does not permanently remove the item.";
+
+    /// <inheritdoc />
+    protected override async Task<object> ExecuteAsync(DeleteUmbracoMediaArgs args, CancellationToken cancellationToken = default)
+    {
+        if (args.Key == Guid.Empty)
+        {
+            return new DeleteUmbracoMediaResult(false, "Media key cannot be empty.");
+        }
+
+        var authResult = await authorizer.AuthorizeMediaAsync(args.Key);
+        if (!authResult.IsAuthorized)
+        {
+            return new DeleteUmbracoMediaResult(false, authResult.Message);
+        }
+
+        var attempt = await mediaEditingService.MoveToRecycleBinAsync(args.Key, authResult.UserKey!.Value);
+
+        return attempt.Success
+            ? new DeleteUmbracoMediaResult(true, null)
+            : new DeleteUmbracoMediaResult(false, attempt.Status.ToMessage());
+    }
+}
+
+/// <summary>
+/// Result of the delete Umbraco media tool.
+/// </summary>
+public record DeleteUmbracoMediaResult(
+    bool Success,
+    string? Message);

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/DeleteUmbracoMediaTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/DeleteUmbracoMediaTool.cs
@@ -47,6 +47,10 @@ public class DeleteUmbracoMediaTool(
             ? new DeleteUmbracoMediaResult(true, null)
             : new DeleteUmbracoMediaResult(false, attempt.Status.ToMessage());
     }
+
+    /// <inheritdoc />
+    protected override string? DescribeInvocation(DeleteUmbracoMediaArgs args)
+        => "Move this media item to the recycle bin (reversible).";
 }
 
 /// <summary>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/DeleteUmbracoMediaTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/DeleteUmbracoMediaTool.cs
@@ -19,6 +19,7 @@ public record DeleteUmbracoMediaArgs(
 [AITool("delete_umbraco_media", "Delete Umbraco Media", ScopeId = MediaWriteScope.ScopeId, IsDestructive = true)]
 public class DeleteUmbracoMediaTool(
     IMediaEditingService mediaEditingService,
+    IMediaService mediaService,
     IUmbracoWriteAuthorizer authorizer)
     : AIToolBase<DeleteUmbracoMediaArgs>
 {
@@ -51,6 +52,10 @@ public class DeleteUmbracoMediaTool(
     /// <inheritdoc />
     protected override string? DescribeInvocation(DeleteUmbracoMediaArgs args)
         => "Move this media item to the recycle bin (reversible).";
+
+    /// <inheritdoc />
+    protected override string? ConfirmationPhrase(DeleteUmbracoMediaArgs args)
+        => mediaService.GetById(args.Key)?.Name;
 }
 
 /// <summary>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/GetUmbracoContentTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/GetUmbracoContentTool.cs
@@ -1,8 +1,7 @@
 using System.ComponentModel;
 
 using Umbraco.AI.Core.Tools.Scopes;
-using Umbraco.Cms.Core.Models.PublishedContent;
-using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.AI.Core.Tools.Umbraco;
 
@@ -19,58 +18,40 @@ public record GetUmbracoContentArgs(
     string? Culture = null);
 
 /// <summary>
-/// Tool that retrieves a published content item from Umbraco by its key, including all property values.
+/// Tool that retrieves a content item from Umbraco by its key, including all property values. Reads
+/// from the business/draft layer via <see cref="IContentEditingService"/> — the same layer the write
+/// tools operate on — so it works for unpublished drafts as well as published content, and returns the
+/// same <see cref="UmbracoContentItem"/> shape those tools do (raw stored property values, no resolved
+/// URL, no friendly breadcrumb/parent).
 /// </summary>
-/// <remarks>
-/// Uses Umbraco's friendly extension methods (Parent(), Children(), Url(), Ancestors())
-/// which internally resolve the navigation query service for optimised tree traversal.
-/// </remarks>
 [AITool("get_umbraco_content", "Get Umbraco Content", ScopeId = ContentReadScope.ScopeId)]
-public class GetUmbracoContentTool : AIToolBase<GetUmbracoContentArgs>
+public class GetUmbracoContentTool(IContentEditingService contentEditingService) : AIToolBase<GetUmbracoContentArgs>
 {
-    private readonly IUmbracoContextAccessor _umbracoContextAccessor;
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="GetUmbracoContentTool"/>.
-    /// </summary>
-    /// <param name="umbracoContextAccessor">The Umbraco context accessor.</param>
-    public GetUmbracoContentTool(IUmbracoContextAccessor umbracoContextAccessor)
-    {
-        _umbracoContextAccessor = umbracoContextAccessor;
-    }
-
     /// <inheritdoc />
     public override string Description =>
-        "Retrieves a published content item from Umbraco by its unique key (GUID). " +
-        "Returns the full content including all property values, content type, URL, parent info, and metadata. " +
-        "Use IDs from search_umbraco results to fetch detailed content. " +
-        "For variant (multilingual) content, specify the culture code to get culture-specific values.";
+        "Retrieves a content item from Umbraco by its unique key (GUID), whether it's published or still " +
+        "an unpublished draft. Returns the full content including all property values, content type, and " +
+        "metadata — the same shape create_umbraco_content/update_umbraco_content return. Use IDs from " +
+        "search_umbraco results to fetch detailed content. For variant (multilingual) content, specify " +
+        "the culture code to get culture-specific values.";
 
     /// <inheritdoc />
-    protected override Task<object> ExecuteAsync(GetUmbracoContentArgs args, CancellationToken cancellationToken = default)
+    protected override async Task<object> ExecuteAsync(GetUmbracoContentArgs args, CancellationToken cancellationToken = default)
     {
         if (args.Key == Guid.Empty)
         {
-            return Task.FromResult<object>(new GetUmbracoContentResult(
-                false, null, "Content key cannot be empty."));
+            return new GetUmbracoContentResult(false, null, "Content key cannot be empty.");
         }
 
-        if (!_umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext))
-        {
-            return Task.FromResult<object>(new GetUmbracoContentResult(
-                false, null, "Umbraco context is not available."));
-        }
-
-        var content = umbracoContext.Content?.GetById(args.Key);
+        var content = await contentEditingService.GetAsync(args.Key);
         if (content is null)
         {
-            return Task.FromResult<object>(new GetUmbracoContentResult(
-                false, null, $"Content with key '{args.Key}' was not found or is not published."));
+            return new GetUmbracoContentResult(false, null, $"Content with key '{args.Key}' was not found.");
         }
 
         var item = ContentToolHelpers.BuildContentItem(content, args.Culture);
 
-        return Task.FromResult<object>(new GetUmbracoContentResult(true, item, null));
+        return new GetUmbracoContentResult(true, item, null);
     }
 }
 
@@ -86,17 +67,23 @@ public record GetUmbracoContentResult(
     string? Message);
 
 /// <summary>
-/// A published content item with full property values.
+/// A content item with full property values. Shared across read and write tools, so its richness
+/// depends on which <c>ContentToolHelpers.BuildContentItem</c> overload built it: from the published
+/// cache (<c>get_content_by_route</c>, resource types) it carries a resolved <see cref="Url"/>, a
+/// friendly breadcrumb <see cref="Path"/>, and <see cref="Parent"/> info; from the business/draft layer
+/// (<c>get_umbraco_content</c>, <c>create_umbraco_content</c>, <c>update_umbraco_content</c>) — which
+/// works for unpublished drafts too — <see cref="Url"/> and <see cref="Parent"/> are always null and
+/// <see cref="Path"/> is the raw comma-separated id path.
 /// </summary>
 /// <param name="Key">The unique key of the content item.</param>
 /// <param name="Name">The name of the content item.</param>
 /// <param name="ContentType">The content type alias.</param>
-/// <param name="Url">The public URL of the content item.</param>
+/// <param name="Url">The public URL of the content item, if resolved from the published cache.</param>
 /// <param name="CreateDate">The creation date.</param>
 /// <param name="UpdateDate">The last update date.</param>
 /// <param name="Level">The depth level in the content tree.</param>
-/// <param name="Path">The breadcrumb path (e.g., "Home > About > Team").</param>
-/// <param name="Parent">The parent content item info, if any.</param>
+/// <param name="Path">The breadcrumb path (e.g., "Home > About > Team") or the raw id path, depending on source.</param>
+/// <param name="Parent">The parent content item info, if resolved from the published cache.</param>
 /// <param name="Properties">The content properties with their values.</param>
 public record UmbracoContentItem(
     Guid Key,

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/GetUmbracoContentTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/GetUmbracoContentTool.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 
 using Umbraco.AI.Core.Tools.Scopes;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Web;
 
 namespace Umbraco.AI.Core.Tools.Umbraco;
 
@@ -20,20 +21,24 @@ public record GetUmbracoContentArgs(
 /// <summary>
 /// Tool that retrieves a content item from Umbraco by its key, including all property values. Reads
 /// from the business/draft layer via <see cref="IContentEditingService"/> — the same layer the write
-/// tools operate on — so it works for unpublished drafts as well as published content, and returns the
-/// same <see cref="UmbracoContentItem"/> shape those tools do (raw stored property values, no resolved
-/// URL, no friendly breadcrumb/parent).
+/// tools operate on — so it works for unpublished drafts as well as published content. Unlike the write
+/// tools' own confirmation payloads, this enriches the result with a real breadcrumb, parent info, and
+/// (when published) a live URL, since a lookup tool's caller usually doesn't already know those.
 /// </summary>
 [AITool("get_umbraco_content", "Get Umbraco Content", ScopeId = ContentReadScope.ScopeId)]
-public class GetUmbracoContentTool(IContentEditingService contentEditingService) : AIToolBase<GetUmbracoContentArgs>
+public class GetUmbracoContentTool(
+    IContentEditingService contentEditingService,
+    IContentService contentService,
+    IUmbracoContextAccessor umbracoContextAccessor)
+    : AIToolBase<GetUmbracoContentArgs>
 {
     /// <inheritdoc />
     public override string Description =>
         "Retrieves a content item from Umbraco by its unique key (GUID), whether it's published or still " +
-        "an unpublished draft. Returns the full content including all property values, content type, and " +
-        "metadata — the same shape create_umbraco_content/update_umbraco_content return. Use IDs from " +
-        "search_umbraco results to fetch detailed content. For variant (multilingual) content, specify " +
-        "the culture code to get culture-specific values.";
+        "an unpublished draft. Returns the full content including all property values, content type, " +
+        "breadcrumb path, and parent info. When the item (and requested culture) is published, also " +
+        "includes its live URL. Use IDs from search_umbraco results to fetch detailed content. For " +
+        "variant (multilingual) content, specify the culture code to get culture-specific values.";
 
     /// <inheritdoc />
     protected override async Task<object> ExecuteAsync(GetUmbracoContentArgs args, CancellationToken cancellationToken = default)
@@ -49,7 +54,7 @@ public class GetUmbracoContentTool(IContentEditingService contentEditingService)
             return new GetUmbracoContentResult(false, null, $"Content with key '{args.Key}' was not found.");
         }
 
-        var item = ContentToolHelpers.BuildContentItem(content, args.Culture);
+        var item = ContentToolHelpers.BuildEnrichedContentItem(content, contentService, umbracoContextAccessor, args.Culture);
 
         return new GetUmbracoContentResult(true, item, null);
     }
@@ -68,22 +73,23 @@ public record GetUmbracoContentResult(
 
 /// <summary>
 /// A content item with full property values. Shared across read and write tools, so its richness
-/// depends on which <c>ContentToolHelpers.BuildContentItem</c> overload built it: from the published
-/// cache (<c>get_content_by_route</c>, resource types) it carries a resolved <see cref="Url"/>, a
-/// friendly breadcrumb <see cref="Path"/>, and <see cref="Parent"/> info; from the business/draft layer
-/// (<c>get_umbraco_content</c>, <c>create_umbraco_content</c>, <c>update_umbraco_content</c>) — which
-/// works for unpublished drafts too — <see cref="Url"/> and <see cref="Parent"/> are always null and
-/// <see cref="Path"/> is the raw comma-separated id path.
+/// depends on which <c>ContentToolHelpers</c> builder method built it: <c>BuildContentItem(IPublishedContent)</c>
+/// (<c>get_content_by_route</c>, resource types) and <c>BuildEnrichedContentItem</c> (<c>get_umbraco_content</c>)
+/// both resolve a friendly breadcrumb <see cref="Path"/> and <see cref="Parent"/> info, with <see cref="Url"/>
+/// populated when the item is published; the lean <c>BuildContentItem(IContent)</c> used by write tools'
+/// own confirmation payloads (<c>create_umbraco_content</c>, <c>update_umbraco_content</c>) — whose caller
+/// already knows the parent it just passed in — always leaves <see cref="Url"/> and <see cref="Parent"/>
+/// null and <see cref="Path"/> as the raw comma-separated id path.
 /// </summary>
 /// <param name="Key">The unique key of the content item.</param>
 /// <param name="Name">The name of the content item.</param>
 /// <param name="ContentType">The content type alias.</param>
-/// <param name="Url">The public URL of the content item, if resolved from the published cache.</param>
+/// <param name="Url">The public URL of the content item, if it's published.</param>
 /// <param name="CreateDate">The creation date.</param>
 /// <param name="UpdateDate">The last update date.</param>
 /// <param name="Level">The depth level in the content tree.</param>
 /// <param name="Path">The breadcrumb path (e.g., "Home > About > Team") or the raw id path, depending on source.</param>
-/// <param name="Parent">The parent content item info, if resolved from the published cache.</param>
+/// <param name="Parent">The parent content item info, if resolved.</param>
 /// <param name="Properties">The content properties with their values.</param>
 public record UmbracoContentItem(
     Guid Key,

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/MoveUmbracoContentItemTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/MoveUmbracoContentItemTool.cs
@@ -68,6 +68,13 @@ public class MoveUmbracoContentItemTool(
 
         return new MoveUmbracoContentItemResult(outcome.Success, outcome.Message);
     }
+
+    /// <inheritdoc />
+    protected override string? DescribeInvocation(MoveUmbracoContentItemArgs args)
+    {
+        var propertyAlias = args.Path.LastOrDefault()?.Alias;
+        return propertyAlias is null ? null : $"Move an item within '{propertyAlias}' to position {args.Position}.";
+    }
 }
 
 /// <summary>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/MoveUmbracoContentItemTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/MoveUmbracoContentItemTool.cs
@@ -1,0 +1,78 @@
+using System.ComponentModel;
+using System.Text.Json.Nodes;
+
+using Umbraco.AI.Core.PropertyValueOperations;
+using Umbraco.AI.Core.Tools.Scopes;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.AI.Core.Tools.Umbraco;
+
+/// <summary>
+/// Arguments for the MoveUmbracoContentItem tool.
+/// </summary>
+public record MoveUmbracoContentItemArgs(
+    [property: Description("The unique key (GUID) of the content item to update.")]
+    Guid Key,
+
+    [property: Description("Path identifying the collection-shaped property (Block List, Block Grid, etc.) the item lives in, potentially nested inside another block. Must start and end with an alias segment.")]
+    IReadOnlyList<UmbracoPropertyPathSegmentArg> Path,
+
+    [property: Description("The key of the block/item to move, as returned by add_umbraco_content_item or seen in the property's current value.")]
+    Guid BlockKey,
+
+    [property: Description("The new zero-based position for the item within the collection.")]
+    int Position,
+
+    [property: Description("Optional culture code (e.g., 'en-US') when the content item varies by culture.")]
+    string? Culture = null,
+
+    [property: Description("Optional segment identifier when the content item is segmented.")]
+    string? Segment = null);
+
+/// <summary>
+/// Tool that moves an item to a new position within a collection-shaped content property (Block List,
+/// Block Grid, etc.).
+/// </summary>
+[AITool("move_umbraco_content_item", "Move Umbraco Content Item", ScopeId = ContentWriteScope.ScopeId, IsDestructive = true)]
+public class MoveUmbracoContentItemTool(
+    IContentEditingService contentEditingService,
+    IAIPropertyValueDispatcher dispatcher,
+    IUmbracoWriteAuthorizer authorizer)
+    : AIToolBase<MoveUmbracoContentItemArgs>
+{
+    /// <inheritdoc />
+    public override string Description =>
+        "Moves an item to a new position within a collection-shaped content property (Block List, Block " +
+        "Grid, etc.). Persists immediately as a draft — call publish_umbraco_content afterward to make the change live.";
+
+    /// <inheritdoc />
+    protected override async Task<object> ExecuteAsync(MoveUmbracoContentItemArgs args, CancellationToken cancellationToken = default)
+    {
+        var dispatchArgs = new JsonObject
+        {
+            ["blockKey"] = args.BlockKey.ToString(),
+            ["position"] = args.Position,
+        };
+
+        var outcome = await ContentPropertyValueOperationHelper.ExecuteAsync(
+            authorizer,
+            contentEditingService,
+            dispatcher,
+            args.Key,
+            args.Path,
+            AIPropertyOperation.MoveItem,
+            dispatchArgs,
+            args.Culture,
+            args.Segment,
+            cancellationToken);
+
+        return new MoveUmbracoContentItemResult(outcome.Success, outcome.Message);
+    }
+}
+
+/// <summary>
+/// Result of the move Umbraco content item tool.
+/// </summary>
+public record MoveUmbracoContentItemResult(
+    bool Success,
+    string? Message);

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/PublishUmbracoContentTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/PublishUmbracoContentTool.cs
@@ -53,6 +53,12 @@ public class PublishUmbracoContentTool(
             ? new PublishUmbracoContentResult(true, null)
             : new PublishUmbracoContentResult(false, attempt.Status.ToMessage());
     }
+
+    /// <inheritdoc />
+    protected override string? DescribeInvocation(PublishUmbracoContentArgs args)
+        => args.Culture is null
+            ? "Publish this content item, making it live."
+            : $"Publish the '{args.Culture}' culture of this content item, making it live.";
 }
 
 /// <summary>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/PublishUmbracoContentTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/PublishUmbracoContentTool.cs
@@ -23,6 +23,7 @@ public record PublishUmbracoContentArgs(
 [AITool("publish_umbraco_content", "Publish Umbraco Content", ScopeId = ContentWriteScope.ScopeId, IsDestructive = true)]
 public class PublishUmbracoContentTool(
     IContentPublishingService contentPublishingService,
+    IContentService contentService,
     IUmbracoWriteAuthorizer authorizer)
     : AIToolBase<PublishUmbracoContentArgs>
 {
@@ -59,6 +60,10 @@ public class PublishUmbracoContentTool(
         => args.Culture is null
             ? "Publish this content item, making it live."
             : $"Publish the '{args.Culture}' culture of this content item, making it live.";
+
+    /// <inheritdoc />
+    protected override string? ConfirmationPhrase(PublishUmbracoContentArgs args)
+        => contentService.GetById(args.Key)?.Name;
 }
 
 /// <summary>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/PublishUmbracoContentTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/PublishUmbracoContentTool.cs
@@ -1,0 +1,63 @@
+using System.ComponentModel;
+
+using Umbraco.AI.Core.Tools.Scopes;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Models.ContentPublishing;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.AI.Core.Tools.Umbraco;
+
+/// <summary>
+/// Arguments for the PublishUmbracoContent tool.
+/// </summary>
+public record PublishUmbracoContentArgs(
+    [property: Description("The unique key (GUID) of the content item to publish.")]
+    Guid Key,
+
+    [property: Description("Optional culture code to publish (e.g., 'en-US', 'da-DK'). Omit for invariant content.")]
+    string? Culture = null);
+
+/// <summary>
+/// Tool that publishes a content item, making it live immediately.
+/// </summary>
+[AITool("publish_umbraco_content", "Publish Umbraco Content", ScopeId = ContentWriteScope.ScopeId, IsDestructive = true)]
+public class PublishUmbracoContentTool(
+    IContentPublishingService contentPublishingService,
+    IUmbracoWriteAuthorizer authorizer)
+    : AIToolBase<PublishUmbracoContentArgs>
+{
+    /// <inheritdoc />
+    public override string Description =>
+        "Publishes a draft Umbraco content item, making it live immediately. " +
+        "Omit Culture for invariant content, or specify a culture code to publish that variant.";
+
+    /// <inheritdoc />
+    protected override async Task<object> ExecuteAsync(PublishUmbracoContentArgs args, CancellationToken cancellationToken = default)
+    {
+        if (args.Key == Guid.Empty)
+        {
+            return new PublishUmbracoContentResult(false, "Content key cannot be empty.");
+        }
+
+        var cultures = args.Culture is not null ? new[] { args.Culture } : null;
+        var authResult = await authorizer.AuthorizeContentAsync(ActionPublish.ActionLetter, args.Key, cultures);
+        if (!authResult.IsAuthorized)
+        {
+            return new PublishUmbracoContentResult(false, authResult.Message);
+        }
+
+        var schedule = new CulturePublishScheduleModel { Culture = args.Culture, Schedule = null };
+        var attempt = await contentPublishingService.PublishAsync(args.Key, [schedule], authResult.UserKey!.Value);
+
+        return attempt.Success
+            ? new PublishUmbracoContentResult(true, null)
+            : new PublishUmbracoContentResult(false, attempt.Status.ToMessage());
+    }
+}
+
+/// <summary>
+/// Result of the publish Umbraco content tool.
+/// </summary>
+public record PublishUmbracoContentResult(
+    bool Success,
+    string? Message);

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/RemoveUmbracoContentItemTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/RemoveUmbracoContentItemTool.cs
@@ -61,6 +61,13 @@ public class RemoveUmbracoContentItemTool(
 
         return new RemoveUmbracoContentItemResult(outcome.Success, outcome.Message);
     }
+
+    /// <inheritdoc />
+    protected override string? DescribeInvocation(RemoveUmbracoContentItemArgs args)
+    {
+        var propertyAlias = args.Path.LastOrDefault()?.Alias;
+        return propertyAlias is null ? null : $"Remove an item from '{propertyAlias}'.";
+    }
 }
 
 /// <summary>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/RemoveUmbracoContentItemTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/RemoveUmbracoContentItemTool.cs
@@ -1,0 +1,71 @@
+using System.ComponentModel;
+using System.Text.Json.Nodes;
+
+using Umbraco.AI.Core.PropertyValueOperations;
+using Umbraco.AI.Core.Tools.Scopes;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.AI.Core.Tools.Umbraco;
+
+/// <summary>
+/// Arguments for the RemoveUmbracoContentItem tool.
+/// </summary>
+public record RemoveUmbracoContentItemArgs(
+    [property: Description("The unique key (GUID) of the content item to update.")]
+    Guid Key,
+
+    [property: Description("Path identifying the collection-shaped property (Block List, Block Grid, etc.) the item lives in, potentially nested inside another block. Must start and end with an alias segment.")]
+    IReadOnlyList<UmbracoPropertyPathSegmentArg> Path,
+
+    [property: Description("The key of the block/item to remove, as returned by add_umbraco_content_item or seen in the property's current value.")]
+    Guid BlockKey,
+
+    [property: Description("Optional culture code (e.g., 'en-US') when the content item varies by culture.")]
+    string? Culture = null,
+
+    [property: Description("Optional segment identifier when the content item is segmented.")]
+    string? Segment = null);
+
+/// <summary>
+/// Tool that removes an item from a collection-shaped content property (Block List, Block Grid, etc.)
+/// by its key.
+/// </summary>
+[AITool("remove_umbraco_content_item", "Remove Umbraco Content Item", ScopeId = ContentWriteScope.ScopeId, IsDestructive = true)]
+public class RemoveUmbracoContentItemTool(
+    IContentEditingService contentEditingService,
+    IAIPropertyValueDispatcher dispatcher,
+    IUmbracoWriteAuthorizer authorizer)
+    : AIToolBase<RemoveUmbracoContentItemArgs>
+{
+    /// <inheritdoc />
+    public override string Description =>
+        "Removes an item from a collection-shaped content property (Block List, Block Grid, etc.) by its " +
+        "key. Persists immediately as a draft — call publish_umbraco_content afterward to make the change live.";
+
+    /// <inheritdoc />
+    protected override async Task<object> ExecuteAsync(RemoveUmbracoContentItemArgs args, CancellationToken cancellationToken = default)
+    {
+        var dispatchArgs = new JsonObject { ["blockKey"] = args.BlockKey.ToString() };
+
+        var outcome = await ContentPropertyValueOperationHelper.ExecuteAsync(
+            authorizer,
+            contentEditingService,
+            dispatcher,
+            args.Key,
+            args.Path,
+            AIPropertyOperation.RemoveItem,
+            dispatchArgs,
+            args.Culture,
+            args.Segment,
+            cancellationToken);
+
+        return new RemoveUmbracoContentItemResult(outcome.Success, outcome.Message);
+    }
+}
+
+/// <summary>
+/// Result of the remove Umbraco content item tool.
+/// </summary>
+public record RemoveUmbracoContentItemResult(
+    bool Success,
+    string? Message);

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/SetUmbracoContentValueTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/SetUmbracoContentValueTool.cs
@@ -67,6 +67,19 @@ public class SetUmbracoContentValueTool(
 
         return new SetUmbracoContentValueResult(outcome.Success, outcome.Message);
     }
+
+    /// <inheritdoc />
+    protected override string? DescribeInvocation(SetUmbracoContentValueArgs args)
+    {
+        var propertyAlias = args.Path.LastOrDefault()?.Alias;
+        return propertyAlias is null ? null : $"Set '{propertyAlias}' to {FormatValuePreview(args.Value)}.";
+    }
+
+    private static string FormatValuePreview(JsonElement value)
+    {
+        var raw = value.ValueKind == JsonValueKind.String ? $"'{value.GetString()}'" : value.GetRawText();
+        return raw.Length > 80 ? string.Concat(raw.AsSpan(0, 77), "...") : raw;
+    }
 }
 
 /// <summary>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/SetUmbracoContentValueTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/SetUmbracoContentValueTool.cs
@@ -1,0 +1,77 @@
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+using Umbraco.AI.Core.PropertyValueOperations;
+using Umbraco.AI.Core.Tools.Scopes;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.AI.Core.Tools.Umbraco;
+
+/// <summary>
+/// Arguments for the SetUmbracoContentValue tool.
+/// </summary>
+public record SetUmbracoContentValueArgs(
+    [property: Description("The unique key (GUID) of the content item to update.")]
+    Guid Key,
+
+    [property: Description("Path identifying the property to set, potentially nested inside a block. An array alternating property-alias segments and block-key segments, e.g. [{\"alias\":\"heroImage\"}] for a root property, or [{\"alias\":\"contentBlocks\"},{\"blockKey\":\"<guid>\"},{\"alias\":\"innerText\"}] for a property inside a block. Must start and end with an alias segment.")]
+    IReadOnlyList<UmbracoPropertyPathSegmentArg> Path,
+
+    [property: Description("The value to set, in the shape get_content_type_schema/get_property_value_schema describes for this property.")]
+    JsonElement Value,
+
+    [property: Description("Optional culture code (e.g., 'en-US') when the content item varies by culture.")]
+    string? Culture = null,
+
+    [property: Description("Optional segment identifier when the content item is segmented.")]
+    string? Segment = null);
+
+/// <summary>
+/// Tool that sets a content property's value directly (a full replacement), including properties
+/// nested inside blocks. Unlike update_umbraco_content's PropertyValues, this works for structured
+/// properties too — Block List, Block Grid, and rich text — by reusing the same value engine the
+/// backoffice UI's own block-editing tools use.
+/// </summary>
+[AITool("set_umbraco_content_value", "Set Umbraco Content Value", ScopeId = ContentWriteScope.ScopeId, IsDestructive = true)]
+public class SetUmbracoContentValueTool(
+    IContentEditingService contentEditingService,
+    IAIPropertyValueDispatcher dispatcher,
+    IUmbracoWriteAuthorizer authorizer)
+    : AIToolBase<SetUmbracoContentValueArgs>
+{
+    /// <inheritdoc />
+    public override string Description =>
+        "Sets a content property's value directly, including properties nested inside blocks (identify " +
+        "the nesting via Path). Works for Block List, Block Grid, and rich text, unlike " +
+        "update_umbraco_content's simple PropertyValues. Call get_content_type_schema first to see the " +
+        "expected value shape. Persists immediately as a draft — call publish_umbraco_content afterward " +
+        "to make the change live.";
+
+    /// <inheritdoc />
+    protected override async Task<object> ExecuteAsync(SetUmbracoContentValueArgs args, CancellationToken cancellationToken = default)
+    {
+        var dispatchArgs = new JsonObject { ["value"] = JsonNode.Parse(args.Value.GetRawText()) };
+
+        var outcome = await ContentPropertyValueOperationHelper.ExecuteAsync(
+            authorizer,
+            contentEditingService,
+            dispatcher,
+            args.Key,
+            args.Path,
+            AIPropertyOperation.SetValue,
+            dispatchArgs,
+            args.Culture,
+            args.Segment,
+            cancellationToken);
+
+        return new SetUmbracoContentValueResult(outcome.Success, outcome.Message);
+    }
+}
+
+/// <summary>
+/// Result of the set Umbraco content value tool.
+/// </summary>
+public record SetUmbracoContentValueResult(
+    bool Success,
+    string? Message);

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/UmbracoWriteAuthorizer.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/UmbracoWriteAuthorizer.cs
@@ -1,0 +1,98 @@
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Security.Authorization;
+
+namespace Umbraco.AI.Core.Tools.Umbraco;
+
+/// <summary>
+/// Result of an authorization check performed by <see cref="IUmbracoWriteAuthorizer"/>.
+/// </summary>
+public sealed record UmbracoWriteAuthorizationResult(bool IsAuthorized, Guid? UserKey, string? Message)
+{
+    public static UmbracoWriteAuthorizationResult Denied(string message) => new(false, null, message);
+
+    public static UmbracoWriteAuthorizationResult Allowed(Guid userKey) => new(true, userKey, null);
+}
+
+/// <summary>
+/// Authorizes a backend AI tool's write operation against the acting backoffice user's real CMS
+/// permissions, mirroring the check the CMS's own Management API controllers perform.
+/// </summary>
+/// <remarks>
+/// <c>IContentEditingService</c>, <c>IContentPublishingService</c>, <c>IMediaEditingService</c>, and
+/// the property-value dispatcher behind the frontend's block-editing tools do NOT self-authorize —
+/// they trust the caller. The CMS's own controllers check permissions themselves, via
+/// <see cref="IContentPermissionAuthorizer"/>/<see cref="IMediaPermissionAuthorizer"/>, before ever
+/// calling those services. Every backend write tool in this folder must call this authorizer first,
+/// or it silently bypasses per-user start-node/permission restrictions.
+/// </remarks>
+public interface IUmbracoWriteAuthorizer
+{
+    /// <summary>
+    /// Authorizes a content write action. Pass <paramref name="contentKey"/> as <c>null</c> to check
+    /// root-level access (e.g. creating an item with no parent).
+    /// </summary>
+    Task<UmbracoWriteAuthorizationResult> AuthorizeContentAsync(
+        string actionLetter, Guid? contentKey, IEnumerable<string>? cultures = null);
+
+    /// <summary>
+    /// Authorizes a media write action. Pass <paramref name="mediaKey"/> as <c>null</c> to check
+    /// root-level access. Media has no action-letter dimension — Umbraco's media permissions only
+    /// distinguish root/recycle-bin/specific-key access, not the kind of operation being performed.
+    /// </summary>
+    Task<UmbracoWriteAuthorizationResult> AuthorizeMediaAsync(Guid? mediaKey);
+}
+
+/// <inheritdoc cref="IUmbracoWriteAuthorizer"/>
+public sealed class UmbracoWriteAuthorizer(
+    IContentPermissionAuthorizer contentPermissionAuthorizer,
+    IMediaPermissionAuthorizer mediaPermissionAuthorizer,
+    IBackOfficeSecurityAccessor backOfficeSecurityAccessor) : IUmbracoWriteAuthorizer
+{
+    public async Task<UmbracoWriteAuthorizationResult> AuthorizeContentAsync(
+        string actionLetter, Guid? contentKey, IEnumerable<string>? cultures = null)
+    {
+        var user = backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser;
+        if (user is null)
+        {
+            return UmbracoWriteAuthorizationResult.Denied("No authenticated backoffice user context is available.");
+        }
+
+        var permissions = new HashSet<string> { actionLetter };
+        var denied = contentKey is null
+            ? await contentPermissionAuthorizer.IsDeniedAtRootLevelAsync(user, permissions)
+            : await contentPermissionAuthorizer.IsDeniedAsync(user, contentKey.Value, actionLetter);
+        if (denied)
+        {
+            return UmbracoWriteAuthorizationResult.Denied("You do not have permission to perform this action on this content item.");
+        }
+
+        var cultureSet = cultures as ISet<string> ?? cultures?.ToHashSet();
+        if (cultureSet is { Count: > 0 })
+        {
+            var culturesDenied = await contentPermissionAuthorizer.IsDeniedForCultures(user, cultureSet);
+            if (culturesDenied)
+            {
+                return UmbracoWriteAuthorizationResult.Denied("You do not have access to one or more of the requested cultures.");
+            }
+        }
+
+        return UmbracoWriteAuthorizationResult.Allowed(user.Key);
+    }
+
+    public async Task<UmbracoWriteAuthorizationResult> AuthorizeMediaAsync(Guid? mediaKey)
+    {
+        var user = backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser;
+        if (user is null)
+        {
+            return UmbracoWriteAuthorizationResult.Denied("No authenticated backoffice user context is available.");
+        }
+
+        var denied = mediaKey is null
+            ? await mediaPermissionAuthorizer.IsDeniedAtRootLevelAsync(user)
+            : await mediaPermissionAuthorizer.IsDeniedAsync(user, mediaKey.Value);
+
+        return denied
+            ? UmbracoWriteAuthorizationResult.Denied("You do not have permission to perform this action on this media item.")
+            : UmbracoWriteAuthorizationResult.Allowed(user.Key);
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/UnpublishUmbracoContentTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/UnpublishUmbracoContentTool.cs
@@ -1,0 +1,62 @@
+using System.ComponentModel;
+
+using Umbraco.AI.Core.Tools.Scopes;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.AI.Core.Tools.Umbraco;
+
+/// <summary>
+/// Arguments for the UnpublishUmbracoContent tool.
+/// </summary>
+public record UnpublishUmbracoContentArgs(
+    [property: Description("The unique key (GUID) of the content item to unpublish.")]
+    Guid Key,
+
+    [property: Description("Optional culture code to unpublish (e.g., 'en-US', 'da-DK'). Omit to unpublish all cultures (or the whole item, for invariant content).")]
+    string? Culture = null);
+
+/// <summary>
+/// Tool that unpublishes a content item, taking it offline.
+/// </summary>
+[AITool("unpublish_umbraco_content", "Unpublish Umbraco Content", ScopeId = ContentWriteScope.ScopeId, IsDestructive = true)]
+public class UnpublishUmbracoContentTool(
+    IContentPublishingService contentPublishingService,
+    IUmbracoWriteAuthorizer authorizer)
+    : AIToolBase<UnpublishUmbracoContentArgs>
+{
+    /// <inheritdoc />
+    public override string Description =>
+        "Unpublishes an Umbraco content item, taking it offline. Omit Culture to unpublish all cultures " +
+        "(or the whole item, for invariant content), or specify a culture code to unpublish just that variant.";
+
+    /// <inheritdoc />
+    protected override async Task<object> ExecuteAsync(UnpublishUmbracoContentArgs args, CancellationToken cancellationToken = default)
+    {
+        if (args.Key == Guid.Empty)
+        {
+            return new UnpublishUmbracoContentResult(false, "Content key cannot be empty.");
+        }
+
+        var cultures = args.Culture is not null ? new[] { args.Culture } : null;
+        var authResult = await authorizer.AuthorizeContentAsync(ActionUnpublish.ActionLetter, args.Key, cultures);
+        if (!authResult.IsAuthorized)
+        {
+            return new UnpublishUmbracoContentResult(false, authResult.Message);
+        }
+
+        var cultureSet = args.Culture is not null ? new HashSet<string> { args.Culture } : null;
+        var attempt = await contentPublishingService.UnpublishAsync(args.Key, cultureSet, authResult.UserKey!.Value);
+
+        return attempt.Success
+            ? new UnpublishUmbracoContentResult(true, null)
+            : new UnpublishUmbracoContentResult(false, attempt.Result.ToMessage());
+    }
+}
+
+/// <summary>
+/// Result of the unpublish Umbraco content tool.
+/// </summary>
+public record UnpublishUmbracoContentResult(
+    bool Success,
+    string? Message);

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/UnpublishUmbracoContentTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/UnpublishUmbracoContentTool.cs
@@ -52,6 +52,12 @@ public class UnpublishUmbracoContentTool(
             ? new UnpublishUmbracoContentResult(true, null)
             : new UnpublishUmbracoContentResult(false, attempt.Result.ToMessage());
     }
+
+    /// <inheritdoc />
+    protected override string? DescribeInvocation(UnpublishUmbracoContentArgs args)
+        => args.Culture is null
+            ? "Unpublish this content item, taking it offline."
+            : $"Unpublish the '{args.Culture}' culture of this content item.";
 }
 
 /// <summary>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/UnpublishUmbracoContentTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/UnpublishUmbracoContentTool.cs
@@ -22,6 +22,7 @@ public record UnpublishUmbracoContentArgs(
 [AITool("unpublish_umbraco_content", "Unpublish Umbraco Content", ScopeId = ContentWriteScope.ScopeId, IsDestructive = true)]
 public class UnpublishUmbracoContentTool(
     IContentPublishingService contentPublishingService,
+    IContentService contentService,
     IUmbracoWriteAuthorizer authorizer)
     : AIToolBase<UnpublishUmbracoContentArgs>
 {
@@ -58,6 +59,10 @@ public class UnpublishUmbracoContentTool(
         => args.Culture is null
             ? "Unpublish this content item, taking it offline."
             : $"Unpublish the '{args.Culture}' culture of this content item.";
+
+    /// <inheritdoc />
+    protected override string? ConfirmationPhrase(UnpublishUmbracoContentArgs args)
+        => contentService.GetById(args.Key)?.Name;
 }
 
 /// <summary>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/UpdateUmbracoContentTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/UpdateUmbracoContentTool.cs
@@ -98,6 +98,23 @@ public class UpdateUmbracoContentTool(
             ContentToolHelpers.BuildContentItem(attempt.Result.Content, args.Culture),
             null);
     }
+
+    /// <inheritdoc />
+    protected override string? DescribeInvocation(UpdateUmbracoContentArgs args)
+    {
+        var parts = new List<string>();
+        if (args.Name is not null)
+        {
+            parts.Add($"rename it to '{args.Name}'");
+        }
+
+        if (args.PropertyValues is { Count: > 0 })
+        {
+            parts.Add($"update {string.Join(", ", args.PropertyValues.Keys.Select(a => $"'{a}'"))}");
+        }
+
+        return parts.Count == 0 ? null : $"Update this content item: {string.Join(" and ", parts)}.";
+    }
 }
 
 /// <summary>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/UpdateUmbracoContentTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/UpdateUmbracoContentTool.cs
@@ -1,0 +1,109 @@
+using System.ComponentModel;
+using System.Text.Json;
+
+using Umbraco.AI.Core.Tools.Scopes;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.AI.Core.Tools.Umbraco;
+
+/// <summary>
+/// Arguments for the UpdateUmbracoContent tool.
+/// </summary>
+public record UpdateUmbracoContentArgs(
+    [property: Description("The unique key (GUID) of the content item to update.")]
+    Guid Key,
+
+    [property: Description("Optional new name for the content item. Omit to leave the name unchanged.")]
+    string? Name,
+
+    [property: Description("Optional simple/scalar property values to set, keyed by property alias. NOT suitable for Block List, Block Grid, or other structured properties — use set_umbraco_content_value/add_umbraco_content_item for those instead. Call get_content_type_schema first to see each property's expected value shape.")]
+    Dictionary<string, JsonElement>? PropertyValues,
+
+    [property: Description("Optional culture code for variant content (e.g., 'en-US', 'da-DK'). Omit for invariant content.")]
+    string? Culture = null);
+
+/// <summary>
+/// Tool that updates an existing Umbraco content item's name and/or simple property values. Changes
+/// are saved as a draft — call publish_umbraco_content afterward to make them live.
+/// </summary>
+[AITool("update_umbraco_content", "Update Umbraco Content", ScopeId = ContentWriteScope.ScopeId, IsDestructive = true)]
+public class UpdateUmbracoContentTool(
+    IContentEditingService contentEditingService,
+    IUmbracoWriteAuthorizer authorizer)
+    : AIToolBase<UpdateUmbracoContentArgs>
+{
+    /// <inheritdoc />
+    public override string Description =>
+        "Updates an existing Umbraco content item's name and/or simple property values, saving as a draft. " +
+        "Call publish_umbraco_content afterward to make the changes live. Call get_content_type_schema first " +
+        "to discover valid property aliases and value shapes. Only simple/scalar property values can be set " +
+        "here — for Block List, Block Grid, or other structured properties, use set_umbraco_content_value or " +
+        "add_umbraco_content_item instead.";
+
+    /// <inheritdoc />
+    protected override async Task<object> ExecuteAsync(UpdateUmbracoContentArgs args, CancellationToken cancellationToken = default)
+    {
+        if (args.Key == Guid.Empty)
+        {
+            return new UpdateUmbracoContentResult(false, null, "Content key cannot be empty.");
+        }
+
+        var authResult = await authorizer.AuthorizeContentAsync(ActionUpdate.ActionLetter, args.Key);
+        if (!authResult.IsAuthorized)
+        {
+            return new UpdateUmbracoContentResult(false, null, authResult.Message);
+        }
+
+        var properties = (args.PropertyValues ?? [])
+            .Select(kvp => new PropertyValueModel { Alias = kvp.Key, Value = kvp.Value, Culture = args.Culture })
+            .ToList();
+
+        // ContentEditingServiceBase.TryGetAndValidateContentType requires at least one Variants entry
+        // matching the content type's own variance regardless of what Properties contains — an invariant
+        // type demands one with Culture/Segment both null, otherwise the whole update fails with
+        // ContentTypeCultureVarianceMismatch even when Name isn't changing. When no new name was given,
+        // load the current one so the Variants entry is still present without altering it.
+        string variantName;
+        if (args.Name is not null)
+        {
+            variantName = args.Name;
+        }
+        else
+        {
+            var existing = await contentEditingService.GetAsync(args.Key);
+            if (existing is null)
+            {
+                return new UpdateUmbracoContentResult(false, null, $"Content with key '{args.Key}' was not found.");
+            }
+
+            variantName = existing.Name ?? string.Empty;
+        }
+
+        var updateModel = new ContentUpdateModel
+        {
+            Properties = properties,
+            Variants = [new VariantModel { Name = variantName, Culture = args.Culture }],
+        };
+
+        var attempt = await contentEditingService.UpdateAsync(args.Key, updateModel, authResult.UserKey!.Value);
+        if (!attempt.Success || attempt.Result.Content is null)
+        {
+            return new UpdateUmbracoContentResult(false, null, attempt.Status.ToMessage());
+        }
+
+        return new UpdateUmbracoContentResult(
+            true,
+            ContentToolHelpers.BuildContentItem(attempt.Result.Content, args.Culture),
+            null);
+    }
+}
+
+/// <summary>
+/// Result of the update Umbraco content tool.
+/// </summary>
+public record UpdateUmbracoContentResult(
+    bool Success,
+    UmbracoContentItem? Content,
+    string? Message);

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/UpdateUmbracoMediaTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/UpdateUmbracoMediaTool.cs
@@ -87,6 +87,23 @@ public class UpdateUmbracoMediaTool(
 
         return new UpdateUmbracoMediaResult(true, ContentToolHelpers.BuildMediaItem(attempt.Result.Content), null);
     }
+
+    /// <inheritdoc />
+    protected override string? DescribeInvocation(UpdateUmbracoMediaArgs args)
+    {
+        var parts = new List<string>();
+        if (args.Name is not null)
+        {
+            parts.Add($"rename it to '{args.Name}'");
+        }
+
+        if (args.PropertyValues is { Count: > 0 })
+        {
+            parts.Add($"update {string.Join(", ", args.PropertyValues.Keys.Select(a => $"'{a}'"))}");
+        }
+
+        return parts.Count == 0 ? null : $"Update this media item: {string.Join(" and ", parts)}.";
+    }
 }
 
 /// <summary>

--- a/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/UpdateUmbracoMediaTool.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Tools/Umbraco/UpdateUmbracoMediaTool.cs
@@ -1,0 +1,98 @@
+using System.ComponentModel;
+using System.Text.Json;
+
+using Umbraco.AI.Core.Tools.Scopes;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.AI.Core.Tools.Umbraco;
+
+/// <summary>
+/// Arguments for the UpdateUmbracoMedia tool.
+/// </summary>
+public record UpdateUmbracoMediaArgs(
+    [property: Description("The unique key (GUID) of the media item to update.")]
+    Guid Key,
+
+    [property: Description("Optional new name for the media item. Omit to leave the name unchanged.")]
+    string? Name,
+
+    [property: Description("Optional simple/scalar property values to set, keyed by property alias. Call get_content_type_schema first to see each property's expected value shape.")]
+    Dictionary<string, JsonElement>? PropertyValues);
+
+/// <summary>
+/// Tool that updates an existing Umbraco media item's name and/or property values.
+/// </summary>
+[AITool("update_umbraco_media", "Update Umbraco Media", ScopeId = MediaWriteScope.ScopeId, IsDestructive = true)]
+public class UpdateUmbracoMediaTool(
+    IMediaEditingService mediaEditingService,
+    IUmbracoWriteAuthorizer authorizer)
+    : AIToolBase<UpdateUmbracoMediaArgs>
+{
+    /// <inheritdoc />
+    public override string Description =>
+        "Updates an existing Umbraco media item's name and/or simple property values. Call " +
+        "get_content_type_schema first to discover valid property aliases and value shapes.";
+
+    /// <inheritdoc />
+    protected override async Task<object> ExecuteAsync(UpdateUmbracoMediaArgs args, CancellationToken cancellationToken = default)
+    {
+        if (args.Key == Guid.Empty)
+        {
+            return new UpdateUmbracoMediaResult(false, null, "Media key cannot be empty.");
+        }
+
+        var authResult = await authorizer.AuthorizeMediaAsync(args.Key);
+        if (!authResult.IsAuthorized)
+        {
+            return new UpdateUmbracoMediaResult(false, null, authResult.Message);
+        }
+
+        var properties = (args.PropertyValues ?? [])
+            .Select(kvp => new PropertyValueModel { Alias = kvp.Key, Value = kvp.Value })
+            .ToList();
+
+        // ContentEditingServiceBase.TryGetAndValidateContentType (shared with media) requires at least
+        // one Variants entry matching the media type's own variance regardless of what Properties
+        // contains — an invariant type demands one with Culture/Segment both null, otherwise the whole
+        // update fails with ContentTypeCultureVarianceMismatch even when Name isn't changing. When no new
+        // name was given, load the current one so the Variants entry is still present without altering it.
+        string variantName;
+        if (args.Name is not null)
+        {
+            variantName = args.Name;
+        }
+        else
+        {
+            var existing = await mediaEditingService.GetAsync(args.Key);
+            if (existing is null)
+            {
+                return new UpdateUmbracoMediaResult(false, null, $"Media with key '{args.Key}' was not found.");
+            }
+
+            variantName = existing.Name ?? string.Empty;
+        }
+
+        var updateModel = new MediaUpdateModel
+        {
+            Properties = properties,
+            Variants = [new VariantModel { Name = variantName }],
+        };
+
+        var attempt = await mediaEditingService.UpdateAsync(args.Key, updateModel, authResult.UserKey!.Value);
+        if (!attempt.Success || attempt.Result.Content is null)
+        {
+            return new UpdateUmbracoMediaResult(false, null, attempt.Status.ToMessage());
+        }
+
+        return new UpdateUmbracoMediaResult(true, ContentToolHelpers.BuildMediaItem(attempt.Result.Content), null);
+    }
+}
+
+/// <summary>
+/// Result of the update Umbraco media tool.
+/// </summary>
+public record UpdateUmbracoMediaResult(
+    bool Success,
+    UmbracoMediaItem? Media,
+    string? Message);

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/AddUmbracoContentItemToolTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/AddUmbracoContentItemToolTests.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+using Moq;
+using Shouldly;
+using Umbraco.AI.Core.PropertyValueOperations;
+using Umbraco.AI.Core.Tools;
+using Umbraco.AI.Core.Tools.Umbraco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.AI.Tests.Unit.Tools.Umbraco;
+
+public class AddUmbracoContentItemToolTests
+{
+    private readonly Mock<IContentEditingService> _contentEditingServiceMock = new();
+    private readonly Mock<IAIPropertyValueDispatcher> _dispatcherMock = new();
+    private readonly Mock<IUmbracoWriteAuthorizer> _authorizerMock = new();
+    private readonly IAITool _tool;
+
+    public AddUmbracoContentItemToolTests()
+    {
+        _tool = new AddUmbracoContentItemTool(_contentEditingServiceMock.Object, _dispatcherMock.Object, _authorizerMock.Object);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HappyPath_SerializesAddItemArgsAsCamelCaseAndReturnsNewBlockKey()
+    {
+        var key = Guid.NewGuid();
+        var userKey = Guid.NewGuid();
+        var newBlockKey = Guid.NewGuid();
+        var contentTypeMock = new Mock<ISimpleContentType>();
+        contentTypeMock.Setup(x => x.Key).Returns(Guid.NewGuid());
+        var contentMock = new Mock<IContent>();
+        contentMock.Setup(x => x.ContentType).Returns(contentTypeMock.Object);
+
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionUpdate.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _contentEditingServiceMock.Setup(x => x.GetAsync(key)).ReturnsAsync(contentMock.Object);
+
+        AIPropertyValueDispatchRequest? captured = null;
+        _dispatcherMock
+            .Setup(x => x.DispatchAsync(It.IsAny<AIPropertyValueDispatchRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<AIPropertyValueDispatchRequest, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(AIPropertyValueDispatchResult.Ok(JsonNode.Parse("{}"), newBlockKey));
+        _contentEditingServiceMock
+            .Setup(x => x.UpdateAsync(key, It.IsAny<ContentUpdateModel>(), userKey))
+            .ReturnsAsync(Attempt<ContentUpdateResult, ContentEditingOperationStatus>.Succeed(
+                ContentEditingOperationStatus.Success, new ContentUpdateResult()));
+
+        var values = new Dictionary<string, JsonElement> { ["heading"] = JsonDocument.Parse("\"Hello\"").RootElement };
+        var args = new AddUmbracoContentItemArgs(
+            key,
+            [new UmbracoPropertyPathSegmentArg("contentBlocks", null)],
+            "heroBlock",
+            values,
+            SettingsValues: null,
+            Position: 1);
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<AddUmbracoContentItemResult>();
+        typed.Success.ShouldBeTrue();
+        typed.BlockKey.ShouldBe(newBlockKey);
+
+        captured.ShouldNotBeNull();
+        captured!.Operation.ShouldBe(AIPropertyOperation.AddItem);
+        var argsObj = captured.Args.ShouldBeOfType<JsonObject>();
+        argsObj["elementType"]!.GetValue<string>().ShouldBe("heroBlock");
+        argsObj["position"]!.GetValue<int>().ShouldBe(1);
+        argsObj["values"]!["heading"]!.GetValue<string>().ShouldBe("Hello");
+        argsObj["settingsValues"].ShouldBeNull();
+    }
+
+    [Fact]
+    public void Description_ReturnsNonEmptyString()
+    {
+        var description = _tool.Description;
+
+        description.ShouldNotBeNullOrWhiteSpace();
+        description.ShouldContain("rich text");
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/ClearUmbracoContentValueToolTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/ClearUmbracoContentValueToolTests.cs
@@ -1,0 +1,71 @@
+using Moq;
+using Shouldly;
+using Umbraco.AI.Core.PropertyValueOperations;
+using Umbraco.AI.Core.Tools;
+using Umbraco.AI.Core.Tools.Umbraco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.AI.Tests.Unit.Tools.Umbraco;
+
+public class ClearUmbracoContentValueToolTests
+{
+    private readonly Mock<IContentEditingService> _contentEditingServiceMock = new();
+    private readonly Mock<IAIPropertyValueDispatcher> _dispatcherMock = new();
+    private readonly Mock<IUmbracoWriteAuthorizer> _authorizerMock = new();
+    private readonly IAITool _tool;
+
+    public ClearUmbracoContentValueToolTests()
+    {
+        _tool = new ClearUmbracoContentValueTool(_contentEditingServiceMock.Object, _dispatcherMock.Object, _authorizerMock.Object);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HappyPath_DispatchesClearValueWithNullArgs()
+    {
+        var key = Guid.NewGuid();
+        var userKey = Guid.NewGuid();
+        var contentTypeMock = new Mock<ISimpleContentType>();
+        contentTypeMock.Setup(x => x.Key).Returns(Guid.NewGuid());
+        var contentMock = new Mock<IContent>();
+        contentMock.Setup(x => x.ContentType).Returns(contentTypeMock.Object);
+
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionUpdate.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _contentEditingServiceMock.Setup(x => x.GetAsync(key)).ReturnsAsync(contentMock.Object);
+
+        AIPropertyValueDispatchRequest? captured = null;
+        _dispatcherMock
+            .Setup(x => x.DispatchAsync(It.IsAny<AIPropertyValueDispatchRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<AIPropertyValueDispatchRequest, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(AIPropertyValueDispatchResult.Ok(null));
+        _contentEditingServiceMock
+            .Setup(x => x.UpdateAsync(key, It.IsAny<ContentUpdateModel>(), userKey))
+            .ReturnsAsync(Attempt<ContentUpdateResult, ContentEditingOperationStatus>.Succeed(
+                ContentEditingOperationStatus.Success, new ContentUpdateResult()));
+
+        var args = new ClearUmbracoContentValueArgs(key, [new UmbracoPropertyPathSegmentArg("title", null)]);
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<ClearUmbracoContentValueResult>();
+        typed.Success.ShouldBeTrue();
+        captured.ShouldNotBeNull();
+        captured!.Operation.ShouldBe(AIPropertyOperation.ClearValue);
+        captured.Args.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Description_ReturnsNonEmptyString()
+    {
+        var description = _tool.Description;
+
+        description.ShouldNotBeNullOrWhiteSpace();
+        description.ShouldContain("empty");
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/ContentPropertyValueOperationHelperTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/ContentPropertyValueOperationHelperTests.cs
@@ -1,0 +1,332 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+using Moq;
+using Shouldly;
+using Umbraco.AI.Core.PropertyValueOperations;
+using Umbraco.AI.Core.Tools.Umbraco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.AI.Tests.Unit.Tools.Umbraco;
+
+public class ContentPropertyValueOperationHelperTests
+{
+    private readonly Mock<IUmbracoWriteAuthorizer> _authorizerMock = new();
+    private readonly Mock<IContentEditingService> _contentEditingServiceMock = new();
+    private readonly Mock<IAIPropertyValueDispatcher> _dispatcherMock = new();
+
+    private static readonly UmbracoPropertyPathSegmentArg RootSegment = new("contentBlocks", null);
+
+    private static Mock<IContent> CreateContentMock(Guid contentTypeKey, object? currentValue, ContentVariation variation = ContentVariation.Nothing)
+    {
+        var contentTypeMock = new Mock<ISimpleContentType>();
+        contentTypeMock.Setup(x => x.Key).Returns(contentTypeKey);
+        contentTypeMock.Setup(x => x.Variations).Returns(variation);
+
+        var contentMock = new Mock<IContent>();
+        contentMock.Setup(x => x.ContentType).Returns(contentTypeMock.Object);
+        contentMock.Setup(x => x.Name).Returns("Home");
+        contentMock.Setup(x => x.GetValue(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(), false)).Returns(currentValue);
+        return contentMock;
+    }
+
+    private Task<ContentPropertyValueOperationOutcome> ExecuteAsync(
+        Guid key,
+        IReadOnlyList<UmbracoPropertyPathSegmentArg>? path,
+        AIPropertyOperation operation = AIPropertyOperation.SetValue,
+        JsonNode? args = null,
+        string? culture = null,
+        string? segment = null)
+        => ContentPropertyValueOperationHelper.ExecuteAsync(
+            _authorizerMock.Object,
+            _contentEditingServiceMock.Object,
+            _dispatcherMock.Object,
+            key,
+            path,
+            operation,
+            args,
+            culture,
+            segment,
+            CancellationToken.None);
+
+    [Fact]
+    public async Task ExecuteAsync_WithEmptyKey_ReturnsErrorWithoutCallingAnything()
+    {
+        var result = await ExecuteAsync(Guid.Empty, [RootSegment]);
+
+        result.Success.ShouldBeFalse();
+        result.Message.ShouldContain("empty");
+        _authorizerMock.Verify(x => x.AuthorizeContentAsync(It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<IEnumerable<string>?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithNullPath_ReturnsError()
+    {
+        var result = await ExecuteAsync(Guid.NewGuid(), null);
+
+        result.Success.ShouldBeFalse();
+        result.Message.ShouldContain("Path must contain");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithEmptyPath_ReturnsError()
+    {
+        var result = await ExecuteAsync(Guid.NewGuid(), []);
+
+        result.Success.ShouldBeFalse();
+        result.Message.ShouldContain("Path must contain");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RootSegmentIsBlockKey_ReturnsError()
+    {
+        var result = await ExecuteAsync(Guid.NewGuid(), [new UmbracoPropertyPathSegmentArg(null, Guid.NewGuid())]);
+
+        result.Success.ShouldBeFalse();
+        result.Message.ShouldContain("property alias segment");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MalformedNonRootSegment_ReturnsErrorWithoutAuthorizing()
+    {
+        // Neither Alias nor BlockKey set on the second segment.
+        var result = await ExecuteAsync(Guid.NewGuid(), [RootSegment, new UmbracoPropertyPathSegmentArg(null, null)]);
+
+        result.Success.ShouldBeFalse();
+        result.Message.ShouldContain("exactly one");
+        _authorizerMock.Verify(x => x.AuthorizeContentAsync(It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<IEnumerable<string>?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AuthorizationDenied_ReturnsErrorWithoutLoadingContent()
+    {
+        var key = Guid.NewGuid();
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionUpdate.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Denied("no permission"));
+
+        var result = await ExecuteAsync(key, [RootSegment]);
+
+        result.Success.ShouldBeFalse();
+        result.Message.ShouldBe("no permission");
+        _contentEditingServiceMock.Verify(x => x.GetAsync(It.IsAny<Guid>()), Times.Never);
+        _dispatcherMock.Verify(x => x.DispatchAsync(It.IsAny<AIPropertyValueDispatchRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ContentNotFound_ReturnsError()
+    {
+        var key = Guid.NewGuid();
+        var userKey = Guid.NewGuid();
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionUpdate.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _contentEditingServiceMock.Setup(x => x.GetAsync(key)).ReturnsAsync((IContent?)null);
+
+        var result = await ExecuteAsync(key, [RootSegment]);
+
+        result.Success.ShouldBeFalse();
+        result.Message.ShouldContain("not found");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DispatcherFails_ReturnsMappedErrorWithoutPersisting()
+    {
+        var key = Guid.NewGuid();
+        var userKey = Guid.NewGuid();
+        var contentTypeKey = Guid.NewGuid();
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionUpdate.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _contentEditingServiceMock.Setup(x => x.GetAsync(key)).ReturnsAsync(CreateContentMock(contentTypeKey, null).Object);
+        _dispatcherMock
+            .Setup(x => x.DispatchAsync(It.IsAny<AIPropertyValueDispatchRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(AIPropertyValueDispatchResult.Fail(new AIPropertyValueOperationError(
+                AIPropertyValueOperationError.Codes.OperationNotSupported, "Cannot add a block to a rich-text property.")));
+
+        var result = await ExecuteAsync(key, [RootSegment]);
+
+        result.Success.ShouldBeFalse();
+        result.Message.ShouldBe("Cannot add a block to a rich-text property.");
+        _contentEditingServiceMock.Verify(
+            x => x.UpdateAsync(It.IsAny<Guid>(), It.IsAny<ContentUpdateModel>(), It.IsAny<Guid>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PersistFails_ReturnsMappedMessage()
+    {
+        var key = Guid.NewGuid();
+        var userKey = Guid.NewGuid();
+        var contentTypeKey = Guid.NewGuid();
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionUpdate.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _contentEditingServiceMock.Setup(x => x.GetAsync(key)).ReturnsAsync(CreateContentMock(contentTypeKey, null).Object);
+        _dispatcherMock
+            .Setup(x => x.DispatchAsync(It.IsAny<AIPropertyValueDispatchRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(AIPropertyValueDispatchResult.Ok(JsonValue.Create("new value")));
+        _contentEditingServiceMock
+            .Setup(x => x.UpdateAsync(key, It.IsAny<ContentUpdateModel>(), userKey))
+            .ReturnsAsync(Attempt<ContentUpdateResult, ContentEditingOperationStatus>.Fail(
+                ContentEditingOperationStatus.PropertyValidationError, new ContentUpdateResult()));
+
+        var result = await ExecuteAsync(key, [RootSegment]);
+
+        result.Success.ShouldBeFalse();
+        result.Message.ShouldContain("validation");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RootValueMissing_DispatchesWithNullRootValue()
+    {
+        // Proves the "build from scratch" scenario: a property with no existing value dispatches
+        // with RootValue: null, which is exactly what the block handlers build a fresh envelope from.
+        var key = Guid.NewGuid();
+        var userKey = Guid.NewGuid();
+        var contentTypeKey = Guid.NewGuid();
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionUpdate.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _contentEditingServiceMock.Setup(x => x.GetAsync(key)).ReturnsAsync(CreateContentMock(contentTypeKey, null).Object);
+
+        AIPropertyValueDispatchRequest? captured = null;
+        var newBlockKey = Guid.NewGuid();
+        _dispatcherMock
+            .Setup(x => x.DispatchAsync(It.IsAny<AIPropertyValueDispatchRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<AIPropertyValueDispatchRequest, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(AIPropertyValueDispatchResult.Ok(JsonNode.Parse("""{"layout":{}}"""), newBlockKey));
+        _contentEditingServiceMock
+            .Setup(x => x.UpdateAsync(key, It.IsAny<ContentUpdateModel>(), userKey))
+            .ReturnsAsync(Attempt<ContentUpdateResult, ContentEditingOperationStatus>.Succeed(
+                ContentEditingOperationStatus.Success, new ContentUpdateResult()));
+
+        var result = await ExecuteAsync(key, [RootSegment], AIPropertyOperation.AddItem);
+
+        result.Success.ShouldBeTrue();
+        result.BlockKey.ShouldBe(newBlockKey);
+        captured.ShouldNotBeNull();
+        captured!.RootValue.ShouldBeNull();
+        captured.DocumentMetadata.ContentTypeKey.ShouldBe(contentTypeKey);
+        captured.DocumentMetadata.Variants.Single().ShouldBe(AIVariantId.Invariant);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PlainTextScalarCurrentValue_DoesNotThrowParsingAsJson()
+    {
+        // A text box's stored value is a plain, non-JSON string — must not throw when converted
+        // to a JsonNode for the dispatcher.
+        var key = Guid.NewGuid();
+        var userKey = Guid.NewGuid();
+        var contentTypeKey = Guid.NewGuid();
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionUpdate.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _contentEditingServiceMock
+            .Setup(x => x.GetAsync(key))
+            .ReturnsAsync(CreateContentMock(contentTypeKey, "Hello World").Object);
+
+        AIPropertyValueDispatchRequest? captured = null;
+        _dispatcherMock
+            .Setup(x => x.DispatchAsync(It.IsAny<AIPropertyValueDispatchRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<AIPropertyValueDispatchRequest, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(AIPropertyValueDispatchResult.Ok(JsonValue.Create("Hello World, updated")));
+        _contentEditingServiceMock
+            .Setup(x => x.UpdateAsync(key, It.IsAny<ContentUpdateModel>(), userKey))
+            .ReturnsAsync(Attempt<ContentUpdateResult, ContentEditingOperationStatus>.Succeed(
+                ContentEditingOperationStatus.Success, new ContentUpdateResult()));
+
+        var result = await ExecuteAsync(key, [RootSegment]);
+
+        result.Success.ShouldBeTrue();
+        captured.ShouldNotBeNull();
+        captured!.RootValue!.GetValue<string>().ShouldBe("Hello World");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NestedBlockPath_ParsesJsonEnvelopeAndBuildsCorrectSegments()
+    {
+        var key = Guid.NewGuid();
+        var userKey = Guid.NewGuid();
+        var contentTypeKey = Guid.NewGuid();
+        var blockKey = Guid.NewGuid();
+        const string envelope = """{"layout":{"Umbraco.BlockList":[]},"contentData":[],"settingsData":[],"expose":[]}""";
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionUpdate.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _contentEditingServiceMock
+            .Setup(x => x.GetAsync(key))
+            .ReturnsAsync(CreateContentMock(contentTypeKey, envelope).Object);
+
+        AIPropertyValueDispatchRequest? captured = null;
+        _dispatcherMock
+            .Setup(x => x.DispatchAsync(It.IsAny<AIPropertyValueDispatchRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<AIPropertyValueDispatchRequest, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(AIPropertyValueDispatchResult.Ok(JsonNode.Parse(envelope)));
+        _contentEditingServiceMock
+            .Setup(x => x.UpdateAsync(key, It.IsAny<ContentUpdateModel>(), userKey))
+            .ReturnsAsync(Attempt<ContentUpdateResult, ContentEditingOperationStatus>.Succeed(
+                ContentEditingOperationStatus.Success, new ContentUpdateResult()));
+
+        var path = new UmbracoPropertyPathSegmentArg[]
+        {
+            new("contentBlocks", null),
+            new(null, blockKey),
+            new("innerText", null),
+        };
+
+        var result = await ExecuteAsync(key, path);
+
+        result.Success.ShouldBeTrue();
+        captured.ShouldNotBeNull();
+        captured!.Path.Count.ShouldBe(3);
+        captured.Path[0].ShouldBeOfType<AIPropertyPathSegment.PropertyAliasSegment>();
+        var blockSegment = captured.Path[1].ShouldBeOfType<AIPropertyPathSegment.BlockKeySegment>();
+        blockSegment.BlockKey.ShouldBe(blockKey);
+        captured.Path[2].ShouldBeOfType<AIPropertyPathSegment.PropertyAliasSegment>();
+        captured.RootValue.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HappyPath_PersistsSinglePropertyValueModelForRootAlias()
+    {
+        var key = Guid.NewGuid();
+        var userKey = Guid.NewGuid();
+        var contentTypeKey = Guid.NewGuid();
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionUpdate.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _contentEditingServiceMock.Setup(x => x.GetAsync(key)).ReturnsAsync(CreateContentMock(contentTypeKey, null).Object);
+        _dispatcherMock
+            .Setup(x => x.DispatchAsync(It.IsAny<AIPropertyValueDispatchRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(AIPropertyValueDispatchResult.Ok(JsonValue.Create("new value")));
+
+        ContentUpdateModel? capturedModel = null;
+        _contentEditingServiceMock
+            .Setup(x => x.UpdateAsync(key, It.IsAny<ContentUpdateModel>(), userKey))
+            .Callback<Guid, ContentUpdateModel, Guid>((_, model, _) => capturedModel = model)
+            .ReturnsAsync(Attempt<ContentUpdateResult, ContentEditingOperationStatus>.Succeed(
+                ContentEditingOperationStatus.Success, new ContentUpdateResult()));
+
+        var result = await ExecuteAsync(key, [RootSegment]);
+
+        result.Success.ShouldBeTrue();
+        capturedModel.ShouldNotBeNull();
+        var property = capturedModel!.Properties.Single();
+        property.Alias.ShouldBe("contentBlocks");
+        ((JsonElement)property.Value!).GetString().ShouldBe("new value");
+
+        // ContentEditingServiceBase.TryGetAndValidateContentType requires an invariant Variants entry
+        // (Culture and Segment both null) for an invariant content type, or the whole update fails with
+        // ContentTypeCultureVarianceMismatch even though nothing here changes the name.
+        var variant = capturedModel.Variants.Single();
+        variant.Name.ShouldBe("Home");
+        variant.Culture.ShouldBeNull();
+        variant.Segment.ShouldBeNull();
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/CreateUmbracoContentToolTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/CreateUmbracoContentToolTests.cs
@@ -1,0 +1,190 @@
+using System.Text.Json;
+
+using Moq;
+using Shouldly;
+using Umbraco.AI.Core.Tools;
+using Umbraco.AI.Core.Tools.Umbraco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.AI.Tests.Unit.Tools.Umbraco;
+
+public class CreateUmbracoContentToolTests
+{
+    private readonly Mock<IContentEditingService> _contentEditingServiceMock;
+    private readonly Mock<IContentTypeService> _contentTypeServiceMock;
+    private readonly Mock<IUmbracoWriteAuthorizer> _authorizerMock;
+    private readonly IAITool _tool;
+
+    public CreateUmbracoContentToolTests()
+    {
+        _contentEditingServiceMock = new Mock<IContentEditingService>();
+        _contentTypeServiceMock = new Mock<IContentTypeService>();
+        _authorizerMock = new Mock<IUmbracoWriteAuthorizer>();
+        _tool = new CreateUmbracoContentTool(
+            _contentEditingServiceMock.Object,
+            _contentTypeServiceMock.Object,
+            _authorizerMock.Object);
+    }
+
+    private static Mock<IContent> CreateContentMock(Guid key, string name, string contentTypeAlias)
+    {
+        var contentTypeMock = new Mock<ISimpleContentType>();
+        contentTypeMock.Setup(x => x.Alias).Returns(contentTypeAlias);
+
+        var contentMock = new Mock<IContent>();
+        contentMock.Setup(x => x.Key).Returns(key);
+        contentMock.Setup(x => x.Name).Returns(name);
+        contentMock.Setup(x => x.GetCultureName(It.IsAny<string?>())).Returns((string?)null);
+        contentMock.Setup(x => x.ContentType).Returns(contentTypeMock.Object);
+        contentMock.Setup(x => x.CreateDate).Returns(DateTime.UtcNow);
+        contentMock.Setup(x => x.UpdateDate).Returns(DateTime.UtcNow);
+        contentMock.Setup(x => x.Level).Returns(1);
+        contentMock.Setup(x => x.Path).Returns("-1,1234");
+        contentMock.Setup(x => x.Properties).Returns(new PropertyCollection());
+        return contentMock;
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithEmptyContentTypeAlias_ReturnsError()
+    {
+        var args = new CreateUmbracoContentArgs(null, "", "Home", null);
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<CreateUmbracoContentResult>();
+        typed.Success.ShouldBeFalse();
+        typed.Message.ShouldContain("empty");
+        _authorizerMock.Verify(x => x.AuthorizeContentAsync(It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<IEnumerable<string>?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithEmptyName_ReturnsError()
+    {
+        var args = new CreateUmbracoContentArgs(null, "blogPost", "", null);
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<CreateUmbracoContentResult>();
+        typed.Success.ShouldBeFalse();
+        typed.Message.ShouldContain("empty");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AuthorizationDenied_ReturnsErrorWithoutCallingServices()
+    {
+        var args = new CreateUmbracoContentArgs(Guid.NewGuid(), "blogPost", "Home", null);
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionNew.ActionLetter, args.ParentKey, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Denied("no permission"));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<CreateUmbracoContentResult>();
+        typed.Success.ShouldBeFalse();
+        typed.Message.ShouldBe("no permission");
+        _contentTypeServiceMock.Verify(x => x.Get(It.IsAny<string>()), Times.Never);
+        _contentEditingServiceMock.Verify(
+            x => x.CreateAsync(It.IsAny<ContentCreateModel>(), It.IsAny<Guid>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ContentTypeNotFound_ReturnsError()
+    {
+        var userKey = Guid.NewGuid();
+        var args = new CreateUmbracoContentArgs(null, "missingType", "Home", null);
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionNew.ActionLetter, null, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _contentTypeServiceMock.Setup(x => x.Get("missingType")).Returns((IContentType?)null);
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<CreateUmbracoContentResult>();
+        typed.Success.ShouldBeFalse();
+        typed.Message.ShouldContain("not found");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CreateFails_ReturnsMappedMessage()
+    {
+        var userKey = Guid.NewGuid();
+        var contentTypeKey = Guid.NewGuid();
+        var args = new CreateUmbracoContentArgs(null, "blogPost", "Home", null);
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionNew.ActionLetter, null, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        var contentTypeMock = new Mock<IContentType>();
+        contentTypeMock.Setup(x => x.Key).Returns(contentTypeKey);
+        _contentTypeServiceMock.Setup(x => x.Get("blogPost")).Returns(contentTypeMock.Object);
+        _contentEditingServiceMock
+            .Setup(x => x.CreateAsync(It.IsAny<ContentCreateModel>(), userKey))
+            .ReturnsAsync(Attempt<ContentCreateResult, ContentEditingOperationStatus>.Fail(
+                ContentEditingOperationStatus.PropertyValidationError, new ContentCreateResult()));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<CreateUmbracoContentResult>();
+        typed.Success.ShouldBeFalse();
+        typed.Message.ShouldContain("validation");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HappyPath_CreatesWithResolvedUserKeyAndReturnsContent()
+    {
+        var userKey = Guid.NewGuid();
+        var contentTypeKey = Guid.NewGuid();
+        var parentKey = Guid.NewGuid();
+        var newKey = Guid.NewGuid();
+        var propertyValues = new Dictionary<string, JsonElement>
+        {
+            ["title"] = JsonDocument.Parse("\"Hello\"").RootElement,
+        };
+        var args = new CreateUmbracoContentArgs(parentKey, "blogPost", "Home", propertyValues, "en-US");
+
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionNew.ActionLetter, parentKey, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+
+        var contentTypeMock = new Mock<IContentType>();
+        contentTypeMock.Setup(x => x.Key).Returns(contentTypeKey);
+        _contentTypeServiceMock.Setup(x => x.Get("blogPost")).Returns(contentTypeMock.Object);
+
+        var createdContentMock = CreateContentMock(newKey, "Home", "blogPost");
+
+        ContentCreateModel? capturedModel = null;
+        _contentEditingServiceMock
+            .Setup(x => x.CreateAsync(It.IsAny<ContentCreateModel>(), userKey))
+            .Callback<ContentCreateModel, Guid>((model, _) => capturedModel = model)
+            .ReturnsAsync(Attempt<ContentCreateResult, ContentEditingOperationStatus>.Succeed(
+                ContentEditingOperationStatus.Success, new ContentCreateResult { Content = createdContentMock.Object }));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<CreateUmbracoContentResult>();
+        typed.Success.ShouldBeTrue();
+        typed.Content.ShouldNotBeNull();
+        typed.Content!.Key.ShouldBe(newKey);
+
+        capturedModel.ShouldNotBeNull();
+        capturedModel!.ContentTypeKey.ShouldBe(contentTypeKey);
+        capturedModel.ParentKey.ShouldBe(parentKey);
+        capturedModel.Variants.Single().Name.ShouldBe("Home");
+        capturedModel.Variants.Single().Culture.ShouldBe("en-US");
+        capturedModel.Properties.Single().Alias.ShouldBe("title");
+    }
+
+    [Fact]
+    public void Description_ReturnsNonEmptyString()
+    {
+        var description = _tool.Description;
+
+        description.ShouldNotBeNullOrWhiteSpace();
+        description.ShouldContain("content type");
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/CreateUmbracoMediaToolTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/CreateUmbracoMediaToolTests.cs
@@ -1,0 +1,111 @@
+using System.Text.Json;
+
+using Moq;
+using Shouldly;
+using Umbraco.AI.Core.Tools;
+using Umbraco.AI.Core.Tools.Umbraco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.AI.Tests.Unit.Tools.Umbraco;
+
+public class CreateUmbracoMediaToolTests
+{
+    private readonly Mock<IMediaEditingService> _mediaEditingServiceMock;
+    private readonly Mock<IMediaTypeService> _mediaTypeServiceMock;
+    private readonly Mock<IUmbracoWriteAuthorizer> _authorizerMock;
+    private readonly IAITool _tool;
+
+    public CreateUmbracoMediaToolTests()
+    {
+        _mediaEditingServiceMock = new Mock<IMediaEditingService>();
+        _mediaTypeServiceMock = new Mock<IMediaTypeService>();
+        _authorizerMock = new Mock<IUmbracoWriteAuthorizer>();
+        _tool = new CreateUmbracoMediaTool(_mediaEditingServiceMock.Object, _mediaTypeServiceMock.Object, _authorizerMock.Object);
+    }
+
+    private static Mock<IMedia> CreateMediaMock(Guid key, string name, string mediaTypeAlias)
+    {
+        var mediaTypeMock = new Mock<ISimpleContentType>();
+        mediaTypeMock.Setup(x => x.Alias).Returns(mediaTypeAlias);
+
+        var mediaMock = new Mock<IMedia>();
+        mediaMock.Setup(x => x.Key).Returns(key);
+        mediaMock.Setup(x => x.Name).Returns(name);
+        mediaMock.Setup(x => x.ContentType).Returns(mediaTypeMock.Object);
+        mediaMock.Setup(x => x.CreateDate).Returns(DateTime.UtcNow);
+        mediaMock.Setup(x => x.UpdateDate).Returns(DateTime.UtcNow);
+        mediaMock.Setup(x => x.Properties).Returns(new PropertyCollection());
+        return mediaMock;
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithEmptyMediaTypeAlias_ReturnsError()
+    {
+        var args = new CreateUmbracoMediaArgs(null, "", "Logo", null);
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<CreateUmbracoMediaResult>();
+        typed.Success.ShouldBeFalse();
+        _authorizerMock.Verify(x => x.AuthorizeMediaAsync(It.IsAny<Guid?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AuthorizationDenied_ReturnsErrorWithoutCallingServices()
+    {
+        var args = new CreateUmbracoMediaArgs(null, "image", "Logo", null);
+        _authorizerMock.Setup(x => x.AuthorizeMediaAsync(null)).ReturnsAsync(UmbracoWriteAuthorizationResult.Denied("no permission"));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<CreateUmbracoMediaResult>();
+        typed.Success.ShouldBeFalse();
+        typed.Message.ShouldBe("no permission");
+        _mediaTypeServiceMock.Verify(x => x.Get(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HappyPath_CreatesWithResolvedUserKeyAndReturnsMedia()
+    {
+        var userKey = Guid.NewGuid();
+        var mediaTypeKey = Guid.NewGuid();
+        var newKey = Guid.NewGuid();
+        var propertyValues = new Dictionary<string, JsonElement> { ["altText"] = JsonDocument.Parse("\"Logo\"").RootElement };
+        var args = new CreateUmbracoMediaArgs(null, "image", "Logo", propertyValues);
+
+        _authorizerMock.Setup(x => x.AuthorizeMediaAsync(null)).ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        var mediaTypeMock = new Mock<IMediaType>();
+        mediaTypeMock.Setup(x => x.Key).Returns(mediaTypeKey);
+        _mediaTypeServiceMock.Setup(x => x.Get("image")).Returns(mediaTypeMock.Object);
+
+        var createdMediaMock = CreateMediaMock(newKey, "Logo", "image");
+        MediaCreateModel? capturedModel = null;
+        _mediaEditingServiceMock
+            .Setup(x => x.CreateAsync(It.IsAny<MediaCreateModel>(), userKey))
+            .Callback<MediaCreateModel, Guid>((model, _) => capturedModel = model)
+            .ReturnsAsync(Attempt<MediaCreateResult, ContentEditingOperationStatus>.Succeed(
+                ContentEditingOperationStatus.Success, new MediaCreateResult { Content = createdMediaMock.Object }));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<CreateUmbracoMediaResult>();
+        typed.Success.ShouldBeTrue();
+        typed.Media!.Key.ShouldBe(newKey);
+        capturedModel.ShouldNotBeNull();
+        capturedModel!.ContentTypeKey.ShouldBe(mediaTypeKey);
+        capturedModel.Variants.Single().Name.ShouldBe("Logo");
+        capturedModel.Properties.Single().Alias.ShouldBe("altText");
+    }
+
+    [Fact]
+    public void Description_ReturnsNonEmptyString()
+    {
+        var description = _tool.Description;
+
+        description.ShouldNotBeNullOrWhiteSpace();
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/DeleteUmbracoContentToolTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/DeleteUmbracoContentToolTests.cs
@@ -13,14 +13,16 @@ namespace Umbraco.AI.Tests.Unit.Tools.Umbraco;
 public class DeleteUmbracoContentToolTests
 {
     private readonly Mock<IContentEditingService> _contentEditingServiceMock;
+    private readonly Mock<IContentService> _contentServiceMock;
     private readonly Mock<IUmbracoWriteAuthorizer> _authorizerMock;
     private readonly IAITool _tool;
 
     public DeleteUmbracoContentToolTests()
     {
         _contentEditingServiceMock = new Mock<IContentEditingService>();
+        _contentServiceMock = new Mock<IContentService>();
         _authorizerMock = new Mock<IUmbracoWriteAuthorizer>();
-        _tool = new DeleteUmbracoContentTool(_contentEditingServiceMock.Object, _authorizerMock.Object);
+        _tool = new DeleteUmbracoContentTool(_contentEditingServiceMock.Object, _contentServiceMock.Object, _authorizerMock.Object);
     }
 
     [Fact]
@@ -104,5 +106,27 @@ public class DeleteUmbracoContentToolTests
 
         description.ShouldNotBeNullOrWhiteSpace();
         description.ShouldContain("recycle bin");
+    }
+
+    [Fact]
+    public void ConfirmationPhrase_ContentFound_ReturnsItsName()
+    {
+        var key = Guid.NewGuid();
+        _contentServiceMock.Setup(x => x.GetById(key)).Returns(Mock.Of<IContent>(c => c.Name == "Home"));
+
+        var phrase = _tool.ConfirmationPhrase(new DeleteUmbracoContentArgs(key));
+
+        phrase.ShouldBe("Home");
+    }
+
+    [Fact]
+    public void ConfirmationPhrase_ContentNotFound_ReturnsNull()
+    {
+        var key = Guid.NewGuid();
+        _contentServiceMock.Setup(x => x.GetById(key)).Returns((IContent?)null);
+
+        var phrase = _tool.ConfirmationPhrase(new DeleteUmbracoContentArgs(key));
+
+        phrase.ShouldBeNull();
     }
 }

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/DeleteUmbracoContentToolTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/DeleteUmbracoContentToolTests.cs
@@ -1,0 +1,108 @@
+using Moq;
+using Shouldly;
+using Umbraco.AI.Core.Tools;
+using Umbraco.AI.Core.Tools.Umbraco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.AI.Tests.Unit.Tools.Umbraco;
+
+public class DeleteUmbracoContentToolTests
+{
+    private readonly Mock<IContentEditingService> _contentEditingServiceMock;
+    private readonly Mock<IUmbracoWriteAuthorizer> _authorizerMock;
+    private readonly IAITool _tool;
+
+    public DeleteUmbracoContentToolTests()
+    {
+        _contentEditingServiceMock = new Mock<IContentEditingService>();
+        _authorizerMock = new Mock<IUmbracoWriteAuthorizer>();
+        _tool = new DeleteUmbracoContentTool(_contentEditingServiceMock.Object, _authorizerMock.Object);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithEmptyKey_ReturnsError()
+    {
+        var args = new DeleteUmbracoContentArgs(Guid.Empty);
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<DeleteUmbracoContentResult>();
+        typed.Success.ShouldBeFalse();
+        typed.Message.ShouldContain("empty");
+        _authorizerMock.Verify(x => x.AuthorizeContentAsync(It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<IEnumerable<string>?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AuthorizationDenied_ReturnsErrorWithoutCallingService()
+    {
+        var key = Guid.NewGuid();
+        var args = new DeleteUmbracoContentArgs(key);
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionDelete.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Denied("no permission"));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<DeleteUmbracoContentResult>();
+        typed.Success.ShouldBeFalse();
+        typed.Message.ShouldBe("no permission");
+        _contentEditingServiceMock.Verify(
+            x => x.MoveToRecycleBinAsync(It.IsAny<Guid>(), It.IsAny<Guid>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DeleteFails_ReturnsMappedMessage()
+    {
+        var userKey = Guid.NewGuid();
+        var key = Guid.NewGuid();
+        var args = new DeleteUmbracoContentArgs(key);
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionDelete.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _contentEditingServiceMock
+            .Setup(x => x.MoveToRecycleBinAsync(key, userKey))
+            .ReturnsAsync(Attempt<IContent?, ContentEditingOperationStatus>.Fail(
+                ContentEditingOperationStatus.NotFound, (IContent?)null));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<DeleteUmbracoContentResult>();
+        typed.Success.ShouldBeFalse();
+        typed.Message.ShouldContain("not found");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HappyPath_MovesToRecycleBinWithResolvedUserKey()
+    {
+        var userKey = Guid.NewGuid();
+        var key = Guid.NewGuid();
+        var args = new DeleteUmbracoContentArgs(key);
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionDelete.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _contentEditingServiceMock
+            .Setup(x => x.MoveToRecycleBinAsync(key, userKey))
+            .ReturnsAsync(Attempt<IContent?, ContentEditingOperationStatus>.Succeed(
+                ContentEditingOperationStatus.Success, Mock.Of<IContent>()));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<DeleteUmbracoContentResult>();
+        typed.Success.ShouldBeTrue();
+        _contentEditingServiceMock.Verify(x => x.MoveToRecycleBinAsync(key, userKey), Times.Once);
+    }
+
+    [Fact]
+    public void Description_ReturnsNonEmptyString()
+    {
+        var description = _tool.Description;
+
+        description.ShouldNotBeNullOrWhiteSpace();
+        description.ShouldContain("recycle bin");
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/DeleteUmbracoMediaToolTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/DeleteUmbracoMediaToolTests.cs
@@ -12,14 +12,16 @@ namespace Umbraco.AI.Tests.Unit.Tools.Umbraco;
 public class DeleteUmbracoMediaToolTests
 {
     private readonly Mock<IMediaEditingService> _mediaEditingServiceMock;
+    private readonly Mock<IMediaService> _mediaServiceMock;
     private readonly Mock<IUmbracoWriteAuthorizer> _authorizerMock;
     private readonly IAITool _tool;
 
     public DeleteUmbracoMediaToolTests()
     {
         _mediaEditingServiceMock = new Mock<IMediaEditingService>();
+        _mediaServiceMock = new Mock<IMediaService>();
         _authorizerMock = new Mock<IUmbracoWriteAuthorizer>();
-        _tool = new DeleteUmbracoMediaTool(_mediaEditingServiceMock.Object, _authorizerMock.Object);
+        _tool = new DeleteUmbracoMediaTool(_mediaEditingServiceMock.Object, _mediaServiceMock.Object, _authorizerMock.Object);
     }
 
     [Fact]
@@ -75,5 +77,27 @@ public class DeleteUmbracoMediaToolTests
 
         description.ShouldNotBeNullOrWhiteSpace();
         description.ShouldContain("recycle bin");
+    }
+
+    [Fact]
+    public void ConfirmationPhrase_MediaFound_ReturnsItsName()
+    {
+        var key = Guid.NewGuid();
+        _mediaServiceMock.Setup(x => x.GetById(key)).Returns(Mock.Of<IMedia>(m => m.Name == "Logo.png"));
+
+        var phrase = _tool.ConfirmationPhrase(new DeleteUmbracoMediaArgs(key));
+
+        phrase.ShouldBe("Logo.png");
+    }
+
+    [Fact]
+    public void ConfirmationPhrase_MediaNotFound_ReturnsNull()
+    {
+        var key = Guid.NewGuid();
+        _mediaServiceMock.Setup(x => x.GetById(key)).Returns((IMedia?)null);
+
+        var phrase = _tool.ConfirmationPhrase(new DeleteUmbracoMediaArgs(key));
+
+        phrase.ShouldBeNull();
     }
 }

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/DeleteUmbracoMediaToolTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/DeleteUmbracoMediaToolTests.cs
@@ -1,0 +1,79 @@
+using Moq;
+using Shouldly;
+using Umbraco.AI.Core.Tools;
+using Umbraco.AI.Core.Tools.Umbraco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.AI.Tests.Unit.Tools.Umbraco;
+
+public class DeleteUmbracoMediaToolTests
+{
+    private readonly Mock<IMediaEditingService> _mediaEditingServiceMock;
+    private readonly Mock<IUmbracoWriteAuthorizer> _authorizerMock;
+    private readonly IAITool _tool;
+
+    public DeleteUmbracoMediaToolTests()
+    {
+        _mediaEditingServiceMock = new Mock<IMediaEditingService>();
+        _authorizerMock = new Mock<IUmbracoWriteAuthorizer>();
+        _tool = new DeleteUmbracoMediaTool(_mediaEditingServiceMock.Object, _authorizerMock.Object);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithEmptyKey_ReturnsError()
+    {
+        var args = new DeleteUmbracoMediaArgs(Guid.Empty);
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<DeleteUmbracoMediaResult>();
+        typed.Success.ShouldBeFalse();
+        _authorizerMock.Verify(x => x.AuthorizeMediaAsync(It.IsAny<Guid?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AuthorizationDenied_ReturnsErrorWithoutCallingService()
+    {
+        var key = Guid.NewGuid();
+        var args = new DeleteUmbracoMediaArgs(key);
+        _authorizerMock.Setup(x => x.AuthorizeMediaAsync(key)).ReturnsAsync(UmbracoWriteAuthorizationResult.Denied("no permission"));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<DeleteUmbracoMediaResult>();
+        typed.Success.ShouldBeFalse();
+        typed.Message.ShouldBe("no permission");
+        _mediaEditingServiceMock.Verify(x => x.MoveToRecycleBinAsync(It.IsAny<Guid>(), It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HappyPath_MovesToRecycleBinWithResolvedUserKey()
+    {
+        var userKey = Guid.NewGuid();
+        var key = Guid.NewGuid();
+        var args = new DeleteUmbracoMediaArgs(key);
+        _authorizerMock.Setup(x => x.AuthorizeMediaAsync(key)).ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _mediaEditingServiceMock
+            .Setup(x => x.MoveToRecycleBinAsync(key, userKey))
+            .ReturnsAsync(Attempt<IMedia?, ContentEditingOperationStatus>.Succeed(
+                ContentEditingOperationStatus.Success, Mock.Of<IMedia>()));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<DeleteUmbracoMediaResult>();
+        typed.Success.ShouldBeTrue();
+        _mediaEditingServiceMock.Verify(x => x.MoveToRecycleBinAsync(key, userKey), Times.Once);
+    }
+
+    [Fact]
+    public void Description_ReturnsNonEmptyString()
+    {
+        var description = _tool.Description;
+
+        description.ShouldNotBeNullOrWhiteSpace();
+        description.ShouldContain("recycle bin");
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/GetUmbracoContentToolTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/GetUmbracoContentToolTests.cs
@@ -25,9 +25,11 @@ public class GetUmbracoContentToolTests
             _contentServiceMock.Object,
             _umbracoContextAccessorMock.Object);
 
-        // No Umbraco context available by default — the published-cache URL lookup itself relies on an
-        // ambient StaticServiceProvider that isn't configured in a unit test, so every test here exercises
-        // the unpublished/draft path deliberately, mirroring GetContentByRouteToolTests' own approach.
+        // No Umbraco context available by default, so BuildEnrichedContentItem always falls back to the
+        // raw/IContentService.GetAncestors path below. The preview-cache path (BuildContentItem(IPublishedContent))
+        // calls the friendly .Url() extension, which relies on an ambient StaticServiceProvider that isn't
+        // configured in a unit test — untestable here for the same reason GetContentByRouteToolTests never
+        // exercises its own "found content" happy path either. Covered by live demo-site verification instead.
         _umbracoContextAccessorMock
             .Setup(x => x.TryGetUmbracoContext(out It.Ref<IUmbracoContext?>.IsAny))
             .Returns(false);

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/GetUmbracoContentToolTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/GetUmbracoContentToolTests.cs
@@ -4,21 +4,36 @@ using Umbraco.AI.Core.Tools;
 using Umbraco.AI.Core.Tools.Umbraco;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Web;
 
 namespace Umbraco.AI.Tests.Unit.Tools.Umbraco;
 
 public class GetUmbracoContentToolTests
 {
     private readonly Mock<IContentEditingService> _contentEditingServiceMock;
+    private readonly Mock<IContentService> _contentServiceMock;
+    private readonly Mock<IUmbracoContextAccessor> _umbracoContextAccessorMock;
     private readonly IAITool _tool;
 
     public GetUmbracoContentToolTests()
     {
         _contentEditingServiceMock = new Mock<IContentEditingService>();
-        _tool = new GetUmbracoContentTool(_contentEditingServiceMock.Object);
+        _contentServiceMock = new Mock<IContentService>();
+        _umbracoContextAccessorMock = new Mock<IUmbracoContextAccessor>();
+        _tool = new GetUmbracoContentTool(
+            _contentEditingServiceMock.Object,
+            _contentServiceMock.Object,
+            _umbracoContextAccessorMock.Object);
+
+        // No Umbraco context available by default — the published-cache URL lookup itself relies on an
+        // ambient StaticServiceProvider that isn't configured in a unit test, so every test here exercises
+        // the unpublished/draft path deliberately, mirroring GetContentByRouteToolTests' own approach.
+        _umbracoContextAccessorMock
+            .Setup(x => x.TryGetUmbracoContext(out It.Ref<IUmbracoContext?>.IsAny))
+            .Returns(false);
     }
 
-    private static Mock<IContent> CreateContentMock(Guid key, string name, string contentTypeAlias)
+    private static Mock<IContent> CreateContentMock(Guid key, string name, string contentTypeAlias, int level = 1)
     {
         var contentTypeMock = new Mock<ISimpleContentType>();
         contentTypeMock.Setup(x => x.Alias).Returns(contentTypeAlias);
@@ -30,7 +45,7 @@ public class GetUmbracoContentToolTests
         contentMock.Setup(x => x.ContentType).Returns(contentTypeMock.Object);
         contentMock.Setup(x => x.CreateDate).Returns(DateTime.UtcNow);
         contentMock.Setup(x => x.UpdateDate).Returns(DateTime.UtcNow);
-        contentMock.Setup(x => x.Level).Returns(1);
+        contentMock.Setup(x => x.Level).Returns(level);
         contentMock.Setup(x => x.Path).Returns("-1,1234");
         contentMock.Setup(x => x.Properties).Returns(new PropertyCollection());
         return contentMock;
@@ -46,8 +61,7 @@ public class GetUmbracoContentToolTests
         var result = await _tool.ExecuteAsync(args, CancellationToken.None);
 
         // Assert
-        result.ShouldBeOfType<GetUmbracoContentResult>();
-        var contentResult = (GetUmbracoContentResult)result;
+        var contentResult = result.ShouldBeOfType<GetUmbracoContentResult>();
         contentResult.Success.ShouldBeFalse();
         contentResult.Message.ShouldContain("empty");
         contentResult.Content.ShouldBeNull();
@@ -66,21 +80,24 @@ public class GetUmbracoContentToolTests
         var result = await _tool.ExecuteAsync(args, CancellationToken.None);
 
         // Assert
-        result.ShouldBeOfType<GetUmbracoContentResult>();
-        var contentResult = (GetUmbracoContentResult)result;
+        var contentResult = result.ShouldBeOfType<GetUmbracoContentResult>();
         contentResult.Success.ShouldBeFalse();
         contentResult.Message.ShouldContain("not found");
     }
 
     [Fact]
-    public async Task ExecuteAsync_WithDraftContent_ReturnsContent()
+    public async Task ExecuteAsync_WithDraftContent_ReturnsContentWithBreadcrumbAndParent_ButNoUrl()
     {
-        // Arrange — proves get_umbraco_content can fetch content that has never been published,
-        // reading from the same business/draft layer the write tools use.
+        // Arrange — proves get_umbraco_content can fetch content that has never been published, and
+        // still resolves a real breadcrumb/parent (unlike the write tools' lean confirmation payload)
+        // via IContentService.GetAncestors, which works regardless of publish state.
         var key = Guid.NewGuid();
         var args = new GetUmbracoContentArgs(key);
-        var contentMock = CreateContentMock(key, "Draft Page", "page");
+        var contentMock = CreateContentMock(key, "Draft Page", "page", level: 2);
+        var rootMock = CreateContentMock(Guid.NewGuid(), "Home", "home", level: 1);
+
         _contentEditingServiceMock.Setup(x => x.GetAsync(key)).ReturnsAsync(contentMock.Object);
+        _contentServiceMock.Setup(x => x.GetAncestors(contentMock.Object)).Returns([rootMock.Object]);
 
         // Act
         var result = await _tool.ExecuteAsync(args, CancellationToken.None);
@@ -91,9 +108,30 @@ public class GetUmbracoContentToolTests
         contentResult.Content.ShouldNotBeNull();
         contentResult.Content!.Key.ShouldBe(key);
         contentResult.Content.Name.ShouldBe("Draft Page");
-        contentResult.Content.ContentType.ShouldBe("page");
         contentResult.Content.Url.ShouldBeNull();
-        contentResult.Content.Parent.ShouldBeNull();
+        contentResult.Content.Parent.ShouldNotBeNull();
+        contentResult.Content.Parent!.Name.ShouldBe("Home");
+        contentResult.Content.Path.ShouldBe("Home > Draft Page");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithNoAncestors_ReturnsSelfOnlyBreadcrumbAndNullParent()
+    {
+        // Arrange — a root-level item has no ancestors at all.
+        var key = Guid.NewGuid();
+        var args = new GetUmbracoContentArgs(key);
+        var contentMock = CreateContentMock(key, "Home", "home");
+
+        _contentEditingServiceMock.Setup(x => x.GetAsync(key)).ReturnsAsync(contentMock.Object);
+        _contentServiceMock.Setup(x => x.GetAncestors(contentMock.Object)).Returns([]);
+
+        // Act
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        // Assert
+        var contentResult = result.ShouldBeOfType<GetUmbracoContentResult>();
+        contentResult.Content!.Parent.ShouldBeNull();
+        contentResult.Content.Path.ShouldBe("Home");
     }
 
     [Fact]

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/GetUmbracoContentToolTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/GetUmbracoContentToolTests.cs
@@ -2,21 +2,38 @@ using Moq;
 using Shouldly;
 using Umbraco.AI.Core.Tools;
 using Umbraco.AI.Core.Tools.Umbraco;
-using Umbraco.Cms.Core.Models.PublishedContent;
-using Umbraco.Cms.Core.PublishedCache;
-using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.AI.Tests.Unit.Tools.Umbraco;
 
 public class GetUmbracoContentToolTests
 {
-    private readonly Mock<IUmbracoContextAccessor> _umbracoContextAccessorMock;
+    private readonly Mock<IContentEditingService> _contentEditingServiceMock;
     private readonly IAITool _tool;
 
     public GetUmbracoContentToolTests()
     {
-        _umbracoContextAccessorMock = new Mock<IUmbracoContextAccessor>();
-        _tool = new GetUmbracoContentTool(_umbracoContextAccessorMock.Object);
+        _contentEditingServiceMock = new Mock<IContentEditingService>();
+        _tool = new GetUmbracoContentTool(_contentEditingServiceMock.Object);
+    }
+
+    private static Mock<IContent> CreateContentMock(Guid key, string name, string contentTypeAlias)
+    {
+        var contentTypeMock = new Mock<ISimpleContentType>();
+        contentTypeMock.Setup(x => x.Alias).Returns(contentTypeAlias);
+
+        var contentMock = new Mock<IContent>();
+        contentMock.Setup(x => x.Key).Returns(key);
+        contentMock.Setup(x => x.Name).Returns(name);
+        contentMock.Setup(x => x.GetCultureName(It.IsAny<string?>())).Returns((string?)null);
+        contentMock.Setup(x => x.ContentType).Returns(contentTypeMock.Object);
+        contentMock.Setup(x => x.CreateDate).Returns(DateTime.UtcNow);
+        contentMock.Setup(x => x.UpdateDate).Returns(DateTime.UtcNow);
+        contentMock.Setup(x => x.Level).Returns(1);
+        contentMock.Setup(x => x.Path).Returns("-1,1234");
+        contentMock.Setup(x => x.Properties).Returns(new PropertyCollection());
+        return contentMock;
     }
 
     [Fact]
@@ -34,24 +51,7 @@ public class GetUmbracoContentToolTests
         contentResult.Success.ShouldBeFalse();
         contentResult.Message.ShouldContain("empty");
         contentResult.Content.ShouldBeNull();
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_WithNoUmbracoContext_ReturnsError()
-    {
-        // Arrange
-        var args = new GetUmbracoContentArgs(Guid.NewGuid());
-        _umbracoContextAccessorMock.Setup(x => x.TryGetUmbracoContext(out It.Ref<IUmbracoContext?>.IsAny))
-            .Returns(false);
-
-        // Act
-        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
-
-        // Assert
-        result.ShouldBeOfType<GetUmbracoContentResult>();
-        var contentResult = (GetUmbracoContentResult)result;
-        contentResult.Success.ShouldBeFalse();
-        contentResult.Message.ShouldContain("not available");
+        _contentEditingServiceMock.Verify(x => x.GetAsync(It.IsAny<Guid>()), Times.Never);
     }
 
     [Fact]
@@ -60,16 +60,7 @@ public class GetUmbracoContentToolTests
         // Arrange
         var key = Guid.NewGuid();
         var args = new GetUmbracoContentArgs(key);
-
-        var contentCacheMock = new Mock<IPublishedContentCache>();
-        contentCacheMock.Setup(x => x.GetById(key)).Returns((IPublishedContent?)null);
-
-        var umbracoContextMock = new Mock<IUmbracoContext>();
-        umbracoContextMock.Setup(x => x.Content).Returns(contentCacheMock.Object);
-
-        IUmbracoContext? ctx = umbracoContextMock.Object;
-        _umbracoContextAccessorMock.Setup(x => x.TryGetUmbracoContext(out ctx))
-            .Returns(true);
+        _contentEditingServiceMock.Setup(x => x.GetAsync(key)).ReturnsAsync((IContent?)null);
 
         // Act
         var result = await _tool.ExecuteAsync(args, CancellationToken.None);
@@ -79,6 +70,30 @@ public class GetUmbracoContentToolTests
         var contentResult = (GetUmbracoContentResult)result;
         contentResult.Success.ShouldBeFalse();
         contentResult.Message.ShouldContain("not found");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithDraftContent_ReturnsContent()
+    {
+        // Arrange — proves get_umbraco_content can fetch content that has never been published,
+        // reading from the same business/draft layer the write tools use.
+        var key = Guid.NewGuid();
+        var args = new GetUmbracoContentArgs(key);
+        var contentMock = CreateContentMock(key, "Draft Page", "page");
+        _contentEditingServiceMock.Setup(x => x.GetAsync(key)).ReturnsAsync(contentMock.Object);
+
+        // Act
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        // Assert
+        var contentResult = result.ShouldBeOfType<GetUmbracoContentResult>();
+        contentResult.Success.ShouldBeTrue();
+        contentResult.Content.ShouldNotBeNull();
+        contentResult.Content!.Key.ShouldBe(key);
+        contentResult.Content.Name.ShouldBe("Draft Page");
+        contentResult.Content.ContentType.ShouldBe("page");
+        contentResult.Content.Url.ShouldBeNull();
+        contentResult.Content.Parent.ShouldBeNull();
     }
 
     [Fact]

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/MoveUmbracoContentItemToolTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/MoveUmbracoContentItemToolTests.cs
@@ -1,0 +1,76 @@
+using System.Text.Json.Nodes;
+
+using Moq;
+using Shouldly;
+using Umbraco.AI.Core.PropertyValueOperations;
+using Umbraco.AI.Core.Tools;
+using Umbraco.AI.Core.Tools.Umbraco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.AI.Tests.Unit.Tools.Umbraco;
+
+public class MoveUmbracoContentItemToolTests
+{
+    private readonly Mock<IContentEditingService> _contentEditingServiceMock = new();
+    private readonly Mock<IAIPropertyValueDispatcher> _dispatcherMock = new();
+    private readonly Mock<IUmbracoWriteAuthorizer> _authorizerMock = new();
+    private readonly IAITool _tool;
+
+    public MoveUmbracoContentItemToolTests()
+    {
+        _tool = new MoveUmbracoContentItemTool(_contentEditingServiceMock.Object, _dispatcherMock.Object, _authorizerMock.Object);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HappyPath_DispatchesMoveItemWithBlockKeyAndPositionArgs()
+    {
+        var key = Guid.NewGuid();
+        var userKey = Guid.NewGuid();
+        var blockKey = Guid.NewGuid();
+        var contentTypeMock = new Mock<ISimpleContentType>();
+        contentTypeMock.Setup(x => x.Key).Returns(Guid.NewGuid());
+        var contentMock = new Mock<IContent>();
+        contentMock.Setup(x => x.ContentType).Returns(contentTypeMock.Object);
+
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionUpdate.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _contentEditingServiceMock.Setup(x => x.GetAsync(key)).ReturnsAsync(contentMock.Object);
+
+        AIPropertyValueDispatchRequest? captured = null;
+        _dispatcherMock
+            .Setup(x => x.DispatchAsync(It.IsAny<AIPropertyValueDispatchRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<AIPropertyValueDispatchRequest, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(AIPropertyValueDispatchResult.Ok(JsonNode.Parse("{}")));
+        _contentEditingServiceMock
+            .Setup(x => x.UpdateAsync(key, It.IsAny<ContentUpdateModel>(), userKey))
+            .ReturnsAsync(Attempt<ContentUpdateResult, ContentEditingOperationStatus>.Succeed(
+                ContentEditingOperationStatus.Success, new ContentUpdateResult()));
+
+        var args = new MoveUmbracoContentItemArgs(key, [new UmbracoPropertyPathSegmentArg("contentBlocks", null)], blockKey, 2);
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<MoveUmbracoContentItemResult>();
+        typed.Success.ShouldBeTrue();
+        captured.ShouldNotBeNull();
+        captured!.Operation.ShouldBe(AIPropertyOperation.MoveItem);
+        var argsObj = captured.Args.ShouldBeOfType<JsonObject>();
+        argsObj["blockKey"]!.GetValue<string>().ShouldBe(blockKey.ToString());
+        argsObj["position"]!.GetValue<int>().ShouldBe(2);
+    }
+
+    [Fact]
+    public void Description_ReturnsNonEmptyString()
+    {
+        var description = _tool.Description;
+
+        description.ShouldNotBeNullOrWhiteSpace();
+        description.ShouldContain("position");
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/PublishUmbracoContentToolTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/PublishUmbracoContentToolTests.cs
@@ -4,6 +4,7 @@ using Umbraco.AI.Core.Tools;
 using Umbraco.AI.Core.Tools.Umbraco;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentPublishing;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
@@ -13,14 +14,16 @@ namespace Umbraco.AI.Tests.Unit.Tools.Umbraco;
 public class PublishUmbracoContentToolTests
 {
     private readonly Mock<IContentPublishingService> _contentPublishingServiceMock;
+    private readonly Mock<IContentService> _contentServiceMock;
     private readonly Mock<IUmbracoWriteAuthorizer> _authorizerMock;
     private readonly IAITool _tool;
 
     public PublishUmbracoContentToolTests()
     {
         _contentPublishingServiceMock = new Mock<IContentPublishingService>();
+        _contentServiceMock = new Mock<IContentService>();
         _authorizerMock = new Mock<IUmbracoWriteAuthorizer>();
-        _tool = new PublishUmbracoContentTool(_contentPublishingServiceMock.Object, _authorizerMock.Object);
+        _tool = new PublishUmbracoContentTool(_contentPublishingServiceMock.Object, _contentServiceMock.Object, _authorizerMock.Object);
     }
 
     [Fact]
@@ -109,5 +112,27 @@ public class PublishUmbracoContentToolTests
 
         description.ShouldNotBeNullOrWhiteSpace();
         description.ShouldContain("live");
+    }
+
+    [Fact]
+    public void ConfirmationPhrase_ContentFound_ReturnsItsName()
+    {
+        var key = Guid.NewGuid();
+        _contentServiceMock.Setup(x => x.GetById(key)).Returns(Mock.Of<IContent>(c => c.Name == "Home"));
+
+        var phrase = _tool.ConfirmationPhrase(new PublishUmbracoContentArgs(key));
+
+        phrase.ShouldBe("Home");
+    }
+
+    [Fact]
+    public void ConfirmationPhrase_ContentNotFound_ReturnsNull()
+    {
+        var key = Guid.NewGuid();
+        _contentServiceMock.Setup(x => x.GetById(key)).Returns((IContent?)null);
+
+        var phrase = _tool.ConfirmationPhrase(new PublishUmbracoContentArgs(key));
+
+        phrase.ShouldBeNull();
     }
 }

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/PublishUmbracoContentToolTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/PublishUmbracoContentToolTests.cs
@@ -1,0 +1,113 @@
+using Moq;
+using Shouldly;
+using Umbraco.AI.Core.Tools;
+using Umbraco.AI.Core.Tools.Umbraco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Models.ContentPublishing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.AI.Tests.Unit.Tools.Umbraco;
+
+public class PublishUmbracoContentToolTests
+{
+    private readonly Mock<IContentPublishingService> _contentPublishingServiceMock;
+    private readonly Mock<IUmbracoWriteAuthorizer> _authorizerMock;
+    private readonly IAITool _tool;
+
+    public PublishUmbracoContentToolTests()
+    {
+        _contentPublishingServiceMock = new Mock<IContentPublishingService>();
+        _authorizerMock = new Mock<IUmbracoWriteAuthorizer>();
+        _tool = new PublishUmbracoContentTool(_contentPublishingServiceMock.Object, _authorizerMock.Object);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithEmptyKey_ReturnsError()
+    {
+        var args = new PublishUmbracoContentArgs(Guid.Empty);
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<PublishUmbracoContentResult>();
+        typed.Success.ShouldBeFalse();
+        typed.Message.ShouldContain("empty");
+        _authorizerMock.Verify(x => x.AuthorizeContentAsync(It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<IEnumerable<string>?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AuthorizationDenied_ReturnsErrorWithoutCallingService()
+    {
+        var key = Guid.NewGuid();
+        var args = new PublishUmbracoContentArgs(key, "da-DK");
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionPublish.ActionLetter, key, It.Is<IEnumerable<string>>(c => c.Single() == "da-DK")))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Denied("no permission"));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<PublishUmbracoContentResult>();
+        typed.Success.ShouldBeFalse();
+        typed.Message.ShouldBe("no permission");
+        _contentPublishingServiceMock.Verify(
+            x => x.PublishAsync(It.IsAny<Guid>(), It.IsAny<ICollection<CulturePublishScheduleModel>>(), It.IsAny<Guid>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PublishFails_ReturnsMappedMessage()
+    {
+        var userKey = Guid.NewGuid();
+        var key = Guid.NewGuid();
+        var args = new PublishUmbracoContentArgs(key);
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionPublish.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _contentPublishingServiceMock
+            .Setup(x => x.PublishAsync(key, It.IsAny<ICollection<CulturePublishScheduleModel>>(), userKey))
+            .ReturnsAsync(Attempt<ContentPublishingResult, ContentPublishingOperationStatus>.Fail(
+                ContentPublishingOperationStatus.MandatoryCultureMissing, new ContentPublishingResult()));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<PublishUmbracoContentResult>();
+        typed.Success.ShouldBeFalse();
+        typed.Message.ShouldContain("mandatory culture");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HappyPath_PublishesWithResolvedUserKeyAndInvariantCulture()
+    {
+        var userKey = Guid.NewGuid();
+        var key = Guid.NewGuid();
+        var args = new PublishUmbracoContentArgs(key);
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionPublish.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+
+        ICollection<CulturePublishScheduleModel>? captured = null;
+        _contentPublishingServiceMock
+            .Setup(x => x.PublishAsync(key, It.IsAny<ICollection<CulturePublishScheduleModel>>(), userKey))
+            .Callback<Guid, ICollection<CulturePublishScheduleModel>, Guid>((_, schedules, _) => captured = schedules)
+            .ReturnsAsync(Attempt<ContentPublishingResult, ContentPublishingOperationStatus>.Succeed(
+                ContentPublishingOperationStatus.Success, new ContentPublishingResult()));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<PublishUmbracoContentResult>();
+        typed.Success.ShouldBeTrue();
+        captured.ShouldNotBeNull();
+        captured!.Single().Culture.ShouldBeNull();
+        captured.Single().Schedule.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Description_ReturnsNonEmptyString()
+    {
+        var description = _tool.Description;
+
+        description.ShouldNotBeNullOrWhiteSpace();
+        description.ShouldContain("live");
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/RemoveUmbracoContentItemToolTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/RemoveUmbracoContentItemToolTests.cs
@@ -1,0 +1,75 @@
+using System.Text.Json.Nodes;
+
+using Moq;
+using Shouldly;
+using Umbraco.AI.Core.PropertyValueOperations;
+using Umbraco.AI.Core.Tools;
+using Umbraco.AI.Core.Tools.Umbraco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.AI.Tests.Unit.Tools.Umbraco;
+
+public class RemoveUmbracoContentItemToolTests
+{
+    private readonly Mock<IContentEditingService> _contentEditingServiceMock = new();
+    private readonly Mock<IAIPropertyValueDispatcher> _dispatcherMock = new();
+    private readonly Mock<IUmbracoWriteAuthorizer> _authorizerMock = new();
+    private readonly IAITool _tool;
+
+    public RemoveUmbracoContentItemToolTests()
+    {
+        _tool = new RemoveUmbracoContentItemTool(_contentEditingServiceMock.Object, _dispatcherMock.Object, _authorizerMock.Object);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HappyPath_DispatchesRemoveItemWithBlockKeyArg()
+    {
+        var key = Guid.NewGuid();
+        var userKey = Guid.NewGuid();
+        var blockKey = Guid.NewGuid();
+        var contentTypeMock = new Mock<ISimpleContentType>();
+        contentTypeMock.Setup(x => x.Key).Returns(Guid.NewGuid());
+        var contentMock = new Mock<IContent>();
+        contentMock.Setup(x => x.ContentType).Returns(contentTypeMock.Object);
+
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionUpdate.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _contentEditingServiceMock.Setup(x => x.GetAsync(key)).ReturnsAsync(contentMock.Object);
+
+        AIPropertyValueDispatchRequest? captured = null;
+        _dispatcherMock
+            .Setup(x => x.DispatchAsync(It.IsAny<AIPropertyValueDispatchRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<AIPropertyValueDispatchRequest, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(AIPropertyValueDispatchResult.Ok(JsonNode.Parse("{}")));
+        _contentEditingServiceMock
+            .Setup(x => x.UpdateAsync(key, It.IsAny<ContentUpdateModel>(), userKey))
+            .ReturnsAsync(Attempt<ContentUpdateResult, ContentEditingOperationStatus>.Succeed(
+                ContentEditingOperationStatus.Success, new ContentUpdateResult()));
+
+        var args = new RemoveUmbracoContentItemArgs(key, [new UmbracoPropertyPathSegmentArg("contentBlocks", null)], blockKey);
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<RemoveUmbracoContentItemResult>();
+        typed.Success.ShouldBeTrue();
+        captured.ShouldNotBeNull();
+        captured!.Operation.ShouldBe(AIPropertyOperation.RemoveItem);
+        var argsObj = captured.Args.ShouldBeOfType<JsonObject>();
+        argsObj["blockKey"]!.GetValue<string>().ShouldBe(blockKey.ToString());
+    }
+
+    [Fact]
+    public void Description_ReturnsNonEmptyString()
+    {
+        var description = _tool.Description;
+
+        description.ShouldNotBeNullOrWhiteSpace();
+        description.ShouldContain("Removes");
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/SetUmbracoContentValueToolTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/SetUmbracoContentValueToolTests.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+using Moq;
+using Shouldly;
+using Umbraco.AI.Core.PropertyValueOperations;
+using Umbraco.AI.Core.Tools;
+using Umbraco.AI.Core.Tools.Umbraco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.AI.Tests.Unit.Tools.Umbraco;
+
+public class SetUmbracoContentValueToolTests
+{
+    private readonly Mock<IContentEditingService> _contentEditingServiceMock = new();
+    private readonly Mock<IAIPropertyValueDispatcher> _dispatcherMock = new();
+    private readonly Mock<IUmbracoWriteAuthorizer> _authorizerMock = new();
+    private readonly IAITool _tool;
+
+    public SetUmbracoContentValueToolTests()
+    {
+        _tool = new SetUmbracoContentValueTool(_contentEditingServiceMock.Object, _dispatcherMock.Object, _authorizerMock.Object);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HappyPath_DispatchesSetValueWithWrappedValueArg()
+    {
+        var key = Guid.NewGuid();
+        var userKey = Guid.NewGuid();
+        var contentTypeMock = new Mock<ISimpleContentType>();
+        contentTypeMock.Setup(x => x.Key).Returns(Guid.NewGuid());
+        var contentMock = new Mock<IContent>();
+        contentMock.Setup(x => x.ContentType).Returns(contentTypeMock.Object);
+        contentMock.Setup(x => x.Name).Returns("Home");
+
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionUpdate.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _contentEditingServiceMock.Setup(x => x.GetAsync(key)).ReturnsAsync(contentMock.Object);
+
+        AIPropertyValueDispatchRequest? captured = null;
+        _dispatcherMock
+            .Setup(x => x.DispatchAsync(It.IsAny<AIPropertyValueDispatchRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<AIPropertyValueDispatchRequest, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(AIPropertyValueDispatchResult.Ok(JsonValue.Create("hello")));
+        _contentEditingServiceMock
+            .Setup(x => x.UpdateAsync(key, It.IsAny<ContentUpdateModel>(), userKey))
+            .ReturnsAsync(Attempt<ContentUpdateResult, ContentEditingOperationStatus>.Succeed(
+                ContentEditingOperationStatus.Success, new ContentUpdateResult()));
+
+        var args = new SetUmbracoContentValueArgs(
+            key,
+            [new UmbracoPropertyPathSegmentArg("title", null)],
+            JsonDocument.Parse("\"hello\"").RootElement);
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<SetUmbracoContentValueResult>();
+        typed.Success.ShouldBeTrue();
+        captured.ShouldNotBeNull();
+        captured!.Operation.ShouldBe(AIPropertyOperation.SetValue);
+        var argsObj = captured.Args.ShouldBeOfType<JsonObject>();
+        argsObj["value"]!.GetValue<string>().ShouldBe("hello");
+    }
+
+    [Fact]
+    public void Description_ReturnsNonEmptyString()
+    {
+        var description = _tool.Description;
+
+        description.ShouldNotBeNullOrWhiteSpace();
+        description.ShouldContain("block");
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/UmbracoWriteAuthorizerTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/UmbracoWriteAuthorizerTests.cs
@@ -1,0 +1,178 @@
+using Moq;
+using Shouldly;
+using Umbraco.AI.Core.Tools.Umbraco;
+using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Security.Authorization;
+
+namespace Umbraco.AI.Tests.Unit.Tools.Umbraco;
+
+public class UmbracoWriteAuthorizerTests
+{
+    private readonly Mock<IContentPermissionAuthorizer> _contentPermissionAuthorizerMock;
+    private readonly Mock<IMediaPermissionAuthorizer> _mediaPermissionAuthorizerMock;
+    private readonly Mock<IBackOfficeSecurityAccessor> _backOfficeSecurityAccessorMock;
+    private readonly IUmbracoWriteAuthorizer _authorizer;
+
+    public UmbracoWriteAuthorizerTests()
+    {
+        _contentPermissionAuthorizerMock = new Mock<IContentPermissionAuthorizer>();
+        _mediaPermissionAuthorizerMock = new Mock<IMediaPermissionAuthorizer>();
+        _backOfficeSecurityAccessorMock = new Mock<IBackOfficeSecurityAccessor>();
+        _authorizer = new UmbracoWriteAuthorizer(
+            _contentPermissionAuthorizerMock.Object,
+            _mediaPermissionAuthorizerMock.Object,
+            _backOfficeSecurityAccessorMock.Object);
+    }
+
+    private void SetCurrentUser(IUser? user)
+    {
+        var securityMock = new Mock<IBackOfficeSecurity>();
+        securityMock.Setup(x => x.CurrentUser).Returns(user);
+        _backOfficeSecurityAccessorMock.Setup(x => x.BackOfficeSecurity).Returns(securityMock.Object);
+    }
+
+    private static Mock<IUser> CreateUserMock(Guid key)
+    {
+        var userMock = new Mock<IUser>();
+        userMock.Setup(x => x.Key).Returns(key);
+        return userMock;
+    }
+
+    [Fact]
+    public async Task AuthorizeContentAsync_NoCurrentUser_ReturnsDenied()
+    {
+        SetCurrentUser(null);
+
+        var result = await _authorizer.AuthorizeContentAsync("Umb.Document.Update", Guid.NewGuid());
+
+        result.IsAuthorized.ShouldBeFalse();
+        result.UserKey.ShouldBeNull();
+        _contentPermissionAuthorizerMock.Verify(
+            x => x.IsDeniedAsync(It.IsAny<IUser>(), It.IsAny<Guid>(), It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task AuthorizeContentAsync_NullContentKey_ChecksRootLevel()
+    {
+        var user = CreateUserMock(Guid.NewGuid());
+        SetCurrentUser(user.Object);
+        _contentPermissionAuthorizerMock
+            .Setup(x => x.IsDeniedAtRootLevelAsync(user.Object, It.Is<ISet<string>>(s => s.Contains("Umb.Document.Create"))))
+            .ReturnsAsync(false);
+
+        var result = await _authorizer.AuthorizeContentAsync("Umb.Document.Create", null);
+
+        result.IsAuthorized.ShouldBeTrue();
+        result.UserKey.ShouldBe(user.Object.Key);
+        _contentPermissionAuthorizerMock.Verify(
+            x => x.IsDeniedAsync(It.IsAny<IUser>(), It.IsAny<Guid>(), It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task AuthorizeContentAsync_KeyedContentDenied_ReturnsDenied()
+    {
+        var user = CreateUserMock(Guid.NewGuid());
+        var contentKey = Guid.NewGuid();
+        SetCurrentUser(user.Object);
+        _contentPermissionAuthorizerMock
+            .Setup(x => x.IsDeniedAsync(user.Object, contentKey, "Umb.Document.Update"))
+            .ReturnsAsync(true);
+
+        var result = await _authorizer.AuthorizeContentAsync("Umb.Document.Update", contentKey);
+
+        result.IsAuthorized.ShouldBeFalse();
+        result.UserKey.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task AuthorizeContentAsync_CulturesDenied_ShortCircuitsEvenWhenBaseCheckPasses()
+    {
+        var user = CreateUserMock(Guid.NewGuid());
+        var contentKey = Guid.NewGuid();
+        SetCurrentUser(user.Object);
+        _contentPermissionAuthorizerMock
+            .Setup(x => x.IsDeniedAsync(user.Object, contentKey, "Umb.Document.Publish"))
+            .ReturnsAsync(false);
+        _contentPermissionAuthorizerMock
+            .Setup(x => x.IsDeniedForCultures(user.Object, It.Is<ISet<string>>(s => s.Contains("da-DK"))))
+            .ReturnsAsync(true);
+
+        var result = await _authorizer.AuthorizeContentAsync("Umb.Document.Publish", contentKey, ["da-DK"]);
+
+        result.IsAuthorized.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task AuthorizeContentAsync_NoCulturesRequested_SkipsCultureCheck()
+    {
+        var user = CreateUserMock(Guid.NewGuid());
+        var contentKey = Guid.NewGuid();
+        SetCurrentUser(user.Object);
+        _contentPermissionAuthorizerMock
+            .Setup(x => x.IsDeniedAsync(user.Object, contentKey, "Umb.Document.Update"))
+            .ReturnsAsync(false);
+
+        var result = await _authorizer.AuthorizeContentAsync("Umb.Document.Update", contentKey);
+
+        result.IsAuthorized.ShouldBeTrue();
+        result.UserKey.ShouldBe(user.Object.Key);
+        _contentPermissionAuthorizerMock.Verify(
+            x => x.IsDeniedForCultures(It.IsAny<IUser>(), It.IsAny<ISet<string>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task AuthorizeMediaAsync_NoCurrentUser_ReturnsDenied()
+    {
+        SetCurrentUser(null);
+
+        var result = await _authorizer.AuthorizeMediaAsync(Guid.NewGuid());
+
+        result.IsAuthorized.ShouldBeFalse();
+        _mediaPermissionAuthorizerMock.Verify(x => x.IsDeniedAsync(It.IsAny<IUser>(), It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AuthorizeMediaAsync_NullMediaKey_ChecksRootLevel()
+    {
+        var user = CreateUserMock(Guid.NewGuid());
+        SetCurrentUser(user.Object);
+        _mediaPermissionAuthorizerMock.Setup(x => x.IsDeniedAtRootLevelAsync(user.Object)).ReturnsAsync(false);
+
+        var result = await _authorizer.AuthorizeMediaAsync(null);
+
+        result.IsAuthorized.ShouldBeTrue();
+        result.UserKey.ShouldBe(user.Object.Key);
+        _mediaPermissionAuthorizerMock.Verify(x => x.IsDeniedAsync(It.IsAny<IUser>(), It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AuthorizeMediaAsync_KeyedMediaDenied_ReturnsDenied()
+    {
+        var user = CreateUserMock(Guid.NewGuid());
+        var mediaKey = Guid.NewGuid();
+        SetCurrentUser(user.Object);
+        _mediaPermissionAuthorizerMock.Setup(x => x.IsDeniedAsync(user.Object, mediaKey)).ReturnsAsync(true);
+
+        var result = await _authorizer.AuthorizeMediaAsync(mediaKey);
+
+        result.IsAuthorized.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task AuthorizeMediaAsync_KeyedMediaAllowed_ReturnsUserKey()
+    {
+        var user = CreateUserMock(Guid.NewGuid());
+        var mediaKey = Guid.NewGuid();
+        SetCurrentUser(user.Object);
+        _mediaPermissionAuthorizerMock.Setup(x => x.IsDeniedAsync(user.Object, mediaKey)).ReturnsAsync(false);
+
+        var result = await _authorizer.AuthorizeMediaAsync(mediaKey);
+
+        result.IsAuthorized.ShouldBeTrue();
+        result.UserKey.ShouldBe(user.Object.Key);
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/UnpublishUmbracoContentToolTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/UnpublishUmbracoContentToolTests.cs
@@ -4,6 +4,7 @@ using Umbraco.AI.Core.Tools;
 using Umbraco.AI.Core.Tools.Umbraco;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
@@ -12,14 +13,16 @@ namespace Umbraco.AI.Tests.Unit.Tools.Umbraco;
 public class UnpublishUmbracoContentToolTests
 {
     private readonly Mock<IContentPublishingService> _contentPublishingServiceMock;
+    private readonly Mock<IContentService> _contentServiceMock;
     private readonly Mock<IUmbracoWriteAuthorizer> _authorizerMock;
     private readonly IAITool _tool;
 
     public UnpublishUmbracoContentToolTests()
     {
         _contentPublishingServiceMock = new Mock<IContentPublishingService>();
+        _contentServiceMock = new Mock<IContentService>();
         _authorizerMock = new Mock<IUmbracoWriteAuthorizer>();
-        _tool = new UnpublishUmbracoContentTool(_contentPublishingServiceMock.Object, _authorizerMock.Object);
+        _tool = new UnpublishUmbracoContentTool(_contentPublishingServiceMock.Object, _contentServiceMock.Object, _authorizerMock.Object);
     }
 
     [Fact]
@@ -119,5 +122,27 @@ public class UnpublishUmbracoContentToolTests
 
         description.ShouldNotBeNullOrWhiteSpace();
         description.ShouldContain("offline");
+    }
+
+    [Fact]
+    public void ConfirmationPhrase_ContentFound_ReturnsItsName()
+    {
+        var key = Guid.NewGuid();
+        _contentServiceMock.Setup(x => x.GetById(key)).Returns(Mock.Of<IContent>(c => c.Name == "Home"));
+
+        var phrase = _tool.ConfirmationPhrase(new UnpublishUmbracoContentArgs(key));
+
+        phrase.ShouldBe("Home");
+    }
+
+    [Fact]
+    public void ConfirmationPhrase_ContentNotFound_ReturnsNull()
+    {
+        var key = Guid.NewGuid();
+        _contentServiceMock.Setup(x => x.GetById(key)).Returns((IContent?)null);
+
+        var phrase = _tool.ConfirmationPhrase(new UnpublishUmbracoContentArgs(key));
+
+        phrase.ShouldBeNull();
     }
 }

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/UnpublishUmbracoContentToolTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/UnpublishUmbracoContentToolTests.cs
@@ -1,0 +1,123 @@
+using Moq;
+using Shouldly;
+using Umbraco.AI.Core.Tools;
+using Umbraco.AI.Core.Tools.Umbraco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.AI.Tests.Unit.Tools.Umbraco;
+
+public class UnpublishUmbracoContentToolTests
+{
+    private readonly Mock<IContentPublishingService> _contentPublishingServiceMock;
+    private readonly Mock<IUmbracoWriteAuthorizer> _authorizerMock;
+    private readonly IAITool _tool;
+
+    public UnpublishUmbracoContentToolTests()
+    {
+        _contentPublishingServiceMock = new Mock<IContentPublishingService>();
+        _authorizerMock = new Mock<IUmbracoWriteAuthorizer>();
+        _tool = new UnpublishUmbracoContentTool(_contentPublishingServiceMock.Object, _authorizerMock.Object);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithEmptyKey_ReturnsError()
+    {
+        var args = new UnpublishUmbracoContentArgs(Guid.Empty);
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<UnpublishUmbracoContentResult>();
+        typed.Success.ShouldBeFalse();
+        typed.Message.ShouldContain("empty");
+        _authorizerMock.Verify(x => x.AuthorizeContentAsync(It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<IEnumerable<string>?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AuthorizationDenied_ReturnsErrorWithoutCallingService()
+    {
+        var key = Guid.NewGuid();
+        var args = new UnpublishUmbracoContentArgs(key);
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionUnpublish.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Denied("no permission"));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<UnpublishUmbracoContentResult>();
+        typed.Success.ShouldBeFalse();
+        typed.Message.ShouldBe("no permission");
+        _contentPublishingServiceMock.Verify(
+            x => x.UnpublishAsync(It.IsAny<Guid>(), It.IsAny<ISet<string>?>(), It.IsAny<Guid>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnpublishFails_ReturnsMappedMessage()
+    {
+        var userKey = Guid.NewGuid();
+        var key = Guid.NewGuid();
+        var args = new UnpublishUmbracoContentArgs(key);
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionUnpublish.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _contentPublishingServiceMock
+            .Setup(x => x.UnpublishAsync(key, null, userKey))
+            .ReturnsAsync(Attempt<ContentPublishingOperationStatus>.Fail(ContentPublishingOperationStatus.ContentNotFound));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<UnpublishUmbracoContentResult>();
+        typed.Success.ShouldBeFalse();
+        typed.Message.ShouldContain("not found");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithCulture_UnpublishesJustThatCulture()
+    {
+        var userKey = Guid.NewGuid();
+        var key = Guid.NewGuid();
+        var args = new UnpublishUmbracoContentArgs(key, "da-DK");
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionUnpublish.ActionLetter, key, It.Is<IEnumerable<string>>(c => c.Single() == "da-DK")))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _contentPublishingServiceMock
+            .Setup(x => x.UnpublishAsync(key, It.Is<ISet<string>>(s => s.Single() == "da-DK"), userKey))
+            .ReturnsAsync(Attempt<ContentPublishingOperationStatus>.Succeed(ContentPublishingOperationStatus.Success));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<UnpublishUmbracoContentResult>();
+        typed.Success.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithNoCulture_UnpublishesAllCultures()
+    {
+        var userKey = Guid.NewGuid();
+        var key = Guid.NewGuid();
+        var args = new UnpublishUmbracoContentArgs(key);
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionUnpublish.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _contentPublishingServiceMock
+            .Setup(x => x.UnpublishAsync(key, null, userKey))
+            .ReturnsAsync(Attempt<ContentPublishingOperationStatus>.Succeed(ContentPublishingOperationStatus.Success));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<UnpublishUmbracoContentResult>();
+        typed.Success.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Description_ReturnsNonEmptyString()
+    {
+        var description = _tool.Description;
+
+        description.ShouldNotBeNullOrWhiteSpace();
+        description.ShouldContain("offline");
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/UpdateUmbracoContentToolTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/UpdateUmbracoContentToolTests.cs
@@ -1,0 +1,209 @@
+using System.Text.Json;
+
+using Moq;
+using Shouldly;
+using Umbraco.AI.Core.Tools;
+using Umbraco.AI.Core.Tools.Umbraco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.AI.Tests.Unit.Tools.Umbraco;
+
+public class UpdateUmbracoContentToolTests
+{
+    private readonly Mock<IContentEditingService> _contentEditingServiceMock;
+    private readonly Mock<IUmbracoWriteAuthorizer> _authorizerMock;
+    private readonly IAITool _tool;
+
+    public UpdateUmbracoContentToolTests()
+    {
+        _contentEditingServiceMock = new Mock<IContentEditingService>();
+        _authorizerMock = new Mock<IUmbracoWriteAuthorizer>();
+        _tool = new UpdateUmbracoContentTool(_contentEditingServiceMock.Object, _authorizerMock.Object);
+    }
+
+    private static Mock<IContent> CreateContentMock(Guid key, string name, string contentTypeAlias)
+    {
+        var contentTypeMock = new Mock<ISimpleContentType>();
+        contentTypeMock.Setup(x => x.Alias).Returns(contentTypeAlias);
+
+        var contentMock = new Mock<IContent>();
+        contentMock.Setup(x => x.Key).Returns(key);
+        contentMock.Setup(x => x.Name).Returns(name);
+        contentMock.Setup(x => x.GetCultureName(It.IsAny<string?>())).Returns((string?)null);
+        contentMock.Setup(x => x.ContentType).Returns(contentTypeMock.Object);
+        contentMock.Setup(x => x.CreateDate).Returns(DateTime.UtcNow);
+        contentMock.Setup(x => x.UpdateDate).Returns(DateTime.UtcNow);
+        contentMock.Setup(x => x.Level).Returns(1);
+        contentMock.Setup(x => x.Path).Returns("-1,1234");
+        contentMock.Setup(x => x.Properties).Returns(new PropertyCollection());
+        return contentMock;
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithEmptyKey_ReturnsError()
+    {
+        var args = new UpdateUmbracoContentArgs(Guid.Empty, "New Name", null);
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<UpdateUmbracoContentResult>();
+        typed.Success.ShouldBeFalse();
+        typed.Message.ShouldContain("empty");
+        _authorizerMock.Verify(x => x.AuthorizeContentAsync(It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<IEnumerable<string>?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AuthorizationDenied_ReturnsErrorWithoutCallingService()
+    {
+        var key = Guid.NewGuid();
+        var args = new UpdateUmbracoContentArgs(key, "New Name", null);
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionUpdate.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Denied("no permission"));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<UpdateUmbracoContentResult>();
+        typed.Success.ShouldBeFalse();
+        typed.Message.ShouldBe("no permission");
+        _contentEditingServiceMock.Verify(
+            x => x.UpdateAsync(It.IsAny<Guid>(), It.IsAny<ContentUpdateModel>(), It.IsAny<Guid>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UpdateFails_ReturnsMappedMessage()
+    {
+        var userKey = Guid.NewGuid();
+        var key = Guid.NewGuid();
+        // A name is supplied here so the call reaches UpdateAsync directly — this test targets the
+        // ToMessage() mapping on a failed UpdateAsync, not the no-name current-name lookup (covered below).
+        var args = new UpdateUmbracoContentArgs(key, "Some Name", null);
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionUpdate.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _contentEditingServiceMock
+            .Setup(x => x.UpdateAsync(key, It.IsAny<ContentUpdateModel>(), userKey))
+            .ReturnsAsync(Attempt<ContentUpdateResult, ContentEditingOperationStatus>.Fail(
+                ContentEditingOperationStatus.NotFound, new ContentUpdateResult()));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<UpdateUmbracoContentResult>();
+        typed.Success.ShouldBeFalse();
+        typed.Message.ShouldContain("not found");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HappyPath_UpdatesWithResolvedUserKeyAndReturnsContent()
+    {
+        var userKey = Guid.NewGuid();
+        var key = Guid.NewGuid();
+        var propertyValues = new Dictionary<string, JsonElement>
+        {
+            ["summary"] = JsonDocument.Parse("\"Updated\"").RootElement,
+        };
+        var args = new UpdateUmbracoContentArgs(key, "New Name", propertyValues, "en-US");
+
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionUpdate.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+
+        var updatedContentMock = CreateContentMock(key, "New Name", "blogPost");
+
+        ContentUpdateModel? capturedModel = null;
+        _contentEditingServiceMock
+            .Setup(x => x.UpdateAsync(key, It.IsAny<ContentUpdateModel>(), userKey))
+            .Callback<Guid, ContentUpdateModel, Guid>((_, model, _) => capturedModel = model)
+            .ReturnsAsync(Attempt<ContentUpdateResult, ContentEditingOperationStatus>.Succeed(
+                ContentEditingOperationStatus.Success, new ContentUpdateResult { Content = updatedContentMock.Object }));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<UpdateUmbracoContentResult>();
+        typed.Success.ShouldBeTrue();
+        typed.Content.ShouldNotBeNull();
+        typed.Content!.Key.ShouldBe(key);
+
+        capturedModel.ShouldNotBeNull();
+        capturedModel!.Variants.Single().Name.ShouldBe("New Name");
+        capturedModel.Variants.Single().Culture.ShouldBe("en-US");
+        capturedModel.Properties.Single().Alias.ShouldBe("summary");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoNameChange_LoadsCurrentNameToAvoidCultureVarianceMismatch()
+    {
+        // ContentEditingServiceBase requires a Variants entry matching the content type's variance
+        // regardless of what's being changed — an invariant type with an empty Variants list fails with
+        // ContentTypeCultureVarianceMismatch even though nothing here is renaming the item. When no new
+        // name is given, the tool must load the current one so a matching entry is still present.
+        var userKey = Guid.NewGuid();
+        var key = Guid.NewGuid();
+        var propertyValues = new Dictionary<string, JsonElement>
+        {
+            ["summary"] = JsonDocument.Parse("\"Updated\"").RootElement,
+        };
+        var args = new UpdateUmbracoContentArgs(key, null, propertyValues);
+
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionUpdate.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _contentEditingServiceMock
+            .Setup(x => x.GetAsync(key))
+            .ReturnsAsync(CreateContentMock(key, "Existing Name", "blogPost").Object);
+
+        ContentUpdateModel? capturedModel = null;
+        var updatedContentMock = CreateContentMock(key, "Existing Name", "blogPost");
+        _contentEditingServiceMock
+            .Setup(x => x.UpdateAsync(key, It.IsAny<ContentUpdateModel>(), userKey))
+            .Callback<Guid, ContentUpdateModel, Guid>((_, model, _) => capturedModel = model)
+            .ReturnsAsync(Attempt<ContentUpdateResult, ContentEditingOperationStatus>.Succeed(
+                ContentEditingOperationStatus.Success, new ContentUpdateResult { Content = updatedContentMock.Object }));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<UpdateUmbracoContentResult>();
+        typed.Success.ShouldBeTrue();
+        capturedModel.ShouldNotBeNull();
+        var variant = capturedModel!.Variants.Single();
+        variant.Name.ShouldBe("Existing Name");
+        variant.Culture.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoNameChange_ContentNotFound_ReturnsErrorWithoutCallingUpdate()
+    {
+        var userKey = Guid.NewGuid();
+        var key = Guid.NewGuid();
+        var args = new UpdateUmbracoContentArgs(key, null, null);
+
+        _authorizerMock
+            .Setup(x => x.AuthorizeContentAsync(ActionUpdate.ActionLetter, key, null))
+            .ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _contentEditingServiceMock.Setup(x => x.GetAsync(key)).ReturnsAsync((IContent?)null);
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<UpdateUmbracoContentResult>();
+        typed.Success.ShouldBeFalse();
+        typed.Message.ShouldContain("not found");
+        _contentEditingServiceMock.Verify(
+            x => x.UpdateAsync(It.IsAny<Guid>(), It.IsAny<ContentUpdateModel>(), It.IsAny<Guid>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void Description_ReturnsNonEmptyString()
+    {
+        var description = _tool.Description;
+
+        description.ShouldNotBeNullOrWhiteSpace();
+        description.ShouldContain("draft");
+    }
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/UpdateUmbracoMediaToolTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Tools/Umbraco/UpdateUmbracoMediaToolTests.cs
@@ -1,0 +1,159 @@
+using System.Text.Json;
+
+using Moq;
+using Shouldly;
+using Umbraco.AI.Core.Tools;
+using Umbraco.AI.Core.Tools.Umbraco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.AI.Tests.Unit.Tools.Umbraco;
+
+public class UpdateUmbracoMediaToolTests
+{
+    private readonly Mock<IMediaEditingService> _mediaEditingServiceMock;
+    private readonly Mock<IUmbracoWriteAuthorizer> _authorizerMock;
+    private readonly IAITool _tool;
+
+    public UpdateUmbracoMediaToolTests()
+    {
+        _mediaEditingServiceMock = new Mock<IMediaEditingService>();
+        _authorizerMock = new Mock<IUmbracoWriteAuthorizer>();
+        _tool = new UpdateUmbracoMediaTool(_mediaEditingServiceMock.Object, _authorizerMock.Object);
+    }
+
+    private static Mock<IMedia> CreateMediaMock(Guid key, string name, string mediaTypeAlias)
+    {
+        var mediaTypeMock = new Mock<ISimpleContentType>();
+        mediaTypeMock.Setup(x => x.Alias).Returns(mediaTypeAlias);
+
+        var mediaMock = new Mock<IMedia>();
+        mediaMock.Setup(x => x.Key).Returns(key);
+        mediaMock.Setup(x => x.Name).Returns(name);
+        mediaMock.Setup(x => x.ContentType).Returns(mediaTypeMock.Object);
+        mediaMock.Setup(x => x.CreateDate).Returns(DateTime.UtcNow);
+        mediaMock.Setup(x => x.UpdateDate).Returns(DateTime.UtcNow);
+        mediaMock.Setup(x => x.Properties).Returns(new PropertyCollection());
+        return mediaMock;
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithEmptyKey_ReturnsError()
+    {
+        var args = new UpdateUmbracoMediaArgs(Guid.Empty, "New Name", null);
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<UpdateUmbracoMediaResult>();
+        typed.Success.ShouldBeFalse();
+        _authorizerMock.Verify(x => x.AuthorizeMediaAsync(It.IsAny<Guid?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AuthorizationDenied_ReturnsErrorWithoutCallingService()
+    {
+        var key = Guid.NewGuid();
+        var args = new UpdateUmbracoMediaArgs(key, "New Name", null);
+        _authorizerMock.Setup(x => x.AuthorizeMediaAsync(key)).ReturnsAsync(UmbracoWriteAuthorizationResult.Denied("no permission"));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<UpdateUmbracoMediaResult>();
+        typed.Success.ShouldBeFalse();
+        typed.Message.ShouldBe("no permission");
+        _mediaEditingServiceMock.Verify(
+            x => x.UpdateAsync(It.IsAny<Guid>(), It.IsAny<MediaUpdateModel>(), It.IsAny<Guid>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HappyPath_UpdatesWithResolvedUserKeyAndReturnsMedia()
+    {
+        var userKey = Guid.NewGuid();
+        var key = Guid.NewGuid();
+        var propertyValues = new Dictionary<string, JsonElement> { ["altText"] = JsonDocument.Parse("\"Updated\"").RootElement };
+        var args = new UpdateUmbracoMediaArgs(key, "New Name", propertyValues);
+
+        _authorizerMock.Setup(x => x.AuthorizeMediaAsync(key)).ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        var updatedMediaMock = CreateMediaMock(key, "New Name", "image");
+
+        MediaUpdateModel? capturedModel = null;
+        _mediaEditingServiceMock
+            .Setup(x => x.UpdateAsync(key, It.IsAny<MediaUpdateModel>(), userKey))
+            .Callback<Guid, MediaUpdateModel, Guid>((_, model, _) => capturedModel = model)
+            .ReturnsAsync(Attempt<MediaUpdateResult, ContentEditingOperationStatus>.Succeed(
+                ContentEditingOperationStatus.Success, new MediaUpdateResult { Content = updatedMediaMock.Object }));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<UpdateUmbracoMediaResult>();
+        typed.Success.ShouldBeTrue();
+        typed.Media!.Key.ShouldBe(key);
+        capturedModel.ShouldNotBeNull();
+        capturedModel!.Variants.Single().Name.ShouldBe("New Name");
+        capturedModel.Properties.Single().Alias.ShouldBe("altText");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoNameChange_LoadsCurrentNameToAvoidCultureVarianceMismatch()
+    {
+        // ContentEditingServiceBase (shared with media) requires a Variants entry matching the media
+        // type's variance regardless of what's being changed — an invariant type with an empty Variants
+        // list fails with ContentTypeCultureVarianceMismatch even though nothing here is renaming the
+        // item. When no new name is given, the tool must load the current one so a matching entry is
+        // still present.
+        var userKey = Guid.NewGuid();
+        var key = Guid.NewGuid();
+        var propertyValues = new Dictionary<string, JsonElement> { ["altText"] = JsonDocument.Parse("\"Updated\"").RootElement };
+        var args = new UpdateUmbracoMediaArgs(key, null, propertyValues);
+
+        _authorizerMock.Setup(x => x.AuthorizeMediaAsync(key)).ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _mediaEditingServiceMock.Setup(x => x.GetAsync(key)).ReturnsAsync(CreateMediaMock(key, "Existing Name", "image").Object);
+
+        MediaUpdateModel? capturedModel = null;
+        var updatedMediaMock = CreateMediaMock(key, "Existing Name", "image");
+        _mediaEditingServiceMock
+            .Setup(x => x.UpdateAsync(key, It.IsAny<MediaUpdateModel>(), userKey))
+            .Callback<Guid, MediaUpdateModel, Guid>((_, model, _) => capturedModel = model)
+            .ReturnsAsync(Attempt<MediaUpdateResult, ContentEditingOperationStatus>.Succeed(
+                ContentEditingOperationStatus.Success, new MediaUpdateResult { Content = updatedMediaMock.Object }));
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<UpdateUmbracoMediaResult>();
+        typed.Success.ShouldBeTrue();
+        capturedModel.ShouldNotBeNull();
+        capturedModel!.Variants.Single().Name.ShouldBe("Existing Name");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoNameChange_MediaNotFound_ReturnsErrorWithoutCallingUpdate()
+    {
+        var userKey = Guid.NewGuid();
+        var key = Guid.NewGuid();
+        var args = new UpdateUmbracoMediaArgs(key, null, null);
+
+        _authorizerMock.Setup(x => x.AuthorizeMediaAsync(key)).ReturnsAsync(UmbracoWriteAuthorizationResult.Allowed(userKey));
+        _mediaEditingServiceMock.Setup(x => x.GetAsync(key)).ReturnsAsync((IMedia?)null);
+
+        var result = await _tool.ExecuteAsync(args, CancellationToken.None);
+
+        var typed = result.ShouldBeOfType<UpdateUmbracoMediaResult>();
+        typed.Success.ShouldBeFalse();
+        typed.Message.ShouldContain("not found");
+        _mediaEditingServiceMock.Verify(
+            x => x.UpdateAsync(It.IsAny<Guid>(), It.IsAny<MediaUpdateModel>(), It.IsAny<Guid>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void Description_ReturnsNonEmptyString()
+    {
+        var description = _tool.Description;
+
+        description.ShouldNotBeNullOrWhiteSpace();
+    }
+}


### PR DESCRIPTION
## Summary
Port of #329 to v17.

- Adds 13 new backend AI tools so agents can create, update, publish/unpublish, and delete content and media, plus author Block List/Grid property values, without a browser editor open (`create_umbraco_content`, `update_umbraco_content`, `publish_umbraco_content`, `unpublish_umbraco_content`, `delete_umbraco_content`, `set_umbraco_content_value`, `add_umbraco_content_item`, `remove_umbraco_content_item`, `move_umbraco_content_item`, `clear_umbraco_content_value`, `create_umbraco_media`, `update_umbraco_media`, `delete_umbraco_media`). All write tools go through a new shared `UmbracoWriteAuthorizer` that replicates the same per-user CMS permission checks the backoffice controllers already enforce, since the underlying write services don't self-authorize.
- Fixes a tool-approval resume bug where chained/sequential HITL approvals could crash or silently drop, caused by rebuilding a fresh `AgentSession` per HTTP request. Bumps `Microsoft.Agents.AI`/`.Workflows` to 1.18.0 and persists/restores the full session state per conversation instead.
- Fixes a `ContentTypeCultureVarianceMismatch` error when updating/creating content without changing its name — the update model now always carries a `Variants` entry matching the content type's variance.

Port note: CMS 17 exposes the EF Core scope interface as `IEfCoreScope` (CMS 18 renamed it to `IEFCoreScope`) — the two new session-state repository methods were adjusted to match this codebase's existing casing convention; everything else ported as a clean cherry-pick with matching migration history on both lines.

## Test plan
- [x] `dotnet test Umbraco.AI/Umbraco.AI.slnx` — 1143 unit + 30 integration, all passing
- [x] `dotnet test Umbraco.AI.Agent/Umbraco.AI.Agent.slnx` — 243 unit + 4 integration, all passing
- [x] `dotnet test Umbraco.AI.Agent.Copilot.Workspace/Umbraco.AI.Agent.Copilot.Workspace.slnx` — 37 unit, all passing
- [x] EF Core migration model snapshot confirmed byte-identical to v18's for this product (shared migration history)
- [ ] Live demo-site smoke test on v17 (verified live on v18 in #329; not yet independently re-verified on v17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)