### PR TITLE
feat(core): Extract text from CSV/TXT/MD/Office files attached in chat

### DIFF
--- a/Umbraco.AI/src/Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.cs
@@ -112,6 +112,7 @@ public static partial class UmbracoBuilderExtensions
         // File processing handlers (extensible - add custom handlers via AIFileProcessingHandlers())
         builder.AIFileProcessingHandlers()
             .Append<OpenXmlFileProcessingHandler>()
+            .Append<PlainTextFileProcessingHandler>()
             .Append<AudioTranscriptionFileProcessingHandler>();
 
         builder.AIChatMiddleware()

--- a/Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/AIFileProcessingChatClient.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/AIFileProcessingChatClient.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Umbraco.AI.Core.Media;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Extensions;
 
@@ -119,7 +120,27 @@ internal sealed class AIFileProcessingChatClient : DelegatingChatClient
                     }
                 }
 
-                var handler = await FindHandlerAsync(dataContent.MediaType, cancellationToken);
+                var effectiveMimeType = dataContent.MediaType;
+                var handler = await FindHandlerAsync(effectiveMimeType, cancellationToken);
+
+                if (handler is null && filename is not null)
+                {
+                    // The browser/client-reported MIME type is frequently wrong for the exact
+                    // file types this feature targets (e.g. Windows often reports .md as
+                    // application/octet-stream, and .csv as application/vnd.ms-excel). Fall back
+                    // to resolving a MIME type from the filename's extension and retry.
+                    var extension = Path.GetExtension(filename);
+                    if (AIMediaExtensionResolver.TryGetMediaType(extension, out var extensionMimeType))
+                    {
+                        var extensionHandler = await FindHandlerAsync(extensionMimeType, cancellationToken);
+                        if (extensionHandler is not null)
+                        {
+                            handler = extensionHandler;
+                            effectiveMimeType = extensionMimeType;
+                        }
+                    }
+                }
+
                 if (handler is null)
                 {
                     // No handler for this type — pass through (images, PDFs, etc.)
@@ -129,7 +150,7 @@ internal sealed class AIFileProcessingChatClient : DelegatingChatClient
 
                 var processingResult = await handler.ProcessAsync(
                     dataContent.Data,
-                    dataContent.MediaType,
+                    effectiveMimeType,
                     filename,
                     cancellationToken);
 

--- a/Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/AIFileProcessingConstants.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/AIFileProcessingConstants.cs
@@ -1,0 +1,13 @@
+namespace Umbraco.AI.Core.FileProcessing;
+
+/// <summary>
+/// Shared limits for file-processing handlers that extract text from uploaded files.
+/// </summary>
+internal static class AIFileProcessingConstants
+{
+    /// <summary>
+    /// The maximum number of characters a handler will return before truncating,
+    /// to keep a single attached file from consuming excessive context budget.
+    /// </summary>
+    public const int MaxExtractedCharacters = 100_000;
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/OpenXmlFileProcessingHandler.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/OpenXmlFileProcessingHandler.cs
@@ -19,8 +19,6 @@ namespace Umbraco.AI.Core.FileProcessing;
 /// </summary>
 internal sealed class OpenXmlFileProcessingHandler : IAIFileProcessingHandler
 {
-    private const int MaxCharacters = 100_000;
-
     private static readonly HashSet<string> SupportedMimeTypes = new(StringComparer.OrdinalIgnoreCase)
     {
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -51,10 +49,10 @@ internal sealed class OpenXmlFileProcessingHandler : IAIFileProcessingHandler
             _ => string.Empty,
         };
 
-        var wasTruncated = content.Length > MaxCharacters;
+        var wasTruncated = content.Length > AIFileProcessingConstants.MaxExtractedCharacters;
         if (wasTruncated)
         {
-            content = content[..MaxCharacters] + "\n\n[Content truncated due to size limits]";
+            content = content[..AIFileProcessingConstants.MaxExtractedCharacters] + "\n\n[Content truncated due to size limits]";
         }
 
         return Task.FromResult(new AIFileProcessingResult(content, wasTruncated));

--- a/Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/PlainTextFileProcessingHandler.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/PlainTextFileProcessingHandler.cs
@@ -25,7 +25,9 @@ internal sealed class PlainTextFileProcessingHandler : IAIFileProcessingHandler
         string? filename,
         CancellationToken cancellationToken = default)
     {
-        var content = Encoding.UTF8.GetString(data.Span);
+        using var stream = new MemoryStream(data.ToArray());
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+        var content = reader.ReadToEnd();
 
         var wasTruncated = content.Length > AIFileProcessingConstants.MaxExtractedCharacters;
         if (wasTruncated)

--- a/Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/PlainTextFileProcessingHandler.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/PlainTextFileProcessingHandler.cs
@@ -1,0 +1,38 @@
+using System.Text;
+
+namespace Umbraco.AI.Core.FileProcessing;
+
+/// <summary>
+/// Extracts text content from plain-text files (CSV, Markdown, plain text).
+/// </summary>
+internal sealed class PlainTextFileProcessingHandler : IAIFileProcessingHandler
+{
+    private static readonly HashSet<string> SupportedMimeTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "text/plain",
+        "text/csv",
+        "text/markdown",
+    };
+
+    /// <inheritdoc />
+    public Task<bool> CanHandleAsync(string mimeType, CancellationToken cancellationToken = default)
+        => Task.FromResult(SupportedMimeTypes.Contains(mimeType));
+
+    /// <inheritdoc />
+    public Task<AIFileProcessingResult> ProcessAsync(
+        ReadOnlyMemory<byte> data,
+        string mimeType,
+        string? filename,
+        CancellationToken cancellationToken = default)
+    {
+        var content = Encoding.UTF8.GetString(data.Span);
+
+        var wasTruncated = content.Length > AIFileProcessingConstants.MaxExtractedCharacters;
+        if (wasTruncated)
+        {
+            content = content[..AIFileProcessingConstants.MaxExtractedCharacters] + "\n\n[Content truncated due to size limits]";
+        }
+
+        return Task.FromResult(new AIFileProcessingResult(content, wasTruncated));
+    }
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Media/AIMediaExtensionResolver.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Media/AIMediaExtensionResolver.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Umbraco.AI.Core.Media;
+
+/// <summary>
+/// Maps file extensions to the MIME types <see cref="IAIUmbracoMediaResolver"/> understands.
+/// Extracted from <see cref="AIUmbracoMediaResolver"/> so the lookup can be unit tested without
+/// the Umbraco CMS media/file-system infrastructure that resolver depends on.
+/// </summary>
+internal static class AIMediaExtensionResolver
+{
+    private static readonly Dictionary<string, string> ExtensionToMediaType = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Images
+        [".jpg"] = "image/jpeg",
+        [".jpeg"] = "image/jpeg",
+        [".png"] = "image/png",
+        [".gif"] = "image/gif",
+        [".webp"] = "image/webp",
+        [".bmp"] = "image/bmp",
+
+        // Audio
+        [".mp3"] = "audio/mpeg",
+        [".wav"] = "audio/wav",
+        [".m4a"] = "audio/mp4",
+        [".mp4"] = "audio/mp4",
+        [".ogg"] = "audio/ogg",
+        [".oga"] = "audio/ogg",
+        [".webm"] = "audio/webm",
+        [".flac"] = "audio/flac",
+
+        // Plain text
+        [".txt"] = "text/plain",
+        [".md"] = "text/markdown",
+        [".csv"] = "text/csv",
+
+        // Office documents
+        [".docx"] = "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        [".xlsx"] = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        [".pptx"] = "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    };
+
+    /// <summary>
+    /// Attempts to resolve the MIME type for a file extension (e.g. <c>.png</c>).
+    /// </summary>
+    /// <param name="extension">The file extension, including the leading dot.</param>
+    /// <param name="mediaType">The resolved MIME type, when found.</param>
+    /// <returns><c>true</c> if the extension is recognized; otherwise <c>false</c>.</returns>
+    public static bool TryGetMediaType(string extension, [NotNullWhen(true)] out string? mediaType)
+        => ExtensionToMediaType.TryGetValue(extension, out mediaType);
+}

--- a/Umbraco.AI/src/Umbraco.AI.Core/Media/AIUmbracoMediaResolver.cs
+++ b/Umbraco.AI/src/Umbraco.AI.Core/Media/AIUmbracoMediaResolver.cs
@@ -11,27 +11,6 @@ namespace Umbraco.AI.Core.Media;
 /// </summary>
 internal sealed class AIUmbracoMediaResolver : IAIUmbracoMediaResolver
 {
-    private static readonly Dictionary<string, string> ExtensionToMediaType = new(StringComparer.OrdinalIgnoreCase)
-    {
-        // Images
-        [".jpg"] = "image/jpeg",
-        [".jpeg"] = "image/jpeg",
-        [".png"] = "image/png",
-        [".gif"] = "image/gif",
-        [".webp"] = "image/webp",
-        [".bmp"] = "image/bmp",
-
-        // Audio
-        [".mp3"] = "audio/mpeg",
-        [".wav"] = "audio/wav",
-        [".m4a"] = "audio/mp4",
-        [".mp4"] = "audio/mp4",
-        [".ogg"] = "audio/ogg",
-        [".oga"] = "audio/ogg",
-        [".webm"] = "audio/webm",
-        [".flac"] = "audio/flac",
-    };
-
     private readonly IMediaService _mediaService;
     private readonly MediaFileManager _mediaFileManager;
     private readonly IOptionsMonitor<AIMediaOptions> _optionsMonitor;
@@ -290,7 +269,7 @@ internal sealed class AIUmbracoMediaResolver : IAIUmbracoMediaResolver
 
         // Get file extension for media type
         var extension = Path.GetExtension(filePath);
-        if (!ExtensionToMediaType.TryGetValue(extension, out var mediaType))
+        if (!AIMediaExtensionResolver.TryGetMediaType(extension, out var mediaType))
         {
             _logger.LogWarning("Unsupported media extension: {Extension}", extension);
             return null;

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/FileProcessing/AIFileProcessingChatClientTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/FileProcessing/AIFileProcessingChatClientTests.cs
@@ -234,6 +234,92 @@ public class AIFileProcessingChatClientTests
         text.ShouldNotContain("base64");
     }
 
+    [Fact]
+    public async Task GetResponseAsync_WithWrongMimeTypeButCsvExtension_FallsBackToExtension()
+    {
+        // Arrange — Windows often reports .csv as application/vnd.ms-excel (the OS's registered
+        // handler) rather than text/csv; the extension fallback should still find the handler.
+        var handler = new FakeHandler("text/csv", "extracted,data");
+        var (client, inner) = CreateClient(handler);
+
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, [CreateDataContent(new byte[] { 1, 2, 3 }, "application/vnd.ms-excel", "report.csv")]),
+        };
+
+        // Act
+        await client.GetResponseAsync(messages);
+
+        // Assert
+        var contents = inner.LastMessages![0].Contents;
+        contents[0].ShouldBeOfType<TextContent>();
+        ((TextContent)contents[0]).Text.ShouldContain("extracted,data");
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_WithWrongMimeTypeButMarkdownExtension_FallsBackToExtension()
+    {
+        // Arrange — browsers often report .md as application/octet-stream (or empty) on Windows;
+        // the extension fallback should still find the handler.
+        var handler = new FakeHandler("text/markdown", "# Notes");
+        var (client, inner) = CreateClient(handler);
+
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, [CreateDataContent(new byte[] { 1, 2, 3 }, "application/octet-stream", "notes.md")]),
+        };
+
+        // Act
+        await client.GetResponseAsync(messages);
+
+        // Assert
+        var contents = inner.LastMessages![0].Contents;
+        contents[0].ShouldBeOfType<TextContent>();
+        ((TextContent)contents[0]).Text.ShouldContain("# Notes");
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_WithUnmatchedMimeTypeAndNoExtensionHandler_PassesThrough()
+    {
+        // Arrange — image/png matches no handler, and the .png extension fallback also matches
+        // no handler; this must still pass through unchanged (no regression from the fallback).
+        var handler = new FakeHandler("text/csv", "ignored");
+        var (client, inner) = CreateClient(handler);
+
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, [CreateDataContent(new byte[] { 1, 2, 3 }, "image/png", "photo.png")]),
+        };
+
+        // Act
+        await client.GetResponseAsync(messages);
+
+        // Assert
+        var contents = inner.LastMessages![0].Contents;
+        contents[0].ShouldBeOfType<DataContent>();
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_WithUnmatchedMimeTypeAndNoFilename_PassesThrough()
+    {
+        // Arrange — no filename means no extension to fall back to; the fallback path must be
+        // skipped entirely rather than throwing or misbehaving.
+        var handler = new FakeHandler("text/csv", "ignored");
+        var (client, inner) = CreateClient(handler);
+
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, [new DataContent(new byte[] { 1, 2, 3 }, "image/png")]),
+        };
+
+        // Act
+        await client.GetResponseAsync(messages);
+
+        // Assert
+        var contents = inner.LastMessages![0].Contents;
+        contents[0].ShouldBeOfType<DataContent>();
+    }
+
     #region Test Helpers
 
     private static (AIFileProcessingChatClient Client, CapturingChatClient Inner) CreateClient(

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/FileProcessing/PlainTextFileProcessingHandlerTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/FileProcessing/PlainTextFileProcessingHandlerTests.cs
@@ -1,0 +1,101 @@
+using System.Text;
+using Umbraco.AI.Core.FileProcessing;
+
+namespace Umbraco.AI.Tests.Unit.FileProcessing;
+
+public class PlainTextFileProcessingHandlerTests
+{
+    private readonly PlainTextFileProcessingHandler _handler = new();
+
+    #region CanHandle
+
+    [Theory]
+    [InlineData("text/plain", true)]
+    [InlineData("text/csv", true)]
+    [InlineData("text/markdown", true)]
+    [InlineData("application/pdf", false)]
+    [InlineData("image/png", false)]
+    [InlineData("application/vnd.openxmlformats-officedocument.wordprocessingml.document", false)]
+    [InlineData("application/octet-stream", false)]
+    public async Task CanHandleAsync_WithMimeType_ReturnsExpected(string mimeType, bool expected)
+    {
+        (await _handler.CanHandleAsync(mimeType)).ShouldBe(expected);
+    }
+
+    #endregion
+
+    #region ProcessAsync
+
+    [Fact]
+    public async Task ProcessAsync_WithPlainText_ReturnsContentUnchanged()
+    {
+        // Arrange
+        var data = Encoding.UTF8.GetBytes("Hello World\nSecond line");
+
+        // Act
+        var result = await _handler.ProcessAsync(data, "text/plain", "notes.txt");
+
+        // Assert
+        result.Content.ShouldBe("Hello World\nSecond line");
+        result.WasTruncated.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithCsv_ReturnsRawCsvText()
+    {
+        // Arrange
+        var data = Encoding.UTF8.GetBytes("name,age\nAlice,30\nBob,25");
+
+        // Act
+        var result = await _handler.ProcessAsync(data, "text/csv", "people.csv");
+
+        // Assert
+        result.Content.ShouldBe("name,age\nAlice,30\nBob,25");
+        result.WasTruncated.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithMarkdown_ReturnsRawMarkdownText()
+    {
+        // Arrange
+        var data = Encoding.UTF8.GetBytes("# Title\n\nSome **bold** text.");
+
+        // Act
+        var result = await _handler.ProcessAsync(data, "text/markdown", "readme.md");
+
+        // Assert
+        result.Content.ShouldBe("# Title\n\nSome **bold** text.");
+        result.WasTruncated.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithEmptyFile_ReturnsEmptyContent()
+    {
+        // Arrange
+        var data = Array.Empty<byte>();
+
+        // Act
+        var result = await _handler.ProcessAsync(data, "text/plain", "empty.txt");
+
+        // Assert
+        result.Content.ShouldBeEmpty();
+        result.WasTruncated.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithLargeContent_TruncatesAndIndicates()
+    {
+        // Arrange - content exceeding 100K characters
+        var data = Encoding.UTF8.GetBytes(new string('A', 110_000));
+
+        // Act
+        var result = await _handler.ProcessAsync(data, "text/plain", "big.txt");
+
+        // Assert
+        result.WasTruncated.ShouldBeTrue();
+        result.Content.ShouldContain("[Content truncated due to size limits]");
+        result.Content.Length.ShouldBeLessThan(110_000);
+    }
+
+    #endregion
+}

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/FileProcessing/PlainTextFileProcessingHandlerTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/FileProcessing/PlainTextFileProcessingHandlerTests.cs
@@ -69,6 +69,22 @@ public class PlainTextFileProcessingHandlerTests
     }
 
     [Fact]
+    public async Task ProcessAsync_WithUtf8Bom_StripsBomFromContent()
+    {
+        // Arrange - Excel's "CSV UTF-8" export always writes a BOM before the content
+        var csvContent = "name,age\nAlice,30\nBob,25";
+        var data = Encoding.UTF8.GetPreamble().Concat(Encoding.UTF8.GetBytes(csvContent)).ToArray();
+
+        // Act
+        var result = await _handler.ProcessAsync(data, "text/csv", "people.csv");
+
+        // Assert
+        result.Content[0].ShouldNotBe('﻿');
+        result.Content.ShouldBe(csvContent);
+        result.WasTruncated.ShouldBeFalse();
+    }
+
+    [Fact]
     public async Task ProcessAsync_WithEmptyFile_ReturnsEmptyContent()
     {
         // Arrange

--- a/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Media/AIMediaExtensionResolverTests.cs
+++ b/Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Media/AIMediaExtensionResolverTests.cs
@@ -1,0 +1,59 @@
+using Umbraco.AI.Core.Media;
+
+namespace Umbraco.AI.Tests.Unit.Media;
+
+public class AIMediaExtensionResolverTests
+{
+    [Theory]
+    [InlineData(".jpg", "image/jpeg")]
+    [InlineData(".jpeg", "image/jpeg")]
+    [InlineData(".png", "image/png")]
+    [InlineData(".gif", "image/gif")]
+    [InlineData(".webp", "image/webp")]
+    [InlineData(".bmp", "image/bmp")]
+    [InlineData(".mp3", "audio/mpeg")]
+    [InlineData(".wav", "audio/wav")]
+    [InlineData(".m4a", "audio/mp4")]
+    [InlineData(".mp4", "audio/mp4")]
+    [InlineData(".ogg", "audio/ogg")]
+    [InlineData(".oga", "audio/ogg")]
+    [InlineData(".webm", "audio/webm")]
+    [InlineData(".flac", "audio/flac")]
+    [InlineData(".txt", "text/plain")]
+    [InlineData(".md", "text/markdown")]
+    [InlineData(".csv", "text/csv")]
+    [InlineData(".docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document")]
+    [InlineData(".xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")]
+    [InlineData(".pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation")]
+    public void TryGetMediaType_WithSupportedExtension_ReturnsExpectedMediaType(string extension, string expectedMediaType)
+    {
+        var result = AIMediaExtensionResolver.TryGetMediaType(extension, out var mediaType);
+
+        result.ShouldBeTrue();
+        mediaType.ShouldBe(expectedMediaType);
+    }
+
+    [Theory]
+    [InlineData(".exe")]
+    [InlineData(".pdf")]
+    [InlineData(".zip")]
+    [InlineData("")]
+    public void TryGetMediaType_WithUnsupportedExtension_ReturnsFalse(string extension)
+    {
+        var result = AIMediaExtensionResolver.TryGetMediaType(extension, out var mediaType);
+
+        result.ShouldBeFalse();
+        mediaType.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData(".JPG", "image/jpeg")]
+    [InlineData(".CSV", "text/csv")]
+    public void TryGetMediaType_IsCaseInsensitive(string extension, string expectedMediaType)
+    {
+        var result = AIMediaExtensionResolver.TryGetMediaType(extension, out var mediaType);
+
+        result.ShouldBeTrue();
+        mediaType.ShouldBe(expectedMediaType);
+    }
+}

--- a/docs/superpowers/plans/2026-09-03-file-content-extraction-phase-1a.md
+++ b/docs/superpowers/plans/2026-09-03-file-content-extraction-phase-1a.md
@@ -1,0 +1,591 @@
+# File Content Extraction — Phase 1a Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the AI actually read `.txt`, `.csv`, and `.md` files (and, as a free side effect,
+`.docx`/`.xlsx`/`.pptx`) attached in chat or fetched via the `get_umbraco_media` tool — today it
+either sees nothing or gets a metadata-only stub.
+
+**Architecture:** Umbraco.AI already has a working, pluggable text-extraction pipeline
+(`IAIFileProcessingHandler` → `AIFileProcessingChatMiddleware`) that converts file attachments
+into text before they reach the AI provider. It has a handler for Office documents and one for
+audio, but none for plain text — and a separate, unrelated extension whitelist
+(`AIUmbracoMediaResolver`) blocks those same file types (plus Office formats) from ever being
+read when the file comes from an Umbraco Media item. This plan adds the missing plain-text
+handler and widens the whitelist. No new abstractions, no new dependencies — this reuses the
+existing handler pattern exactly as OpenXML and audio do today.
+
+**Tech Stack:** .NET 10, xUnit, Shouldly, Moq (existing test stack — no new packages).
+
+**Spec:** `docs/superpowers/specs/2026-09-03-file-content-extraction-design.md` (Phase 1a section
+specifically; Phase 1b "Resources panel" and Phase 2 "PDF" are explicitly out of scope here).
+
+## Global Constraints
+
+- No new NuGet dependencies (Phase 1a only touches formats .NET can decode natively).
+- Truncate extracted text at 100,000 characters with the marker
+  `[Content truncated due to size limits]`, matching `OpenXmlFileProcessingHandler`'s existing
+  convention exactly — pull this into one shared constant rather than duplicating the number.
+- New handler classes are `internal sealed`, matching `OpenXmlFileProcessingHandler` and
+  `AudioTranscriptionFileProcessingHandler`.
+- Feature-sliced structure: new files live flat inside the existing `FileProcessing/` and
+  `Media/` folders in `Umbraco.AI.Core` — no new subfolders.
+- `.pdf` stays unsupported after this plan (Phase 2, separate dependency, separate plan) — Task 3
+  includes a test asserting this explicitly, so a future change can't silently widen scope here.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `Umbraco.AI.Core/FileProcessing/AIFileProcessingConstants.cs` (new) | Single source of truth for the 100,000-character truncation cap, shared by every text-extraction handler. |
+| `Umbraco.AI.Core/FileProcessing/OpenXmlFileProcessingHandler.cs` (modify) | Switch its local truncation constant to the shared one. No behavior change. |
+| `Umbraco.AI.Core/FileProcessing/PlainTextFileProcessingHandler.cs` (new) | Decodes `text/plain`, `text/csv`, `text/markdown` bytes as UTF-8 and returns them, truncating per the shared cap. |
+| `Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.cs` (modify) | Registers the new handler in the `AIFileProcessingHandlers()` chain. |
+| `Umbraco.AI.Core/Media/AIMediaExtensionResolver.cs` (new) | Pure extension→MIME-type lookup, extracted out of `AIUmbracoMediaResolver` so it's unit-testable without Umbraco's media/file-system infrastructure. Carries the widened list (adds `.txt`/`.md`/`.csv`/`.docx`/`.xlsx`/`.pptx` to the existing image/audio set). |
+| `Umbraco.AI.Core/Media/AIUmbracoMediaResolver.cs` (modify) | Delegates to `AIMediaExtensionResolver` instead of its own private dictionary. No other behavior change. |
+
+Task order: 1 → 2 → 3. Task 3 (the `Media` namespace) has no code dependency on Tasks 1–2 (the
+`FileProcessing` namespace) and could run in parallel if using subagent-driven-development, but
+is listed last for a simpler linear read.
+
+---
+
+### Task 1: Extract the shared truncation constant
+
+**Files:**
+- Create: `Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/AIFileProcessingConstants.cs`
+- Modify: `Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/OpenXmlFileProcessingHandler.cs:22,54,57`
+- Test: `Umbraco.AI/tests/Umbraco.AI.Tests.Unit/FileProcessing/OpenXmlFileProcessingHandlerTests.cs` (existing — no new test, used as a regression check)
+
+**Interfaces:**
+- Produces: `Umbraco.AI.Core.FileProcessing.AIFileProcessingConstants.MaxExtractedCharacters` (`internal const int`, value `100_000`) — consumed by Task 2's handler.
+
+This is a pure refactor (no behavior change), so it's verified by the existing test suite rather
+than a new test — `OpenXmlFileProcessingHandlerTests.ProcessAsync_WithLargeContent_TruncatesAndIndicates`
+already asserts the exact truncation behavior this constant drives.
+
+- [ ] **Step 1: Create the shared constant**
+
+Create `Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/AIFileProcessingConstants.cs`:
+
+```csharp
+namespace Umbraco.AI.Core.FileProcessing;
+
+/// <summary>
+/// Shared limits for file-processing handlers that extract text from uploaded files.
+/// </summary>
+internal static class AIFileProcessingConstants
+{
+    /// <summary>
+    /// The maximum number of characters a handler will return before truncating,
+    /// to keep a single attached file from consuming excessive context budget.
+    /// </summary>
+    public const int MaxExtractedCharacters = 100_000;
+}
+```
+
+- [ ] **Step 2: Point `OpenXmlFileProcessingHandler` at the shared constant**
+
+In `Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/OpenXmlFileProcessingHandler.cs`, remove this
+line:
+
+```csharp
+    private const int MaxCharacters = 100_000;
+```
+
+And replace this block:
+
+```csharp
+        var wasTruncated = content.Length > MaxCharacters;
+        if (wasTruncated)
+        {
+            content = content[..MaxCharacters] + "\n\n[Content truncated due to size limits]";
+        }
+```
+
+with:
+
+```csharp
+        var wasTruncated = content.Length > AIFileProcessingConstants.MaxExtractedCharacters;
+        if (wasTruncated)
+        {
+            content = content[..AIFileProcessingConstants.MaxExtractedCharacters] + "\n\n[Content truncated due to size limits]";
+        }
+```
+
+Both files are in the same `Umbraco.AI.Core.FileProcessing` namespace, so no new `using` is needed.
+
+- [ ] **Step 3: Run the existing OpenXML tests to confirm no regression**
+
+Run: `dotnet test Umbraco.AI/Umbraco.AI.slnx --filter "FullyQualifiedName~OpenXmlFileProcessingHandlerTests"`
+Expected: All tests PASS, including `ProcessAsync_WithLargeContent_TruncatesAndIndicates`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/AIFileProcessingConstants.cs Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/OpenXmlFileProcessingHandler.cs
+git commit -m "refactor(core): Extract shared file-processing truncation constant"
+```
+
+---
+
+### Task 2: Plain-text file processing handler
+
+**Files:**
+- Create: `Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/PlainTextFileProcessingHandler.cs`
+- Create: `Umbraco.AI/tests/Umbraco.AI.Tests.Unit/FileProcessing/PlainTextFileProcessingHandlerTests.cs`
+- Modify: `Umbraco.AI/src/Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.cs:112-115`
+
+**Interfaces:**
+- Consumes: `Umbraco.AI.Core.FileProcessing.AIFileProcessingConstants.MaxExtractedCharacters` (Task 1), `IAIFileProcessingHandler` (existing interface), `AIFileProcessingResult(string Content, bool WasTruncated)` (existing record).
+- Produces: `Umbraco.AI.Core.FileProcessing.PlainTextFileProcessingHandler` — no other task depends on this directly; it's wired into the DI collection by this task's own registration step.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Umbraco.AI/tests/Umbraco.AI.Tests.Unit/FileProcessing/PlainTextFileProcessingHandlerTests.cs`:
+
+```csharp
+using System.Text;
+using Umbraco.AI.Core.FileProcessing;
+
+namespace Umbraco.AI.Tests.Unit.FileProcessing;
+
+public class PlainTextFileProcessingHandlerTests
+{
+    private readonly PlainTextFileProcessingHandler _handler = new();
+
+    #region CanHandle
+
+    [Theory]
+    [InlineData("text/plain", true)]
+    [InlineData("text/csv", true)]
+    [InlineData("text/markdown", true)]
+    [InlineData("application/pdf", false)]
+    [InlineData("image/png", false)]
+    [InlineData("application/vnd.openxmlformats-officedocument.wordprocessingml.document", false)]
+    [InlineData("application/octet-stream", false)]
+    public async Task CanHandleAsync_WithMimeType_ReturnsExpected(string mimeType, bool expected)
+    {
+        (await _handler.CanHandleAsync(mimeType)).ShouldBe(expected);
+    }
+
+    #endregion
+
+    #region ProcessAsync
+
+    [Fact]
+    public async Task ProcessAsync_WithPlainText_ReturnsContentUnchanged()
+    {
+        // Arrange
+        var data = Encoding.UTF8.GetBytes("Hello World\nSecond line");
+
+        // Act
+        var result = await _handler.ProcessAsync(data, "text/plain", "notes.txt");
+
+        // Assert
+        result.Content.ShouldBe("Hello World\nSecond line");
+        result.WasTruncated.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithCsv_ReturnsRawCsvText()
+    {
+        // Arrange
+        var data = Encoding.UTF8.GetBytes("name,age\nAlice,30\nBob,25");
+
+        // Act
+        var result = await _handler.ProcessAsync(data, "text/csv", "people.csv");
+
+        // Assert
+        result.Content.ShouldBe("name,age\nAlice,30\nBob,25");
+        result.WasTruncated.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithMarkdown_ReturnsRawMarkdownText()
+    {
+        // Arrange
+        var data = Encoding.UTF8.GetBytes("# Title\n\nSome **bold** text.");
+
+        // Act
+        var result = await _handler.ProcessAsync(data, "text/markdown", "readme.md");
+
+        // Assert
+        result.Content.ShouldBe("# Title\n\nSome **bold** text.");
+        result.WasTruncated.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithEmptyFile_ReturnsEmptyContent()
+    {
+        // Arrange
+        var data = Array.Empty<byte>();
+
+        // Act
+        var result = await _handler.ProcessAsync(data, "text/plain", "empty.txt");
+
+        // Assert
+        result.Content.ShouldBeEmpty();
+        result.WasTruncated.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithLargeContent_TruncatesAndIndicates()
+    {
+        // Arrange - content exceeding 100K characters
+        var data = Encoding.UTF8.GetBytes(new string('A', 110_000));
+
+        // Act
+        var result = await _handler.ProcessAsync(data, "text/plain", "big.txt");
+
+        // Assert
+        result.WasTruncated.ShouldBeTrue();
+        result.Content.ShouldContain("[Content truncated due to size limits]");
+        result.Content.Length.ShouldBeLessThan(110_000);
+    }
+
+    #endregion
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test Umbraco.AI/Umbraco.AI.slnx --filter "FullyQualifiedName~PlainTextFileProcessingHandlerTests"`
+Expected: FAIL to compile — `PlainTextFileProcessingHandler` does not exist yet.
+
+- [ ] **Step 3: Implement the handler**
+
+Create `Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/PlainTextFileProcessingHandler.cs`:
+
+```csharp
+using System.Text;
+
+namespace Umbraco.AI.Core.FileProcessing;
+
+/// <summary>
+/// Extracts text content from plain-text files (CSV, Markdown, plain text).
+/// </summary>
+internal sealed class PlainTextFileProcessingHandler : IAIFileProcessingHandler
+{
+    private static readonly HashSet<string> SupportedMimeTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "text/plain",
+        "text/csv",
+        "text/markdown",
+    };
+
+    /// <inheritdoc />
+    public Task<bool> CanHandleAsync(string mimeType, CancellationToken cancellationToken = default)
+        => Task.FromResult(SupportedMimeTypes.Contains(mimeType));
+
+    /// <inheritdoc />
+    public Task<AIFileProcessingResult> ProcessAsync(
+        ReadOnlyMemory<byte> data,
+        string mimeType,
+        string? filename,
+        CancellationToken cancellationToken = default)
+    {
+        var content = Encoding.UTF8.GetString(data.Span);
+
+        var wasTruncated = content.Length > AIFileProcessingConstants.MaxExtractedCharacters;
+        if (wasTruncated)
+        {
+            content = content[..AIFileProcessingConstants.MaxExtractedCharacters] + "\n\n[Content truncated due to size limits]";
+        }
+
+        return Task.FromResult(new AIFileProcessingResult(content, wasTruncated));
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test Umbraco.AI/Umbraco.AI.slnx --filter "FullyQualifiedName~PlainTextFileProcessingHandlerTests"`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Register the handler**
+
+In `Umbraco.AI/src/Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.cs`, change:
+
+```csharp
+        // File processing handlers (extensible - add custom handlers via AIFileProcessingHandlers())
+        builder.AIFileProcessingHandlers()
+            .Append<OpenXmlFileProcessingHandler>()
+            .Append<AudioTranscriptionFileProcessingHandler>();
+```
+
+to:
+
+```csharp
+        // File processing handlers (extensible - add custom handlers via AIFileProcessingHandlers())
+        builder.AIFileProcessingHandlers()
+            .Append<OpenXmlFileProcessingHandler>()
+            .Append<PlainTextFileProcessingHandler>()
+            .Append<AudioTranscriptionFileProcessingHandler>();
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Umbraco.AI/src/Umbraco.AI.Core/FileProcessing/PlainTextFileProcessingHandler.cs Umbraco.AI/tests/Umbraco.AI.Tests.Unit/FileProcessing/PlainTextFileProcessingHandlerTests.cs Umbraco.AI/src/Umbraco.AI.Core/Configuration/UmbracoBuilderExtensions.cs
+git commit -m "feat(core): Extract text from plain-text file attachments (csv, txt, md)"
+```
+
+---
+
+### Task 3: Widen the Umbraco Media extension whitelist
+
+**Files:**
+- Create: `Umbraco.AI/src/Umbraco.AI.Core/Media/AIMediaExtensionResolver.cs`
+- Create: `Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Media/AIMediaExtensionResolverTests.cs`
+- Modify: `Umbraco.AI/src/Umbraco.AI.Core/Media/AIUmbracoMediaResolver.cs:14-33,292-297`
+
+**Interfaces:**
+- Produces: `Umbraco.AI.Core.Media.AIMediaExtensionResolver.TryGetMediaType(string extension, out string? mediaType)` (`internal static`, returns `bool`) — consumed by `AIUmbracoMediaResolver.LoadFromPath` in this same task.
+
+**Why extract this into its own class:** `AIUmbracoMediaResolver` has zero existing unit tests
+today, and testing it directly would mean standing up Umbraco's `MediaFileManager`/`IMediaService`
+infrastructure just to check a MIME-type lookup table. Pulling the pure lookup into its own file
+gives it a real, isolated unit test with no CMS mocking required, without changing any observable
+behavior of the resolver itself.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Media/AIMediaExtensionResolverTests.cs`:
+
+```csharp
+using Umbraco.AI.Core.Media;
+
+namespace Umbraco.AI.Tests.Unit.Media;
+
+public class AIMediaExtensionResolverTests
+{
+    [Theory]
+    [InlineData(".jpg", "image/jpeg")]
+    [InlineData(".jpeg", "image/jpeg")]
+    [InlineData(".png", "image/png")]
+    [InlineData(".gif", "image/gif")]
+    [InlineData(".webp", "image/webp")]
+    [InlineData(".bmp", "image/bmp")]
+    [InlineData(".mp3", "audio/mpeg")]
+    [InlineData(".wav", "audio/wav")]
+    [InlineData(".m4a", "audio/mp4")]
+    [InlineData(".mp4", "audio/mp4")]
+    [InlineData(".ogg", "audio/ogg")]
+    [InlineData(".oga", "audio/ogg")]
+    [InlineData(".webm", "audio/webm")]
+    [InlineData(".flac", "audio/flac")]
+    [InlineData(".txt", "text/plain")]
+    [InlineData(".md", "text/markdown")]
+    [InlineData(".csv", "text/csv")]
+    [InlineData(".docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document")]
+    [InlineData(".xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")]
+    [InlineData(".pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation")]
+    public void TryGetMediaType_WithSupportedExtension_ReturnsExpectedMediaType(string extension, string expectedMediaType)
+    {
+        var result = AIMediaExtensionResolver.TryGetMediaType(extension, out var mediaType);
+
+        result.ShouldBeTrue();
+        mediaType.ShouldBe(expectedMediaType);
+    }
+
+    [Theory]
+    [InlineData(".exe")]
+    [InlineData(".pdf")]
+    [InlineData(".zip")]
+    [InlineData("")]
+    public void TryGetMediaType_WithUnsupportedExtension_ReturnsFalse(string extension)
+    {
+        var result = AIMediaExtensionResolver.TryGetMediaType(extension, out var mediaType);
+
+        result.ShouldBeFalse();
+        mediaType.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData(".JPG", "image/jpeg")]
+    [InlineData(".CSV", "text/csv")]
+    public void TryGetMediaType_IsCaseInsensitive(string extension, string expectedMediaType)
+    {
+        var result = AIMediaExtensionResolver.TryGetMediaType(extension, out var mediaType);
+
+        result.ShouldBeTrue();
+        mediaType.ShouldBe(expectedMediaType);
+    }
+}
+```
+
+Note the `.pdf` case lives in the *unsupported* theory — PDF is Phase 2 (its own plan, its own
+dependency decision). This test pins that boundary down so it can't drift by accident.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test Umbraco.AI/Umbraco.AI.slnx --filter "FullyQualifiedName~AIMediaExtensionResolverTests"`
+Expected: FAIL to compile — `AIMediaExtensionResolver` does not exist yet.
+
+- [ ] **Step 3: Implement the resolver**
+
+Create `Umbraco.AI/src/Umbraco.AI.Core/Media/AIMediaExtensionResolver.cs`:
+
+```csharp
+using System.Diagnostics.CodeAnalysis;
+
+namespace Umbraco.AI.Core.Media;
+
+/// <summary>
+/// Maps file extensions to the MIME types <see cref="IAIUmbracoMediaResolver"/> understands.
+/// Extracted from <see cref="AIUmbracoMediaResolver"/> so the lookup can be unit tested without
+/// the Umbraco CMS media/file-system infrastructure that resolver depends on.
+/// </summary>
+internal static class AIMediaExtensionResolver
+{
+    private static readonly Dictionary<string, string> ExtensionToMediaType = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Images
+        [".jpg"] = "image/jpeg",
+        [".jpeg"] = "image/jpeg",
+        [".png"] = "image/png",
+        [".gif"] = "image/gif",
+        [".webp"] = "image/webp",
+        [".bmp"] = "image/bmp",
+
+        // Audio
+        [".mp3"] = "audio/mpeg",
+        [".wav"] = "audio/wav",
+        [".m4a"] = "audio/mp4",
+        [".mp4"] = "audio/mp4",
+        [".ogg"] = "audio/ogg",
+        [".oga"] = "audio/ogg",
+        [".webm"] = "audio/webm",
+        [".flac"] = "audio/flac",
+
+        // Plain text
+        [".txt"] = "text/plain",
+        [".md"] = "text/markdown",
+        [".csv"] = "text/csv",
+
+        // Office documents
+        [".docx"] = "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        [".xlsx"] = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        [".pptx"] = "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    };
+
+    /// <summary>
+    /// Attempts to resolve the MIME type for a file extension (e.g. <c>.png</c>).
+    /// </summary>
+    /// <param name="extension">The file extension, including the leading dot.</param>
+    /// <param name="mediaType">The resolved MIME type, when found.</param>
+    /// <returns><c>true</c> if the extension is recognized; otherwise <c>false</c>.</returns>
+    public static bool TryGetMediaType(string extension, [NotNullWhen(true)] out string? mediaType)
+        => ExtensionToMediaType.TryGetValue(extension, out mediaType);
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test Umbraco.AI/Umbraco.AI.slnx --filter "FullyQualifiedName~AIMediaExtensionResolverTests"`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Wire `AIUmbracoMediaResolver` to the new resolver**
+
+In `Umbraco.AI/src/Umbraco.AI.Core/Media/AIUmbracoMediaResolver.cs`, remove this block (the
+private dictionary, currently at the top of the class):
+
+```csharp
+    private static readonly Dictionary<string, string> ExtensionToMediaType = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Images
+        [".jpg"] = "image/jpeg",
+        [".jpeg"] = "image/jpeg",
+        [".png"] = "image/png",
+        [".gif"] = "image/gif",
+        [".webp"] = "image/webp",
+        [".bmp"] = "image/bmp",
+
+        // Audio
+        [".mp3"] = "audio/mpeg",
+        [".wav"] = "audio/wav",
+        [".m4a"] = "audio/mp4",
+        [".mp4"] = "audio/mp4",
+        [".ogg"] = "audio/ogg",
+        [".oga"] = "audio/ogg",
+        [".webm"] = "audio/webm",
+        [".flac"] = "audio/flac",
+    };
+```
+
+And in `LoadFromPath`, replace:
+
+```csharp
+        // Get file extension for media type
+        var extension = Path.GetExtension(filePath);
+        if (!ExtensionToMediaType.TryGetValue(extension, out var mediaType))
+        {
+            _logger.LogWarning("Unsupported media extension: {Extension}", extension);
+            return null;
+        }
+```
+
+with:
+
+```csharp
+        // Get file extension for media type
+        var extension = Path.GetExtension(filePath);
+        if (!AIMediaExtensionResolver.TryGetMediaType(extension, out var mediaType))
+        {
+            _logger.LogWarning("Unsupported media extension: {Extension}", extension);
+            return null;
+        }
+```
+
+Both files are in the same `Umbraco.AI.Core.Media` namespace, so no new `using` is needed.
+
+- [ ] **Step 6: Run the full Media test folder to confirm no regression**
+
+Run: `dotnet test Umbraco.AI/Umbraco.AI.slnx --filter "FullyQualifiedName~Umbraco.AI.Tests.Unit.Media"`
+Expected: All tests PASS (`AIImageCropperTests`, `AIImageDownscalerTests`, and the two new
+`AIMediaExtensionResolverTests` theories) — the crop/downscale tests are unaffected since they
+don't touch extension resolution, but this confirms nothing in the `Media` folder broke.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Umbraco.AI/src/Umbraco.AI.Core/Media/AIMediaExtensionResolver.cs Umbraco.AI/tests/Umbraco.AI.Tests.Unit/Media/AIMediaExtensionResolverTests.cs Umbraco.AI/src/Umbraco.AI.Core/Media/AIUmbracoMediaResolver.cs
+git commit -m "feat(core): Allow text and Office file extensions through the Umbraco media resolver"
+```
+
+---
+
+## Post-plan verification (manual, not a task)
+
+Once all three tasks are done, the spec's symptoms 1 and 2 should be fixed:
+
+1. Attach a `.csv` file directly in a Copilot chat message and ask what's in it — the AI should
+   now read and describe the rows.
+2. Upload the same file as an Umbraco Media item, reference it in a prompt/agent flow that calls
+   `get_umbraco_media`, and confirm the AI can describe its contents.
+3. As a bonus check: repeat with a `.docx` file — it should now work too, since Task 3 opened the
+   whitelist for a handler (`OpenXmlFileProcessingHandler`) that already existed.
+
+This manual check isn't a task with its own commit — it's a sanity pass against the demo site
+before calling Phase 1a done. Symptom 3 (the "Resources" panel) is Phase 1b, a separate plan.
+
+## Self-Review Notes
+
+- **Spec coverage:** Phase 1a's two spec deliverables — the plain-text handler and the widened
+  resolver whitelist (including the "free" `.docx`/`.xlsx`/`.pptx` unlock) — are both covered
+  (Tasks 2 and 3). The shared-constant cleanup the spec called out is Task 1. Phase 1b and Phase
+  2 are out of scope by design and not included here.
+- **Redundant test avoided:** the spec's testing section mentions an "integration-style test
+  through `AIFileProcessingChatClient`". `AIFileProcessingChatClientTests.cs` already has a
+  `FakeHandler` covering `text/csv` end-to-end at that layer — adding a second, near-identical
+  test using the real `PlainTextFileProcessingHandler` would just re-test the same client logic
+  with different fake data. Skipped as redundant per this repo's stated testing philosophy
+  (avoid arbitrary/passthrough tests); Task 2's own unit tests already prove the handler's
+  behavior in isolation.
+- **No registration test:** the `UmbracoBuilderExtensions.cs` composer wiring in Task 2 Step 5 is
+  boilerplate DI registration with no branching logic, consistent with why the existing
+  `OpenXmlFileProcessingHandler`/`AudioTranscriptionFileProcessingHandler` registrations have no
+  dedicated test either.

--- a/docs/superpowers/specs/2026-09-03-file-content-extraction-design.md
+++ b/docs/superpowers/specs/2026-09-03-file-content-extraction-design.md
@@ -1,0 +1,185 @@
+# File Content Extraction (CSV/TXT/MD/Office/PDF) — Design
+
+**Date:** 2026-09-03
+**Repo:** `Umbraco.AI` (monorepo) — primarily `Umbraco.AI.Core`, with a follow-up touch in
+`Umbraco.AI.Agent.Core` for the Copilot "Resources" panel
+**Status:** Local design only — no ticket filed yet
+**Scope:** Core fix applies to both `v18/dev` and `v17/dev` (see "Version sync" below)
+
+## Problem
+
+Reported via the Copilot chat: attaching `product-snapshot-sep-2026.csv` directly in chat, or
+adding it as a "Resource" pointing at an Umbraco Media item, never lets the AI read its
+contents. Three symptoms observed:
+
+1. **Direct chat attachment** — user attaches the CSV to a chat message and asks "what's in
+   this file?". The AI replies it sees no attachment at all.
+2. **Agent tool fetch** — the AI calls `get_umbraco_media` (an existing tool) against the same
+   file (now stored as an Umbraco Media item) and the tool call succeeds, but the AI still says
+   it has no way to read the file's contents.
+3. **"Resources" panel** (Copilot side panel, distinct from the "Contexts" panel) — the file is
+   attached as an always-on resource. The AI only ever learns the file's name and byte count
+   (`product-snapshot-sep-2026.csv (48,423 bytes)`), never its content.
+
+## What already exists (verified in code)
+
+Umbraco.AI already has a working, pluggable text-extraction pipeline — this is not a
+greenfield feature, it's closing gaps in something that's already half-built:
+
+- **`IAIFileProcessingHandler`** (`Umbraco.AI.Core/FileProcessing/IAIFileProcessingHandler.cs`)
+  — pluggable interface: `CanHandleAsync(mimeType)` / `ProcessAsync(bytes, mimeType, filename)`
+  → `AIFileProcessingResult(Content, WasTruncated)`.
+- **`OpenXmlFileProcessingHandler`** already extracts text from `.docx`, `.xlsx`, `.pptx` (via
+  `DocumentFormat.OpenXml`, already a Core package dependency), with a 100,000-character
+  truncation cap and a `[Content truncated due to size limits]` marker.
+- **`AudioTranscriptionFileProcessingHandler`** transcribes audio via the speech-to-text
+  service, when a default STT profile is configured.
+- **`AIFileProcessingChatMiddleware` / `AIFileProcessingChatClient`** (registered as
+  `IAIChatMiddleware`) scan every outgoing chat message for `DataContent`, and for each one, ask
+  the handler collection for a match. If a handler is found, the binary attachment is replaced
+  with a `TextContent` (`[File: name]\n<extracted text>`) before the request reaches the
+  provider. No handler match → passed through untouched (works today for images, since
+  providers handle those natively).
+- Handlers are registered in order via `builder.AIFileProcessingHandlers().Append<T>()`
+  (`AIFileProcessingHandlerCollectionBuilder`); first match wins.
+
+**The gap is narrow**: no handler exists yet for plain text (`.txt`, `.csv`, `.md`) or PDF, and
+a *second*, unrelated whitelist (`IAIUmbracoMediaResolver`) blocks those extensions — plus
+`.docx`/`.xlsx`/`.pptx` — from ever being read when the file comes from an Umbraco Media item
+rather than a raw chat upload.
+
+### The two separate code paths behind symptoms 1–3
+
+| Symptom | Path | Governing code |
+|---|---|---|
+| 1. Direct chat attachment | `AGUIFileProcessor` (Agent) stores the upload, converts it to AG-UI content, which becomes M.E.AI `DataContent` on the chat message. Checked only against `ContentSettings.IsFileAllowedForUpload`. | Reaches `AIFileProcessingChatMiddleware` — fixed by adding a handler (no resolver whitelist involved). |
+| 2. `get_umbraco_media` tool | `GetUmbracoMediaItem.cs` calls `IAIUmbracoMediaResolver.ResolveAsync(mediaKey)`, which rejects any extension not in its hard-coded `ExtensionToMediaType` dictionary (images + audio only) **before the file is even opened**. On success it calls `AIRuntimeContext.AddData(bytes, mediaType)`, which is injected as `DataContent` on the next turn by `AIRuntimeContextInjectingChatClient` — and *that* message does reach `AIFileProcessingChatMiddleware`. | Blocked at the resolver whitelist — never reaches the middleware today. |
+| 3. "Resources" panel | Not yet pinned down to an exact class in this session (see "Open question" below). Confirmed it does **not** go through `AIContextResourceType` (the "Contexts" panel's mechanism — built-in types are only `text` and `brand-voice`); most likely renders via the entity-adapter/formatter pipeline (`MediaEntityAdapter` → `CmsEntityFormatHelper.FormatCmsEntity`), which only prints CMS property values (name, byte size, etc.), never file content. | Needs its own fix — extracting text isn't enough if nothing calls the extractor. |
+
+## Goals
+
+- Fix symptom 1 and 2 by teaching the existing file-processing pipeline about plain-text
+  formats, and by opening up `IAIUmbracoMediaResolver`'s extension whitelist so Office and
+  text files can be read from Umbraco Media at all (Office extraction already works — it's
+  just unreachable today).
+- Fix symptom 3 by making the "Resources" panel's media formatting call the same
+  text-extraction building block, instead of only ever showing file metadata.
+- Land PDF support as a clearly separate, later phase — it needs a new dependency and has no
+  existing scaffolding to lean on.
+
+## Non-goals
+
+- OCR / scanned (image-only) PDFs — different technology, own project if ever needed.
+- Any change to how images or audio are handled — those already work.
+- Filing a ticket or committing to a delivery date — this doc is for local review only.
+
+## Phase 1a — Plain text handler + resolver whitelist (fixes symptoms 1 and 2)
+
+**New handler**: `PlainTextFileProcessingHandler` implementing `IAIFileProcessingHandler`,
+registered alongside the existing handlers via `builder.AIFileProcessingHandlers().Append<...>()`.
+
+- Handles `text/plain`, `text/csv`, `text/markdown`.
+- `ProcessAsync` decodes the bytes as UTF-8 and returns them as-is (no restructuring needed —
+  unlike Office XML, there's no markup to strip).
+- Apply the same truncation convention as `OpenXmlFileProcessingHandler`: cap at 100,000
+  characters, append `[Content truncated due to size limits]` when exceeded. Reuse the same
+  constant rather than duplicating the magic number — worth promoting `MaxCharacters` to a
+  shared constant while touching this code.
+
+**Resolver whitelist** (`AIUmbracoMediaResolver.ExtensionToMediaType`,
+`Umbraco.AI.Core/Media/AIUmbracoMediaResolver.cs:14`): add entries so files stored as Umbraco
+Media can be read at all:
+
+| Extension | MIME type |
+|---|---|
+| `.txt` | `text/plain` |
+| `.md` | `text/markdown` |
+| `.csv` | `text/csv` |
+| `.docx` | `application/vnd.openxmlformats-officedocument.wordprocessingml.document` |
+| `.xlsx` | `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` |
+| `.pptx` | `application/vnd.openxmlformats-officedocument.presentationml.presentation` |
+
+The `.docx`/`.xlsx`/`.pptx` rows are a zero-cost addition — `OpenXmlFileProcessingHandler`
+already handles those MIME types; they're just unreachable via the media resolver today.
+
+**Why this is enough for symptoms 1 and 2**: both paths ultimately produce a `DataContent` that
+flows through `AIFileProcessingChatMiddleware`, which already does the "does a handler exist for
+this MIME type → replace with extracted text" work. Symptom 1 doesn't touch the resolver at all
+(raw chat uploads aren't Umbraco Media), so the handler alone fixes it. Symptom 2 needs both the
+resolver change (so the tool can read the file) and the handler (so the extracted text is usable).
+
+**Verify during implementation**: confirm the middleware ordering means
+`AIRuntimeContextInjectingChatClient` (which injects tool-added `DataContent`) runs *before*
+`AIFileProcessingChatClient` sees the message, so tool-fetched files get processed. Both are
+registered as `IAIChatMiddleware`; check `UmbracoBuilderExtensions` for the current append order
+and adjust with `InsertBefore`/`InsertAfter` if needed.
+
+## Phase 1b — "Resources" panel fix (fixes symptom 3)
+
+**Open question (needs a short investigation spike before/at the start of implementation):**
+this session could not pin down the exact class that formats a "Resources"-panel Media item for
+the LLM. Ruled out: `AIContextResourceType` (Contexts panel's mechanism — no `media`/`entity`
+resource type exists among the built-ins). Best lead: the entity-adapter/formatter pipeline
+(`MediaEntityAdapter.FormatForLlm` → `CmsEntityFormatHelper.FormatCmsEntity`,
+`Umbraco.AI.Core/EntityAdapter/Adapters/MediaEntityAdapter.cs`), which today only prints CMS
+property values. The implementation plan should start by locating the exact call site (likely
+by reproducing the panel in the running demo site and tracing the request), then apply the fix
+below.
+
+**Fix, once located**: when formatting a Media entity for LLM consumption, resolve the
+underlying file via `IAIUmbracoMediaResolver` and, if its MIME type has a matching
+`IAIFileProcessingHandler`, append the extracted text to the formatted output (keep the existing
+name/size line — it's useful context, just not sufficient on its own). Apply the same
+truncation cap as Phase 1a. This matters more here than elsewhere: a Resource marked "Always" is
+re-sent on *every* turn of the conversation, so an uncapped attachment is a recurring token cost,
+not a one-off.
+
+## Phase 2 — PDF (later, separate follow-up)
+
+- PDF text extraction has no existing scaffolding in this repo and needs a new third-party
+  dependency (unlike Office formats, .NET has no built-in PDF text reader). Per repo convention,
+  a new dependency needs sign-off before it's added — this doc does not commit to one.
+- Same handler shape as Phase 1a: a new `IAIFileProcessingHandler` for `application/pdf`,
+  registered the same way, same truncation convention.
+- Same resolver-whitelist change needed: add `.pdf` → `application/pdf` to
+  `AIUmbracoMediaResolver.ExtensionToMediaType`.
+- Scanned/image-only PDFs (no embedded text layer) are explicitly out of scope (see Non-goals).
+
+## Error handling
+
+- Unreadable/corrupt files: handlers should catch parse failures and return an empty or
+  best-effort partial result rather than throwing — consistent with how
+  `AIUmbracoMediaResolver.ResolveAsync` already swallows exceptions and logs a warning instead
+  of failing the whole request.
+- Disallowed extensions (per CMS `ContentSettings.IsFileAllowedForUpload`) continue to be
+  silently skipped, same as today — no change to that check.
+- Oversized files: truncate with a visible marker rather than failing outright, matching
+  existing `OpenXmlFileProcessingHandler` behavior.
+
+## Testing
+
+- Unit tests for `PlainTextFileProcessingHandler`: handles each MIME type, truncates correctly,
+  handles empty/whitespace-only files.
+- Unit tests for the widened `AIUmbracoMediaResolver.ExtensionToMediaType` map (extend existing
+  resolver tests with the new extensions).
+- Integration-style test through `AIFileProcessingChatClient` confirming a `DataContent` with
+  `text/csv` becomes `TextContent` in the outgoing message.
+- Resources-panel fix: add a test once the exact formatter class is confirmed, covering both the
+  "file has a handler" and "file has no handler, falls back to metadata-only" cases.
+
+## Version sync
+
+This is a `Umbraco.AI.Core` change with no CMS-major-specific dependency, so per the repo's
+multi-version policy it should land on both `v18/dev` and `v17/dev` (both currently in
+"Features + bug fixes" phase). Confirm with whoever picks this up whether to implement once and
+backport, or branch from `v17/dev` directly if v17 is the primary target.
+
+## Summary of file touches (Phase 1)
+
+| File | Change |
+|---|---|
+| `Umbraco.AI.Core/FileProcessing/PlainTextFileProcessingHandler.cs` | New handler |
+| `Umbraco.AI.Core/FileProcessing/OpenXmlFileProcessingHandler.cs` | Extract shared `MaxCharacters` constant (minor cleanup while touching this area) |
+| `Umbraco.AI.Core/Media/AIUmbracoMediaResolver.cs` | Add 6 extensions to `ExtensionToMediaType` |
+| Composer registering `AIFileProcessingHandlers()` | Append the new handler |
+| `Umbraco.AI.Core/EntityAdapter/Adapters/MediaEntityAdapter.cs` (or wherever Phase 1b's spike lands) | Include extracted text for text-extractable Media |


### PR DESCRIPTION
## Summary

The AI couldn't read the contents of `.csv`, `.txt`, or `.md` files attached directly in chat, or fetched via the `get_umbraco_media` tool from an Umbraco Media item — it only ever saw the raw attachment or nothing at all. Investigation found a working, pluggable text-extraction pipeline already existed for Word/Excel/PowerPoint and audio (`IAIFileProcessingHandler` → `AIFileProcessingChatMiddleware`), but nothing for plain text — and a separate, unrelated file-extension whitelist on `AIUmbracoMediaResolver` blocked both plain-text and Office formats from ever reaching that pipeline when the file came from an Umbraco Media item.

Full design/investigation: `docs/superpowers/specs/2026-09-03-file-content-extraction-design.md` (Phase 1a section). Implementation plan: `docs/superpowers/plans/2026-09-03-file-content-extraction-phase-1a.md`.

## Changes

- Added `PlainTextFileProcessingHandler` for `text/plain`, `text/csv`, `text/markdown`.
- Widened `AIUmbracoMediaResolver`'s extension whitelist to allow `.txt`/`.md`/`.csv` and, as a free side effect, `.docx`/`.xlsx`/`.pptx` (the handler for those already existed — it was just unreachable via Media).
- Stripped a UTF-8 byte-order-mark that was corrupting the first column of Excel-exported CSVs.
- Added a filename-extension fallback for the chat-attachment path, since browsers often report the wrong/empty MIME type for `.csv`/`.md` on Windows.

## Testing

- [x] Unit tests pass (1104/1104)
- [x] Integration tests pass
- [ ] Tested in demo site — not yet done; backend changes verified via automated tests only, not through the Copilot UI
- [ ] Frontend builds successfully (if applicable) — no frontend changes in this PR

## Breaking Changes

None.

## Related Issues

Deliberately out of scope: PDF support (needs a new third-party dependency — own follow-up), and the Copilot "current entity" context path (fixed separately in the stacked PR on top of this one, #346).