### PR TITLE
fix(agent-ui): Stop chat auto-scroll from overriding a manual scroll during streaming

### DIFF
--- a/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/components/chat.element.ts
+++ b/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/components/chat.element.ts
@@ -3,6 +3,7 @@ import { UmbLitElement } from "@umbraco-cms/backoffice/lit-element";
 import type { UaiChatMessage, UaiAgentState } from "../types/index.js";
 import { UAI_CHAT_CONTEXT, type UaiChatContextApi } from "../context.js";
 import type { PendingApproval } from "../services/hitl.context.js";
+import { isNearBottom } from "../utils/scroll.js";
 
 /**
  * Main chat component.
@@ -28,6 +29,7 @@ export class UaiChatElement extends UmbLitElement {
 
     #chatContext?: UaiChatContextApi;
     #messagesRef = createRef<HTMLElement>();
+    #isFollowingBottom = true;
 
     constructor() {
         super();
@@ -84,7 +86,14 @@ export class UaiChatElement extends UmbLitElement {
         return undefined;
     }
 
+    #handleMessagesScroll() {
+        const container = this.#messagesRef.value;
+        if (!container) return;
+        this.#isFollowingBottom = isNearBottom(container);
+    }
+
     #scrollToBottom() {
+        if (!this.#isFollowingBottom) return;
         requestAnimationFrame(() => {
             const container = this.#messagesRef.value;
             if (container) {
@@ -132,7 +141,7 @@ export class UaiChatElement extends UmbLitElement {
     override render() {
         return html`
             <div class="chat-container">
-                <div class="messages-area" ${ref(this.#messagesRef)}>
+                <div class="messages-area" ${ref(this.#messagesRef)} @scroll=${this.#handleMessagesScroll}>
                     ${this._messages.length === 0
                         ? html`
                               <div class="empty-state">

--- a/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/components/chat.element.ts
+++ b/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/components/chat.element.ts
@@ -92,6 +92,17 @@ export class UaiChatElement extends UmbLitElement {
         this.#isFollowingBottom = isNearBottom(container);
     }
 
+    /**
+     * Re-arms auto-follow so the next message update scrolls to the bottom, regardless of where a
+     * previous message source (e.g. a different conversation) left the scroll position. Consumers that
+     * reuse a single `<uai-chat>` across multiple message sources -- Copilot Workspace switching between
+     * saved conversations without remounting the element -- must call this when the source changes, or a
+     * scroll-up left over from the previous conversation silently suppresses the new one's initial scroll.
+     */
+    resetScrollFollow(): void {
+        this.#isFollowingBottom = true;
+    }
+
     #scrollToBottom() {
         if (!this.#isFollowingBottom) return;
         requestAnimationFrame(() => {

--- a/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/utils/scroll.ts
+++ b/Umbraco.AI.Agent.UI/src/Umbraco.AI.Agent.UI/Client/src/chat/utils/scroll.ts
@@ -1,0 +1,12 @@
+const NEAR_BOTTOM_THRESHOLD_PX = 50;
+
+/**
+ * True when the container is close enough to the bottom that new content
+ * should keep it pinned there, rather than jumping a user who scrolled up.
+ */
+export function isNearBottom(
+    container: { scrollTop: number; scrollHeight: number; clientHeight: number },
+    threshold = NEAR_BOTTOM_THRESHOLD_PX,
+): boolean {
+    return container.scrollHeight - container.scrollTop - container.clientHeight <= threshold;
+}


### PR DESCRIPTION
## Summary
- Chat auto-scroll used to force the view to the bottom on every streamed message update, even if the user had manually scrolled up to read earlier text.
- Auto-scroll now only follows the stream while the user is already near the bottom, and resumes automatically once they scroll back down.

## Test plan
- [x] `npm run build:core`, `npm run build:agent` and `npm run build:agent-ui` all pass with no new type errors.
- [ ] Manually verify in the demo site: start a streaming response, scroll up mid-stream, confirm the view stays put; scroll back to bottom, confirm auto-follow resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)