### PR TITLE
fix(ci,deps): Scope Umbraco Prereleases source mapping in NuGet.CI.config

### DIFF
--- a/NuGet.CI.config
+++ b/NuGet.CI.config
@@ -21,12 +21,23 @@
       <package pattern="Umbraco.AI" />
       <package pattern="Umbraco.AI.*" />
     </packageSource>
-    <!-- Umbraco Prereleases: official beta/rc builds (e.g. Umbraco.Cms 18 RCs before stable,
-         Automate prerelease milestones). Nightly purges builds, so mapping Automate here too lets
-         restore fall back to a milestone build that survives a nightly purge. -->
+    <!-- Umbraco Prereleases: official beta/rc builds (Automate prerelease milestones, Deploy).
+         Patterns are intentionally specific (Umbraco.Automate*, Umbraco.Deploy*) rather than the
+         broader Umbraco.* / Umbraco.Cms* — when a package ID matches a pattern in more than one
+         source, NuGet resolves from the source with the longest matching pattern, and MyGet has
+         been observed republishing the same prerelease version with different bytes (e.g.
+         Umbraco.Code 3.0.0-beta), breaking lockfile contentHash validation with NU1403. Scoping
+         this source to only the package families that genuinely live here lets generic packages
+         like Umbraco.Code, and stable Umbraco.Cms, always resolve from the immutable nuget.org
+         tarball. See NuGet.config for the matching fix applied to local dev restores
+         (f306143a, 11b21769) — this file was never updated to match. Nightly purges builds, so
+         mapping Automate here too lets restore fall back to a milestone build that survives a
+         nightly purge. -->
     <packageSource key="Umbraco Prereleases">
-      <package pattern="Umbraco" />
-      <package pattern="Umbraco.*" />
+      <package pattern="Umbraco.Automate" />
+      <package pattern="Umbraco.Automate.*" />
+      <package pattern="Umbraco.Deploy" />
+      <package pattern="Umbraco.Deploy.*" />
     </packageSource>
     <!-- Umbraco Nightly: continuous nightly Automate builds. -->
     <packageSource key="Umbraco Nightly">


### PR DESCRIPTION
## Summary
- Build [285897](https://dev.azure.com/umbraco/Umbraco%20AI/_build/results?buildId=285897) failed on the Moonshot pack job with `NU1403: Package content hash validation failed for Umbraco.Code.3.0.0-beta`
- `NuGet.CI.config` (the config the pack pipeline restores with) still mapped the broad `Umbraco` / `Umbraco.*` patterns to both `nuget.org` and the MyGet `Umbraco Prereleases` feed, so a generic package like `Umbraco.Code` could resolve from either source
- MyGet has been observed republishing `Umbraco.Code.3.0.0-beta` with different bytes than nuget.org — this exact bug was already fixed in `NuGet.config` twice (f306143a, 11b21769), but `NuGet.CI.config` was never updated to match
- Scopes the Prereleases source down to just `Umbraco.Automate*` / `Umbraco.Deploy*`, mirroring `NuGet.config`, so generic packages always resolve from the immutable nuget.org tarball

## Test plan
- [x] Restored `Umbraco.AI`, `Umbraco.AI.OpenAI`, and `Umbraco.AI.Moonshot` against the fixed config with fully cleared NuGet caches — no `packages.lock.json` changes, no NU1403
- [x] Confirmed `v17/dev`'s `NuGet.CI.config` already has this scoping — no backport needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)